### PR TITLE
chore: replace previous repo references

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ To enable this configuration use the `extends` property in your
 | [prefer-explicit-assert](docs/rules/prefer-explicit-assert.md) | Suggest using explicit assertions rather than just `getBy*` queries |                                                                           |                    |
 | [consistent-data-testid](docs/rules/consistent-data-testid.md) | Ensure `data-testid` values match a provided regex.                 |                                                                           |                    |
 
-[build-badge]: https://img.shields.io/travis/Belco90/eslint-plugin-testing-library?style=flat-square
-[build-url]: https://travis-ci.org/belco90/eslint-plugin-testing-library
+[build-badge]: https://img.shields.io/travis/testing-library/eslint-plugin-testing-library?style=flat-square
+[build-url]: https://travis-ci.org/testing-library/eslint-plugin-testing-library
 [version-badge]: https://img.shields.io/npm/v/eslint-plugin-testing-library?style=flat-square
 [version-url]: https://www.npmjs.com/package/eslint-plugin-testing-library
 [license-badge]: https://img.shields.io/npm/l/eslint-plugin-testing-library?style=flat-square
@@ -185,6 +185,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/lib/rules/prefer-expect-query-by.js
+++ b/lib/rules/prefer-expect-query-by.js
@@ -88,7 +88,7 @@ module.exports = {
           messageId: 'expectQueryBy',
           // TODO: we keep the autofixing disabled for now, until we figure out
           // a better way to amend for the edge cases.
-          // See also the related discussion: https://github.com/Belco90/eslint-plugin-testing-library/pull/22#discussion_r335394402
+          // See also the related discussion: https://github.com/testing-library/eslint-plugin-testing-library/pull/22#discussion_r335394402
           // fix(fixer) {
           //   return fixer.replaceText(
           //     nodesGetBy[0],

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,7 +13,7 @@ const combineQueries = (variants, methods) => {
 };
 
 const getDocsUrl = ruleName =>
-  `https://github.com/Belco90/eslint-plugin-testing-library/tree/master/docs/rules/${ruleName}.md`;
+  `https://github.com/testing-library/eslint-plugin-testing-library/tree/master/docs/rules/${ruleName}.md`;
 
 const SYNC_QUERIES_VARIANTS = ['getBy', 'getAllBy', 'queryBy', 'queryAllBy'];
 const ASYNC_QUERIES_VARIANTS = ['findBy', 'findAllBy'];

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Belco90/eslint-plugin-testing-library.git"
+    "url": "https://github.com/testing-library/eslint-plugin-testing-library.git"
   },
-  "homepage": "https://github.com/Belco90/eslint-plugin-testing-library",
+  "homepage": "https://github.com/testing-library/eslint-plugin-testing-library",
   "bugs": {
-    "url": "https://github.com/Belco90/eslint-plugin-testing-library/issues"
+    "url": "https://github.com/testing-library/eslint-plugin-testing-library/issues"
   },
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
As this project was previously at my repo, it would be better to replace some references to it. I'm not replacing references in contributors section of README as comments from the bot says "Do not remove or modify this section".