### PR TITLE
feat(no-debug): scan for `screen.debug()`

### DIFF
--- a/docs/rules/no-debug.md
+++ b/docs/rules/no-debug.md
@@ -40,3 +40,4 @@ If you use [custom render functions](https://testing-library.com/docs/example-re
 ## Further Reading
 
 - [debug API in React Testing Library](https://testing-library.com/docs/react-testing-library/api#debug)
+- [`screen.debug` in Dom Testing Library](https://testing-library.com/docs/dom-testing-library/api-queries#screendebug)

--- a/docs/rules/no-debug.md
+++ b/docs/rules/no-debug.md
@@ -2,12 +2,9 @@
 
 Just like `console.log` statements pollutes the browser's output, debug statements also pollutes the tests if one of your team mates forgot to remove it. `debug` statements should be used when you actually want to debug your tests but should not be pushed to the codebase.
 
-In addition, it also checks for `debug` on [`screen` object](https://testing-library.com/docs/dom-testing-library/api-queries#screen) from `@testing-library/dom`
-and libraries that re-export it, such as `@testing-library/react`.
-
 ## Rule Details
 
-This rule aims to disallow the use of `debug` and `screen.debug` in your tests.
+This rule aims to disallow the use of `debug` in your tests.
 
 Examples of **incorrect** code for this rule:
 

--- a/docs/rules/no-debug.md
+++ b/docs/rules/no-debug.md
@@ -2,18 +2,33 @@
 
 Just like `console.log` statements pollutes the browser's output, debug statements also pollutes the tests if one of your team mates forgot to remove it. `debug` statements should be used when you actually want to debug your tests but should not be pushed to the codebase.
 
+In addition, it also checks for `debug` on [`screen` object](https://testing-library.com/docs/dom-testing-library/api-queries#screen) from `@testing-library/dom`
+and libraries that re-export it, such as `@testing-library/react`.
+
 ## Rule Details
 
-This rule aims to disallow the use of `debug` in your tests.
+This rule aims to disallow the use of `debug` and `screen.debug` in your tests.
 
 Examples of **incorrect** code for this rule:
 
 ```js
 const { debug } = render(<Hello />);
 debug();
-// OR
+```
+
+```js
 const utils = render(<Hello />);
 utils.debug();
+```
+
+```js
+import { screen } from '@testing-library/dom';
+screen.debug();
+```
+
+```js
+const { screen } = require('@testing-library/react');
+screen.debug();
 ```
 
 If you use [custom render functions](https://testing-library.com/docs/example-react-redux) then you can set a config option in your `.eslintrc` to look for these.

--- a/lib/rules/no-debug.js
+++ b/lib/rules/no-debug.js
@@ -2,6 +2,14 @@
 
 const { getDocsUrl } = require('../utils');
 
+const LIBRARY_MODULES_WITH_SCREEN = [
+  '@testing-library/dom',
+  '@testing-library/react',
+  '@testing-library/preact',
+  '@testing-library/vue',
+  '@testing-library/svelte',
+];
+
 module.exports = {
   meta: {
     type: 'problem',
@@ -36,6 +44,8 @@ module.exports = {
       [{ renderFunctions }] = context.options;
     }
 
+    let hasImportedScreen = false;
+
     return {
       VariableDeclarator(node) {
         if (
@@ -57,8 +67,58 @@ module.exports = {
           }
         }
       },
+      [`VariableDeclarator > CallExpression > Identifier[name="require"]`](
+        node
+      ) {
+        const { arguments: args } = node.parent;
+
+        const literalNodeScreenModuleName = args.find(args =>
+          LIBRARY_MODULES_WITH_SCREEN.includes(args.value)
+        );
+
+        if (!literalNodeScreenModuleName) {
+          return;
+        }
+
+        const declaratorNode = node.parent.parent;
+
+        if (
+          declaratorNode.id.type === 'ObjectPattern' &&
+          declaratorNode.id.properties.some(
+            property => property.key.name === 'screen'
+          )
+        ) {
+          hasImportedScreen = true;
+        }
+      },
+      ImportDeclaration(node) {
+        const screenModuleName = LIBRARY_MODULES_WITH_SCREEN.find(
+          module => module === node.source.value
+        );
+
+        if (
+          screenModuleName &&
+          node.specifiers.some(
+            specifier => specifier.imported.name === 'screen'
+          )
+        ) {
+          hasImportedScreen = true;
+        }
+      },
       [`CallExpression > Identifier[name="debug"]`](node) {
         if (hasDestructuredDebugStatement) {
+          context.report({
+            node,
+            messageId: 'noDebug',
+          });
+        }
+      },
+      [`CallExpression > MemberExpression > Identifier[name="debug"]`](node) {
+        if (
+          hasImportedScreen &&
+          node.parent &&
+          node.parent.object.name === 'screen'
+        ) {
           context.report({
             node,
             messageId: 'noDebug',

--- a/tests/lib/rules/no-debug.js
+++ b/tests/lib/rules/no-debug.js
@@ -17,6 +17,7 @@ const ruleTester = new RuleTester({
     ecmaFeatures: {
       jsx: true,
     },
+    sourceType: 'module',
   },
 });
 ruleTester.run('no-debug', rule, {
@@ -54,6 +55,33 @@ ruleTester.run('no-debug', rule, {
       code: `
         const utils = render(<Component/>)
         utils.foo()
+      `,
+    },
+    {
+      code: `screen.debug()`,
+    },
+    {
+      code: `
+        const { screen } = require('@testing-library/dom')
+        screen.debug
+      `,
+    },
+    {
+      code: `
+        import { screen } from '@testing-library/dom'
+        screen.debug
+      `,
+    },
+    {
+      code: `
+        const { screen } = require('something-else')
+        screen.debug()
+      `,
+    },
+    {
+      code: `
+        import { screen } from 'something-else'
+        screen.debug()
       `,
     },
   ],
@@ -108,6 +136,28 @@ ruleTester.run('no-debug', rule, {
         {
           messageId: 'noDebug',
         },
+        {
+          messageId: 'noDebug',
+        },
+      ],
+    },
+    {
+      code: `
+        const { screen } = require('@testing-library/dom')
+        screen.debug()
+      `,
+      errors: [
+        {
+          messageId: 'noDebug',
+        },
+      ],
+    },
+    {
+      code: `
+        import { screen } from '@testing-library/dom'
+        screen.debug()
+      `,
+      errors: [
         {
           messageId: 'noDebug',
         },

--- a/tests/lib/rules/no-debug.js
+++ b/tests/lib/rules/no-debug.js
@@ -73,6 +73,12 @@ ruleTester.run('no-debug', rule, {
       `,
     },
     {
+      code: `const { queries } = require('@testing-library/dom')`,
+    },
+    {
+      code: `import { queries } from '@testing-library/dom'`,
+    },
+    {
       code: `
         const { screen } = require('something-else')
         screen.debug()


### PR DESCRIPTION
`screen` export was added in [`@testing-library/dom@6.12.0`](https://github.com/testing-library/dom-testing-library/releases/tag/v6.12.0).

I think `no-debug` rule should also take into consideration the `screen.debug()` as it's basically just an utility to console.log entire testing container.

ref: https://github.com/testing-library/dom-testing-library/pull/429
