### PR TITLE
docs(prefer-explicit-assert): remove references to old rule

### DIFF
--- a/docs/rules/prefer-explicit-assert.md
+++ b/docs/rules/prefer-explicit-assert.md
@@ -13,12 +13,6 @@ elements in their tests rather than just use `getBy*` queries and expect
 it doesn't throw an error so it's easier to understand what's the
 expected behavior within the test.
 
-> ⚠️ Please note that this rule is recommended to be used together with
-> [prefer-expect-query-by](docs/rules/prefer-expect-query-by.md), so the
-> combination of these two rules will force users to do 2 actual
-> changes: wrap `getBy*` with `expect` assertion and then use `queryBy*`
-> instead of `getBy*` for asserting.
-
 Examples of **incorrect** code for this rule:
 
 ```js
@@ -40,9 +34,6 @@ expect(getByText('foo')).toBeDefined();
 
 const utils = render(<Component />);
 expect(utils.getByText('foo')).toBeDefined();
-
-// ⚠️ `getBy*` should be replaced by `queryBy*` when combined with `prefer-expect-query-by` rule
-expect(queryByText('foo')).toBeDefined();
 
 // even more explicit if you use `@testing-library/jest-dom` matcher
 // for checking the element is present in the document
@@ -73,10 +64,6 @@ This rule accepts a single options argument:
 
 If you prefer to use `getBy*` queries implicitly as an assert-like
 method itself, then this rule is not recommended.
-
-## Related Rules
-
-- [prefer-expect-query-by](prefer-expect-query-by.md)
 
 ## Further Reading
 


### PR DESCRIPTION
As spotted in #74 we still have references to non-existing prefer-expect-query-by rule within prefer-explicit-assert doc. This PR removes all those references as they don't make sense anymore.