### PR TITLE
feat(no-wait-for-empty-callback ): new rule no-wait-for-empty-callback 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@
 [![Tweet][tweet-badge]][tweet-url]
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-13-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ## Installation
@@ -132,18 +134,19 @@ To enable this configuration use the `extends` property in your
 
 ## Supported Rules
 
-| Rule                                                                                                | Description                                                                 | Configurations                                                            | Fixable            |
-| --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ------------------ |
-| [await-async-query](docs/rules/await-async-query.md)                                                | Enforce async queries to have proper `await`                                | ![recommended-badge][] ![angular-badge][] ![react-badge][] ![vue-badge][] |                    |
-| [await-async-utils](docs/rules/await-async-utils.md)                                                | Enforce async utils to be awaited properly                                  | ![recommended-badge][] ![angular-badge][] ![react-badge][] ![vue-badge][] |                    |
-| [await-fire-event](docs/rules/await-fire-event.md)                                                  | Enforce async fire event methods to be awaited                              | ![vue-badge][]                                                            |                    |
-| [consistent-data-testid](docs/rules/consistent-data-testid.md)                                      | Ensure `data-testid` values match a provided regex.                         |                                                                           |                    |
-| [no-await-sync-query](docs/rules/no-await-sync-query.md)                                            | Disallow unnecessary `await` for sync queries                               | ![recommended-badge][] ![angular-badge][] ![react-badge][] ![vue-badge][] |                    |
-| [no-debug](docs/rules/no-debug.md)                                                                  | Disallow the use of `debug`                                                 | ![angular-badge][] ![react-badge][] ![vue-badge][]                        |                    |
-| [no-dom-import](docs/rules/no-dom-import.md)                                                        | Disallow importing from DOM Testing Library                                 | ![angular-badge][] ![react-badge][] ![vue-badge][]                        | ![fixable-badge][] |
+| Rule                                                                                                   | Description                                                                 | Configurations                                                            | Fixable            |
+| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ------------------ |
+| [await-async-query](docs/rules/await-async-query.md)                                                   | Enforce async queries to have proper `await`                                | ![recommended-badge][] ![angular-badge][] ![react-badge][] ![vue-badge][] |                    |
+| [await-async-utils](docs/rules/await-async-utils.md)                                                   | Enforce async utils to be awaited properly                                  | ![recommended-badge][] ![angular-badge][] ![react-badge][] ![vue-badge][] |                    |
+| [await-fire-event](docs/rules/await-fire-event.md)                                                     | Enforce async fire event methods to be awaited                              | ![vue-badge][]                                                            |                    |
+| [consistent-data-testid](docs/rules/consistent-data-testid.md)                                         | Ensure `data-testid` values match a provided regex.                         |                                                                           |                    |
+| [no-await-sync-query](docs/rules/no-await-sync-query.md)                                               | Disallow unnecessary `await` for sync queries                               | ![recommended-badge][] ![angular-badge][] ![react-badge][] ![vue-badge][] |                    |
+| [no-debug](docs/rules/no-debug.md)                                                                     | Disallow the use of `debug`                                                 | ![angular-badge][] ![react-badge][] ![vue-badge][]                        |                    |
+| [no-dom-import](docs/rules/no-dom-import.md)                                                           | Disallow importing from DOM Testing Library                                 | ![angular-badge][] ![react-badge][] ![vue-badge][]                        | ![fixable-badge][] |
 | [no-get-by-for-checking-element-not-present](docs/rules/no-get-by-for-checking-element-not-present.md) | Disallow the use of `getBy*` queries when checking elements are not present |                                                                           |                    |
-| [no-manual-cleanup](docs/rules/no-manual-cleanup.md)                                                | Disallow the use of `cleanup`                                               |                                                                           |                    |
-| [prefer-explicit-assert](docs/rules/prefer-explicit-assert.md)                                      | Suggest using explicit assertions rather than just `getBy*` queries         |                                                                           |                    |
+| [no-manual-cleanup](docs/rules/no-manual-cleanup.md)                                                   | Disallow the use of `cleanup`                                               |                                                                           |                    |
+| [no-wait-for-empty-callback](docs/rules/no-wait-for-empty-callback.md)                                 | Disallow empty callbacks for `waitFor` and `waitForElementToBeRemoved`      |                                                                           |                    |
+| [prefer-explicit-assert](docs/rules/prefer-explicit-assert.md)                                         | Suggest using explicit assertions rather than just `getBy*` queries         |                                                                           |                    |
 
 [build-badge]: https://img.shields.io/travis/testing-library/eslint-plugin-testing-library?style=flat-square
 [build-url]: https://travis-ci.org/testing-library/eslint-plugin-testing-library
@@ -194,6 +197,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/docs/rules/no-wait-for-empty-callback.md
+++ b/docs/rules/no-wait-for-empty-callback.md
@@ -1,0 +1,39 @@
+# Empty callbacks inside `waitFor` and `waitForElementToBeRemoved` are not preferred (no-wait-for-empty-callback)
+
+## Rule Details
+
+This rule aims to ensure the correct usage of `waitFor` and `waitForElementToBeRemoved`, in the way that they're intended to be used.
+If an empty callback is used, these methods will just wait a tick, instead of making sure that a node was added or removed to the DOM.
+
+Examples of **incorrect** code for this rule:
+
+```js
+const foo = async () => {
+  await waitFor(() => {});
+  await waitFor(function() {});
+  await waitFor(noop);
+
+  await waitForElementToBeRemoved(() => {});
+  await waitForElementToBeRemoved(function() {});
+  await waitForElementToBeRemoved(noop);
+};
+```
+
+Examples of **correct** code for this rule:
+
+```js
+const foo = async () => {
+  await waitFor(() => {
+    screen.getByText(/submit/i);
+  });
+
+  const submit = screen.getByText(/submit/i);
+  await waitForElementToBeRemoved(() => submit);
+  // or
+  await waitForElementToBeRemoved(submit);
+};
+```
+
+## Further Reading
+
+- [dom-testing-library v7 release](https://github.com/testing-library/dom-testing-library/releases/tag/v7.0.0)

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ const rules = {
   'no-dom-import': require('./rules/no-dom-import'),
   'no-get-by-for-checking-element-not-present': require('./rules/no-get-by-for-checking-element-not-present'),
   'no-manual-cleanup': require('./rules/no-manual-cleanup'),
+  'no-wait-for-empty-callback': require('./rules/no-wait-for-empty-callback'),
   'prefer-explicit-assert': require('./rules/prefer-explicit-assert'),
 };
 

--- a/lib/rules/no-wait-for-empty-callback.js
+++ b/lib/rules/no-wait-for-empty-callback.js
@@ -1,38 +1,33 @@
 'use strict';
 
+const { getDocsUrl } = require('../utils');
+
 const WAIT_EXPRESSION_QUERY =
   'CallExpression[callee.name=/^(waitFor|waitForElementToBeRemoved)$/]';
 
 module.exports = {
   meta: {
-    type: 'code',
+    type: 'suggestion',
     docs: {
-      description: '',
+      description:
+        "It's not preferred to use empty callbacks in `waitFor` and `waitForElementToBeRemoved`",
       category: 'Best Practices',
       recommended: false,
+      url: getDocsUrl('no-wait-for-empty-callback'),
     },
     messages: {
-      noWaitForEmptyCallback: '',
+      noWaitForEmptyCallback:
+        'You should verify if a node is added or removed to the DOM in  `waitFor` and `waitForElementToBeRemoved`',
     },
     fixable: null,
     schema: [],
   },
 
   // trimmed down implementation of https://github.com/eslint/eslint/blob/master/lib/rules/no-empty-function.js
+  // TODO: var referencing any of previously mentioned?
   create: function(context) {
-    const sourceCode = context.getSourceCode();
-
     function reportIfEmpty(node) {
-      const innerComments = sourceCode.getTokens(node.body, {
-        includeComments: true,
-        filter: isCommentToken,
-      });
-
-      if (
-        node.body.type === 'BlockStatement' &&
-        node.body.body.length === 0 &&
-        innerComments.length === 0
-      ) {
+      if (node.body.type === 'BlockStatement' && node.body.body.length === 0) {
         context.report({
           node,
           loc: node.body.loc.start,
@@ -56,9 +51,3 @@ module.exports = {
     };
   },
 };
-
-function isCommentToken(token) {
-  return (
-    token.type === 'Line' || token.type === 'Block' || token.type === 'Shebang'
-  );
-}

--- a/lib/rules/no-wait-for-empty-callback.js
+++ b/lib/rules/no-wait-for-empty-callback.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const WAIT_EXPRESSION_QUERY =
+  'CallExpression[callee.name=/^(waitFor|waitForElementToBeRemoved)$/]';
+
+module.exports = {
+  meta: {
+    type: 'code',
+    docs: {
+      description: '',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    messages: {
+      noWaitForEmptyCallback: '',
+    },
+    fixable: null,
+    schema: [],
+  },
+
+  // trimmed down implementation of https://github.com/eslint/eslint/blob/master/lib/rules/no-empty-function.js
+  create: function(context) {
+    const sourceCode = context.getSourceCode();
+
+    function reportIfEmpty(node) {
+      const innerComments = sourceCode.getTokens(node.body, {
+        includeComments: true,
+        filter: isCommentToken,
+      });
+
+      if (
+        node.body.type === 'BlockStatement' &&
+        node.body.body.length === 0 &&
+        innerComments.length === 0
+      ) {
+        context.report({
+          node,
+          loc: node.body.loc.start,
+          messageId: 'noWaitForEmptyCallback',
+        });
+      }
+    }
+
+    function reportNoop(node) {
+      context.report({
+        node,
+        loc: node.loc.start,
+        messageId: 'noWaitForEmptyCallback',
+      });
+    }
+
+    return {
+      [`${WAIT_EXPRESSION_QUERY} > ArrowFunctionExpression`]: reportIfEmpty,
+      [`${WAIT_EXPRESSION_QUERY} > FunctionExpression`]: reportIfEmpty,
+      [`${WAIT_EXPRESSION_QUERY} > Identifier[name="noop"]`]: reportNoop,
+    };
+  },
+};
+
+function isCommentToken(token) {
+  return (
+    token.type === 'Line' || token.type === 'Block' || token.type === 'Shebang'
+  );
+}

--- a/tests/lib/rules/no-wait-for-empty-callback.js
+++ b/tests/lib/rules/no-wait-for-empty-callback.js
@@ -17,24 +17,23 @@ ruleTester.run('no-wait-for-empty-callback', rule, {
       code: `${m}(() => {
           screen.getByText(/submit/i)
         })`,
-      errors: [
-        {
-          messageId: 'noWaitForEmptyCallback',
-        },
-      ],
     })),
     ...ALL_WAIT_METHODS.map(m => ({
       code: `${m}(function() {
           screen.getByText(/submit/i)
         })`,
-      errors: [
-        {
-          messageId: 'noWaitForEmptyCallback',
-        },
-      ],
     })),
     {
+      code: `waitForElementToBeRemoved(someNode)`,
+    },
+    {
+      code: `waitForElementToBeRemoved(() => someNode)`,
+    },
+    {
       code: `waitSomethingElse(() => {})`,
+    },
+    {
+      code: `wait(() => {})`,
     },
   ],
 
@@ -48,6 +47,23 @@ ruleTester.run('no-wait-for-empty-callback', rule, {
       ],
     })),
     ...ALL_WAIT_METHODS.map(m => ({
+      code: `${m}((a, b) => {})`,
+      errors: [
+        {
+          messageId: 'noWaitForEmptyCallback',
+        },
+      ],
+    })),
+    ...ALL_WAIT_METHODS.map(m => ({
+      code: `${m}(() => { /* I'm empty anyway */ })`,
+      errors: [
+        {
+          messageId: 'noWaitForEmptyCallback',
+        },
+      ],
+    })),
+
+    ...ALL_WAIT_METHODS.map(m => ({
       code: `${m}(function() {
 
       })`,
@@ -57,6 +73,27 @@ ruleTester.run('no-wait-for-empty-callback', rule, {
         },
       ],
     })),
+    ...ALL_WAIT_METHODS.map(m => ({
+      code: `${m}(function(a) {
+
+      })`,
+      errors: [
+        {
+          messageId: 'noWaitForEmptyCallback',
+        },
+      ],
+    })),
+    ...ALL_WAIT_METHODS.map(m => ({
+      code: `${m}(function() {
+        // another empty callback
+      })`,
+      errors: [
+        {
+          messageId: 'noWaitForEmptyCallback',
+        },
+      ],
+    })),
+
     ...ALL_WAIT_METHODS.map(m => ({
       code: `${m}(noop)`,
       errors: [

--- a/tests/lib/rules/no-wait-for-empty-callback.js
+++ b/tests/lib/rules/no-wait-for-empty-callback.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const rule = require('../../../lib/rules/no-wait-for-empty-callback');
+const RuleTester = require('eslint').RuleTester;
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2018 } });
+
+const ALL_WAIT_METHODS = ['waitFor', 'waitForElementToBeRemoved'];
+
+ruleTester.run('no-wait-for-empty-callback', rule, {
+  valid: [
+    ...ALL_WAIT_METHODS.map(m => ({
+      code: `${m}(() => {
+          screen.getByText(/submit/i)
+        })`,
+      errors: [
+        {
+          messageId: 'noWaitForEmptyCallback',
+        },
+      ],
+    })),
+    ...ALL_WAIT_METHODS.map(m => ({
+      code: `${m}(function() {
+          screen.getByText(/submit/i)
+        })`,
+      errors: [
+        {
+          messageId: 'noWaitForEmptyCallback',
+        },
+      ],
+    })),
+    {
+      code: `waitSomethingElse(() => {})`,
+    },
+  ],
+
+  invalid: [
+    ...ALL_WAIT_METHODS.map(m => ({
+      code: `${m}(() => {})`,
+      errors: [
+        {
+          messageId: 'noWaitForEmptyCallback',
+        },
+      ],
+    })),
+    ...ALL_WAIT_METHODS.map(m => ({
+      code: `${m}(function() {
+
+      })`,
+      errors: [
+        {
+          messageId: 'noWaitForEmptyCallback',
+        },
+      ],
+    })),
+    ...ALL_WAIT_METHODS.map(m => ({
+      code: `${m}(noop)`,
+      errors: [
+        {
+          messageId: 'noWaitForEmptyCallback',
+        },
+      ],
+    })),
+  ],
+});


### PR DESCRIPTION
Closes #92 

This rule covers:

- empty arrow function (i.e. `() => {}`)
- empty regular function (i.e. `function () {}`)
- a function or var called `noop`


Inspired by eslint no-empty-function rule