### PR TITLE
fix(no-debug): enable for angular

### DIFF
--- a/lib/rules/no-debug.js
+++ b/lib/rules/no-debug.js
@@ -4,6 +4,7 @@ const { getDocsUrl } = require('../utils');
 
 const LIBRARY_MODULES_WITH_SCREEN = [
   '@testing-library/dom',
+  '@testing-library/angular',
   '@testing-library/react',
   '@testing-library/preact',
   '@testing-library/vue',


### PR DESCRIPTION
Angular also uses `debug` 😁
