### PR TITLE
fix: add missing doc urls

### DIFF
--- a/lib/rules/consistent-data-testid.js
+++ b/lib/rules/consistent-data-testid.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { getDocsUrl } = require('../utils');
+
 const FILENAME_PLACEHOLDER = '{fileName}';
 
 module.exports = {
@@ -8,6 +10,7 @@ module.exports = {
       description: 'Ensures consistent usage of `data-testid`',
       category: 'Best Practices',
       recommended: false,
+      url: getDocsUrl('consistent-data-testid'),
     },
     messages: {
       invalidTestId: '`{{attr}}` "{{value}}" should match `{{regex}}`',

--- a/lib/rules/no-manual-cleanup.js
+++ b/lib/rules/no-manual-cleanup.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { getDocsUrl } = require('../utils');
+
 const CLEANUP_LIBRARY_REGEX = /(@testing-library\/(preact|react|svelte|vue))|@marko\/testing-library/;
 
 module.exports = {
@@ -9,6 +11,7 @@ module.exports = {
       description: ' Disallow the use of `cleanup`',
       category: 'Best Practices',
       recommended: false,
+      url: getDocsUrl('no-manual-cleanup'),
     },
     messages: {
       noManualCleanup:

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -4,7 +4,7 @@ const { configs, rules } = require('../lib');
 const fs = require('fs');
 const path = require('path');
 
-const rulesModules = fs.readdirSync(path.join(__dirname, '/lib/rules'));
+const rulesModules = fs.readdirSync(path.join(__dirname, '../lib/rules'));
 
 it('should export all available rules', () => {
   const availableRules = rulesModules.map(module => module.replace('.js', ''));


### PR DESCRIPTION
Add missing references to docs.
Also point missing export tests to the rules of the lib, instead of the tests.