### PR TITLE
Pr/fix async checks when calling queries member expressions

### DIFF
--- a/docs/rules/await-async-query.md
+++ b/docs/rules/await-async-query.md
@@ -30,6 +30,12 @@ const bar = () => {
   findByText('submit');
   // ...
 };
+
+const baz = () => {
+  // ...
+  screen.findAllByPlaceholderText('name');
+  // ...
+};
 ```
 
 Examples of **correct** code for this rule:
@@ -48,6 +54,12 @@ const bar = () => {
   findByText('submit').then(() => {
     // ...
   });
+};
+
+const baz = () => {
+  // ...
+  await screen.findAllByPlaceholderText('name');
+  // ...
 };
 
 // return the promise within a function is correct too!

--- a/docs/rules/no-await-sync-query.md
+++ b/docs/rules/no-await-sync-query.md
@@ -29,6 +29,11 @@ const bar = () => {
     // ...
   });
 };
+
+const baz = () => {
+  // ...
+  const button = await screen.getByText('submit');
+};
 ```
 
 Examples of **correct** code for this rule:
@@ -44,6 +49,11 @@ const bar = () => {
   // ...
   const button = getByText('submit');
   // ...
+};
+
+const baz = () => {
+  // ...
+  const button = screen.getByText('submit');
 };
 ```
 

--- a/lib/rules/await-async-query.js
+++ b/lib/rules/await-async-query.js
@@ -28,18 +28,26 @@ module.exports = {
 
   create: function(context) {
     const testingLibraryQueryUsage = [];
+    const isQueryUsage = node =>
+      !isAwaited(node.parent.parent) &&
+      !isPromiseResolved(node) &&
+      !hasClosestExpectResolvesRejects(node);
+
     return {
       [`CallExpression > Identifier[name=${ASYNC_QUERIES_REGEXP}]`](node) {
-        if (
-          !isAwaited(node.parent.parent) &&
-          !isPromiseResolved(node) &&
-          !hasClosestExpectResolvesRejects(node)
-        ) {
-          testingLibraryQueryUsage.push(node);
+        if (isQueryUsage(node)) {
+          testingLibraryQueryUsage.push({ node, queryName: node.name });
+        }
+      },
+      [`MemberExpression > Identifier[name=${ASYNC_QUERIES_REGEXP}]`](node) {
+        // Perform checks in parent MemberExpression insted of current identifier
+        const parent = node.parent;
+        if (isQueryUsage(parent)) {
+          testingLibraryQueryUsage.push({ node: parent, queryName: node.name });
         }
       },
       'Program:exit'() {
-        testingLibraryQueryUsage.forEach(node => {
+        testingLibraryQueryUsage.forEach(({ node, queryName }) => {
           const variableDeclaratorParent = node.parent.parent;
 
           const references =
@@ -54,7 +62,7 @@ module.exports = {
               node,
               messageId: 'awaitAsyncQuery',
               data: {
-                name: node.name,
+                name: queryName,
               },
             });
           } else {
@@ -68,7 +76,7 @@ module.exports = {
                   node,
                   messageId: 'awaitAsyncQuery',
                   data: {
-                    name: node.name,
+                    name: queryName,
                   },
                 });
 

--- a/lib/rules/await-async-query.js
+++ b/lib/rules/await-async-query.js
@@ -49,12 +49,7 @@ module.exports = {
                 .references.slice(1)) ||
             [];
 
-          if (
-            references &&
-            references.length === 0 &&
-            !isAwaited(node.parent.parent) &&
-            !isPromiseResolved(node)
-          ) {
+          if (references && references.length === 0) {
             context.report({
               node,
               messageId: 'awaitAsyncQuery',

--- a/lib/rules/no-await-sync-query.js
+++ b/lib/rules/no-await-sync-query.js
@@ -21,18 +21,17 @@ module.exports = {
   },
 
   create: function(context) {
+    const reportError = node =>
+      context.report({
+        node,
+        messageId: 'noAwaitSyncQuery',
+        data: {
+          name: node.name,
+        },
+      });
     return {
-      [`AwaitExpression > CallExpression > Identifier[name=${SYNC_QUERIES_REGEXP}]`](
-        node
-      ) {
-        context.report({
-          node,
-          messageId: 'noAwaitSyncQuery',
-          data: {
-            name: node.name,
-          },
-        });
-      },
+      [`AwaitExpression > CallExpression > Identifier[name=${SYNC_QUERIES_REGEXP}]`]: reportError,
+      [`AwaitExpression > CallExpression > MemberExpression > Identifier[name=${SYNC_QUERIES_REGEXP}]`]: reportError,
     };
   },
 };

--- a/tests/lib/rules/await-async-query.js
+++ b/tests/lib/rules/await-async-query.js
@@ -25,6 +25,14 @@ ruleTester.run('await-async-query', rule, {
       `,
     })),
 
+    // async queries declaration are valid
+    ...ASYNC_QUERIES_COMBINATIONS.map(query => ({
+      code: `async () => {
+        await screen.${query}('foo')
+      }
+      `,
+    })),
+
     // async queries with await operator are valid
     ...ASYNC_QUERIES_COMBINATIONS.map(query => ({
       code: `async () => {
@@ -145,6 +153,25 @@ ruleTester.run('await-async-query', rule, {
         const foo = ${query}('foo')
       }
       `,
+        errors: [
+          {
+            messageId: 'awaitAsyncQuery',
+          },
+        ],
+      })),
+      ...ASYNC_QUERIES_COMBINATIONS.map(query => ({
+        code: `async () => {
+        screen.${query}('foo')
+      }
+      `,
+        errors: [
+          {
+            messageId: 'awaitAsyncQuery',
+          },
+        ],
+      })),
+      ...ASYNC_QUERIES_COMBINATIONS.map(query => ({
+        code: `const foo = screen.${query}('foo')`,
         errors: [
           {
             messageId: 'awaitAsyncQuery',

--- a/tests/lib/rules/no-await-sync-query.js
+++ b/tests/lib/rules/no-await-sync-query.js
@@ -43,9 +43,9 @@ ruleTester.run('no-await-sync-query', rule, {
     })),
   ],
 
-  invalid:
+  invalid: [
     // sync queries with await operator are not valid
-    SYNC_QUERIES_COMBINATIONS.map(query => ({
+    ...SYNC_QUERIES_COMBINATIONS.map(query => ({
       code: `async () => {
         await ${query}('foo')
       }
@@ -56,4 +56,18 @@ ruleTester.run('no-await-sync-query', rule, {
         },
       ],
     })),
+
+    // sync queries in screen with await operator are not valid
+    ...SYNC_QUERIES_COMBINATIONS.map(query => ({
+      code: `async () => {
+        await screen.${query}('foo')
+      }
+      `,
+      errors: [
+        {
+          messageId: 'noAwaitSyncQuery',
+        },
+      ],
+    })),
+  ],
 });


### PR DESCRIPTION
# What
This PR fixes [113](https://github.com/testing-library/eslint-plugin-testing-library/issues/113). It updates 2 rules: `await-async-query` and `no-await-sync-query`

## How

- Selectors were adjusted to match queries inside MemberExpression nodes
- Some minor refactoring was done to avoid repetition in the new selectors
- More info in the commit messages

## Demo

**await-async-query**

Before:
![Screenshot from 2020-04-18 09-51-28](https://user-images.githubusercontent.com/18427801/79631937-79e13c80-815c-11ea-82e5-9b52e22d1bc1.png)

After
![Screenshot from 2020-04-18 09-48-58](https://user-images.githubusercontent.com/18427801/79631940-7fd71d80-815c-11ea-8a49-dc8ca2598af6.png)

**no-await-sync-query**

Before:
![Screenshot from 2020-04-18 10-10-35](https://user-images.githubusercontent.com/18427801/79632023-ec521c80-815c-11ea-9d3b-fb8c7420927a.png)


After:
![Screenshot from 2020-04-18 10-09-56](https://user-images.githubusercontent.com/18427801/79632017-e5c3a500-815c-11ea-8bf9-0e6029982cfc.png)

