### PR TITLE
feat: add basic config for cypress

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@
 [![Tweet][tweet-badge]][tweet-url]
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-16-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ## Installation
@@ -105,6 +107,17 @@ To enable this configuration use the `extends` property in your
 ```json
 {
   "extends": ["plugin:testing-library/angular"]
+}
+```
+
+#### Cypress
+
+To enable this configuration use the `extends` property in your
+`.eslintrc` config file:
+
+```json
+{
+  "extends": ["plugin:testing-library/cypress"]
 }
 ```
 
@@ -202,6 +215,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,12 @@ module.exports = {
         'testing-library/no-dom-import': ['error', 'angular'],
       },
     },
+    cypress: {
+      plugins: ['testing-library'],
+      rules: {
+        'testing-library/no-debug': 'warn',
+      },
+    },
     react: {
       plugins: ['testing-library'],
       rules: {


### PR DESCRIPTION
I noticed that some of the default rules (like for `async`) don't really work for Cypress, as [commands are not promises](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Commands-Are-Not-Promises).

So I thought it would be good to start a default config for Cypress as well.