### PR TITLE
fix: correct consistent-data-testid docs example

### DIFF
--- a/docs/rules/consistent-data-testid.md
+++ b/docs/rules/consistent-data-testid.md
@@ -33,7 +33,7 @@ const baz = props => <div>...</div>;
 
 ```json
 {
-  "testing-library/data-testid": [
+  "testing-library/consistent-data-testid": [
     2,
     {
       "testIdPattern": "^TestId(__[A-Z]*)?$"


### PR DESCRIPTION
I just noticed the docs don't have the correct rule name here as I was having some trouble getting it to work. 