### PR TITLE
fix: ensure node exists before using in isArrowFunctionExpression

### DIFF
--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -104,5 +104,5 @@ export function hasThenProperty(node: TSESTree.Node) {
 }
 
 export function isArrowFunctionExpression(node: TSESTree.Node): node is TSESTree.ArrowFunctionExpression {
-  return node.type === 'ArrowFunctionExpression'
+  return node && node.type === 'ArrowFunctionExpression'
 }

--- a/tests/lib/rules/prefer-find-by.test.ts
+++ b/tests/lib/rules/prefer-find-by.test.ts
@@ -53,7 +53,10 @@ ruleTester.run(RULE_NAME, rule, {
       `
     })),
     {
-      code: `await waitFor()`
+      code: `
+        await waitFor();
+        await wait();
+      `
     }
   ],
   invalid: [

--- a/tests/lib/rules/prefer-find-by.test.ts
+++ b/tests/lib/rules/prefer-find-by.test.ts
@@ -51,7 +51,10 @@ ruleTester.run(RULE_NAME, rule, {
       code: `
         await waitFor(() => expect(${queryMethod}('baz')).toBeInTheDocument());
       `
-    }))
+    })),
+    {
+      code: `await waitFor()`
+    }
   ],
   invalid: [
     // using reduce + concat 'cause flatMap is not available in node10.x


### PR DESCRIPTION
This fixes an issue where the linter blows up when there are no arguments in `wait()` or `waitFor()`

![image](https://user-images.githubusercontent.com/5173987/84462689-48a15c00-ac35-11ea-97e4-04e08051120a.png)
