### PR TITLE
ci: include eslint matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,26 @@
 language: node_js
 
 env:
-  - FORCE_COLOR=true
+  global:
+    - FORCE_COLOR=true
+  matrix:
+    - ESLINT=5
+    - ESLINT=6
 
 node_js:
   - 10.12
   - 12
-  - node
+  - 14
+
+before_script:
+  - 'if [ -n "${ESLINT-}" ]; then npm install --no-save "eslint@${ESLINT}" ; fi'
 
 jobs:
   include:
     - stage: release
       if: branch = master AND type != pull_request
-      node_js: 12
+      node_js: 14
+      env: ESLINT=6
       script: npm run build
       deploy:
         provider: script

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@typescript-eslint/eslint-plugin": "^2.26.0",
     "@typescript-eslint/parser": "^2.26.0",
     "cpy-cli": "^3.1.0",
-    "eslint": "^6.3.0",
+    "eslint": "^5 || ^6",
     "eslint-config-prettier": "^6.1.0",
     "eslint-config-standard": "^14.1.0",
     "eslint-plugin-import": "^2.18.2",
@@ -67,11 +67,11 @@
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
-    "eslint": ">=5"
+    "eslint": "^5 || ^6"
   },
   "engines": {
-    "node": ">=8",
-    "npm": ">=5"
+    "node": "^10.12.0 || >=12.0.0",
+    "npm": ">=6"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Update CI matrix to run tests combining supported node versions (v10.12, v12, v14) and ESLint versions (v5, v6). This will help adding support for ESLint v7 in #139

I'm not sure how to test or dry run the release stage, so I may need to readjust something when this PR is merged (unless someone can help me testing this locally).