### PR TITLE
fix: add findby variable declaration to prefer-find-by when auto fixing

### DIFF
--- a/tests/lib/rules/prefer-find-by.test.ts
+++ b/tests/lib/rules/prefer-find-by.test.ts
@@ -1,7 +1,7 @@
-import { InvalidTestCase } from '@typescript-eslint/experimental-utils/dist/ts-eslint'
+import { InvalidTestCase, ValidTestCase } from '@typescript-eslint/experimental-utils/dist/ts-eslint'
 import { createRuleTester } from '../test-utils';
 import { ASYNC_QUERIES_COMBINATIONS, SYNC_QUERIES_COMBINATIONS } from '../../../lib/utils';
-import rule, { WAIT_METHODS, RULE_NAME } from '../../../lib/rules/prefer-find-by';
+import rule, { WAIT_METHODS, RULE_NAME, getFindByQueryVariant, MessageIds } from '../../../lib/rules/prefer-find-by';
 
 const ruleTester = createRuleTester({
   ecmaFeatures: {
@@ -9,10 +9,26 @@ const ruleTester = createRuleTester({
   },
 });
 
+function buildFindByMethod(queryMethod: string) {
+  return `${getFindByQueryVariant(queryMethod)}${queryMethod.split('By')[1]}`
+}
+
+function createScenario<T extends ValidTestCase<[]> | InvalidTestCase<MessageIds, []>>(callback: (waitMethod: string, queryMethod: string) => T) {
+  return WAIT_METHODS.reduce((acc: T[], waitMethod) => 
+    acc.concat(
+      SYNC_QUERIES_COMBINATIONS
+        .map((queryMethod) => callback(waitMethod, queryMethod))
+    )
+  , [])
+}
+
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     ...ASYNC_QUERIES_COMBINATIONS.map((queryMethod) => ({
-      code: `const submitButton = await ${queryMethod}('foo')`
+      code: `
+        const { ${queryMethod} } = setup()
+        const submitButton = await ${queryMethod}('foo')
+      `
     })),
     ...ASYNC_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `const submitButton = await screen.${queryMethod}('foo')`
@@ -60,35 +76,117 @@ ruleTester.run(RULE_NAME, rule, {
     }
   ],
   invalid: [
-    // using reduce + concat 'cause flatMap is not available in node10.x
-    ...WAIT_METHODS.reduce((acc: InvalidTestCase<'preferFindBy', []>[], waitMethod) => acc
-      .concat(
-        SYNC_QUERIES_COMBINATIONS.map((queryMethod: string) => ({
-          code: `const submitButton = await ${waitMethod}(() => ${queryMethod}('foo', { name: 'baz' }))`,
-          errors: [{
-            messageId: 'preferFindBy',
-            data: {
-              queryVariant: queryMethod.includes('All') ? 'findAllBy': 'findBy',
-              queryMethod: queryMethod.split('By')[1],
-              fullQuery: `${waitMethod}(() => ${queryMethod}('foo', { name: 'baz' }))`,
-            },
-          }],
-          output: `const submitButton = await ${queryMethod.includes('All') ? 'findAllBy': 'findBy'}${queryMethod.split('By')[1]}('foo', { name: 'baz' })`
-        }))
-      ).concat(
-        SYNC_QUERIES_COMBINATIONS.map((queryMethod: string) => ({
-          code: `const submitButton = await ${waitMethod}(() => screen.${queryMethod}('foo', { name: 'baz' }))`,
-          errors: [{
-            messageId: 'preferFindBy',
-            data: {
-              queryVariant: queryMethod.includes('All') ? 'findAllBy': 'findBy',
-              queryMethod: queryMethod.split('By')[1],
-              fullQuery: `${waitMethod}(() => screen.${queryMethod}('foo', { name: 'baz' }))`,
-            }
-          }],
-          output: `const submitButton = await screen.${queryMethod.includes('All') ? 'findAllBy': 'findBy'}${queryMethod.split('By')[1]}('foo', { name: 'baz' })`
-        }))
-      ),
-    [])
+    ...createScenario((waitMethod: string, queryMethod: string) => ({
+      code: `
+        const { ${queryMethod} } = render()
+        const submitButton = await ${waitMethod}(() => ${queryMethod}('foo', { name: 'baz' }))
+      `,
+      errors: [{
+        messageId: 'preferFindBy',
+        data: {
+          queryVariant: getFindByQueryVariant(queryMethod),
+          queryMethod: queryMethod.split('By')[1],
+          fullQuery: `${waitMethod}(() => ${queryMethod}('foo', { name: 'baz' }))`,
+        },
+      }],
+      output: `
+        const { ${queryMethod}, ${buildFindByMethod(queryMethod)} } = render()
+        const submitButton = await ${buildFindByMethod(queryMethod)}('foo', { name: 'baz' })
+      `
+    })),
+    ...createScenario((waitMethod: string, queryMethod: string) => ({
+      code: `const submitButton = await ${waitMethod}(() => screen.${queryMethod}('foo', { name: 'baz' }))`,
+      errors: [{
+        messageId: 'preferFindBy',
+        data: {
+          queryVariant: getFindByQueryVariant(queryMethod),
+          queryMethod: queryMethod.split('By')[1],
+          fullQuery: `${waitMethod}(() => screen.${queryMethod}('foo', { name: 'baz' }))`,
+        }
+      }],
+      output: `const submitButton = await screen.${buildFindByMethod(queryMethod)}('foo', { name: 'baz' })`
+    })),
+    // // this scenario verifies it works when the render function is defined in another scope
+    ...WAIT_METHODS.map((waitMethod: string) => ({
+      code: `
+        const { getByText, queryByLabelText, findAllByRole } = customRender()
+        it('foo', async () => {
+          const submitButton = await ${waitMethod}(() => getByText('baz', { name: 'button' }))
+        })
+      `,
+      errors: [{
+        messageId: 'preferFindBy',
+        data: {
+          queryVariant: 'findBy',
+          queryMethod: 'Text',
+          fullQuery: `${waitMethod}(() => getByText('baz', { name: 'button' }))`,
+        }
+      }],
+      output: `
+        const { getByText, queryByLabelText, findAllByRole, findByText } = customRender()
+        it('foo', async () => {
+          const submitButton = await findByText('baz', { name: 'button' })
+        })
+      `
+    })),
+    // // this scenario verifies when findBy* were already defined (because it was used elsewhere)
+    ...WAIT_METHODS.map((waitMethod: string) => ({
+      code: `
+        const { getAllByRole, findAllByRole } = customRender()
+        describe('some scenario', () => {
+          it('foo', async () => {
+            const submitButton = await ${waitMethod}(() => getAllByRole('baz', { name: 'button' }))
+          })
+        })
+      `,
+      errors: [{
+        messageId: 'preferFindBy',
+        data: {
+          queryVariant: 'findAllBy',
+          queryMethod: 'Role',
+          fullQuery: `${waitMethod}(() => getAllByRole('baz', { name: 'button' }))`,
+        }
+      }],
+      output: `
+        const { getAllByRole, findAllByRole } = customRender()
+        describe('some scenario', () => {
+          it('foo', async () => {
+            const submitButton = await findAllByRole('baz', { name: 'button' })
+          })
+        })
+      `
+    })),
+    // invalid code, as we need findBy* to be defined somewhere, but required for getting 100% coverage
+    {
+      code: `const submitButton = await waitFor(() => getByText('baz', { name: 'button' }))`,
+      errors: [{
+        messageId: 'preferFindBy',
+        data: {
+          queryVariant: 'findBy',
+          queryMethod: 'Text',
+          fullQuery: `waitFor(() => getByText('baz', { name: 'button' }))`
+        }
+      }],
+      output: `const submitButton = await findByText('baz', { name: 'button' })`
+    },
+    // this code would be invalid too, as findByRole is not defined anywhere.
+    {
+      code: `
+        const getByRole = render().getByRole
+        const submitButton = await waitFor(() => getByRole('baz', { name: 'button' }))
+      `,
+      errors: [{
+        messageId: 'preferFindBy',
+        data: {
+          queryVariant: 'findBy',
+          queryMethod: 'Role',
+          fullQuery: `waitFor(() => getByRole('baz', { name: 'button' }))`
+        }
+      }],
+      output: `
+        const getByRole = render().getByRole
+        const submitButton = await findByRole('baz', { name: 'button' })
+      `
+    }
   ],
 })


### PR DESCRIPTION
This PR fixes #167 

The following scenario

```ts
// incorrect
const { getByText } = render(<Foo />)
await waitFor(() => getByText('foo'))
```

now becomes
```ts
// correct - and findByText is defined
const { getByText, findByText } = render(<Foo />)
await findByText('foo')
```

this should even work if they are in different levels. For instance

```ts
// incorrect
const { getByText } = render(<Foo />)
it('tests', async () => {
   await waitFor(() => getByText('foo'))
})
```

should be converted to

```ts
// correct - findByText is defined
// as long as the customRender is in any parent scope from the original code, this works
const { getByText, findByText } = customRender(<Foo />)
it('tests', async () => {
     await findByText('foo')
})
```

there are some scenarios that I assume they are out of scope, and I am seriously not sure how to fix them. For instance, if the query is passed from a function, like 

```ts
function commonCode(getByText) {
  await waitFor(() => getByText(baz))
// do stuff
}

// later, in a test
commonCode(render().getByText)
```

or similar, I can't fix it.. but I guess that sounds like a non-realistic scenario.

Another that _might_ be slightly more realistic (or actually, less complex) might be something like

```ts
const utils= render(baz)
const getByText = utils.getByText
await waitFor(() => getByText('foo'))
```

I am not fixing that either. I'd assume if they are storing the result from the `render`, then they are using that variable. These snippets seem mostly hacks to avoid the rule, rather than code that someone would write on its own.


and a demo gif!

![2020-06-26_17-08-17](https://user-images.githubusercontent.com/352474/87607415-acef8980-c6d3-11ea-9f5c-086522c507f4.gif)


(The spaces are due to other eslint rules I've configured on the project I tested this 👀 )


P.S: I'm not using the fork 🎉 