### PR TITLE
feat(no-render-in-setup): adds no-render-in-setup rule, closes #207

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@
 [![Tweet][tweet-badge]][tweet-url]
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-29-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ## Installation
@@ -141,6 +143,7 @@ To enable this configuration use the `extends` property in your
 | [no-debug](docs/rules/no-debug.md)                                     | Disallow the use of `debug`                                                | ![angular-badge][] ![react-badge][] ![vue-badge][]                        |                    |
 | [no-dom-import](docs/rules/no-dom-import.md)                           | Disallow importing from DOM Testing Library                                | ![angular-badge][] ![react-badge][] ![vue-badge][]                        | ![fixable-badge][] |
 | [no-manual-cleanup](docs/rules/no-manual-cleanup.md)                   | Disallow the use of `cleanup`                                              |                                                                           |                    |
+| [no-render-in-setup](docs/rules/no-render-in-setup.md)                 | Disallow the use of `render` in setup functions                            |                                                                           |                    |
 | [no-wait-for-empty-callback](docs/rules/no-wait-for-empty-callback.md) | Disallow empty callbacks for `waitFor` and `waitForElementToBeRemoved`     |                                                                           |                    |
 | [prefer-explicit-assert](docs/rules/prefer-explicit-assert.md)         | Suggest using explicit assertions rather than just `getBy*` queries        |                                                                           |                    |
 | [prefer-find-by](docs/rules/prefer-find-by.md)                         | Suggest using `findBy*` methods instead of the `waitFor` + `getBy` queries | ![recommended-badge][] ![angular-badge][] ![react-badge][] ![vue-badge][] | ![fixable-badge][] |
@@ -219,6 +222,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/docs/rules/no-render-in-setup.md
+++ b/docs/rules/no-render-in-setup.md
@@ -1,0 +1,42 @@
+# Disallow the use of `render` in setup functions (no-render-in-setup)
+
+## Rule Details
+
+This rule disallows the usage of `render` in setup functions (`beforeEach` or `beforeAll`) in favor of a single test with multiple assertions.
+
+Examples of **incorrect** code for this rule:
+
+```js
+beforeEach(() => {
+  render(<MyComponent />);
+});
+
+it('Should have foo', () => {
+  expect(screen.getByText('foo')).toBeInTheDocument();
+});
+
+it('Should have bar', () => {
+  expect(screen.getByText('bar')).toBeInTheDocument();
+});
+
+it('Should have baz', () => {
+  expect(screen.getByText('baz')).toBeInTheDocument();
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+it('Should have foo, bar and baz', () => {
+  render(<MyComponent />);
+  expect(screen.getByText('foo')).toBeInTheDocument();
+  expect(screen.getByText('bar')).toBeInTheDocument();
+  expect(screen.getByText('baz')).toBeInTheDocument();
+});
+```
+
+If you use [custom render functions](https://testing-library.com/docs/example-react-redux) then you can set a config option in your `.eslintrc` to look for these.
+
+```
+   "testing-library/no-render-in-setup": ["error", {"renderFunctions":["renderWithRedux", "renderWithRouter"]}],
+```

--- a/docs/rules/no-render-in-setup.md
+++ b/docs/rules/no-render-in-setup.md
@@ -41,7 +41,7 @@ If you use [custom render functions](https://testing-library.com/docs/example-re
    "testing-library/no-render-in-setup": ["error", {"renderFunctions": ["renderWithRedux", "renderWithRouter"]}],
 ```
 
-If you would would like to allow the use of `render` (or custom render function) in _either_ `beforeAll` or `beforeEach`, this can be configured using the option `allowTestingFrameworkSetupHook`. This may be useful if you have configured your tests to [skip auto cleanup](https://testing-library.com/docs/react-testing-library/setup#skipping-auto-cleanup). `allowTestingFrameworkSetupHook` is an enum that accepts either `"beforeAll"` or `"beforeEach"`.
+If you would like to allow the use of `render` (or custom render function) in _either_ `beforeAll` or `beforeEach`, this can be configured using the option `allowTestingFrameworkSetupHook`. This may be useful if you have configured your tests to [skip auto cleanup](https://testing-library.com/docs/react-testing-library/setup#skipping-auto-cleanup). `allowTestingFrameworkSetupHook` is an enum that accepts either `"beforeAll"` or `"beforeEach"`.
 
 ```
    "testing-library/no-render-in-setup": ["error", {"allowTestingFrameworkSetupHook": "beforeAll"}],

--- a/docs/rules/no-render-in-setup.md
+++ b/docs/rules/no-render-in-setup.md
@@ -2,7 +2,7 @@
 
 ## Rule Details
 
-This rule disallows the usage of `render` in setup functions (`beforeEach` and `beforeAll`) in favor of moving `render` closer to test assertions.
+This rule disallows the usage of `render` (or a custom render function) in setup functions (`beforeEach` and `beforeAll`) in favor of moving `render` closer to test assertions.
 
 Examples of **incorrect** code for this rule:
 
@@ -18,20 +18,29 @@ it('Should have foo', () => {
 it('Should have bar', () => {
   expect(screen.getByText('bar')).toBeInTheDocument();
 });
+```
 
-it('Should have baz', () => {
-  expect(screen.getByText('baz')).toBeInTheDocument();
+```js
+beforeAll(() => {
+  render(<MyComponent />);
+});
+
+it('Should have foo', () => {
+  expect(screen.getByText('foo')).toBeInTheDocument();
+});
+
+it('Should have bar', () => {
+  expect(screen.getByText('bar')).toBeInTheDocument();
 });
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
-it('Should have foo, bar and baz', () => {
+it('Should have foo and bar', () => {
   render(<MyComponent />);
   expect(screen.getByText('foo')).toBeInTheDocument();
   expect(screen.getByText('bar')).toBeInTheDocument();
-  expect(screen.getByText('baz')).toBeInTheDocument();
 });
 ```
 
@@ -41,7 +50,7 @@ If you use [custom render functions](https://testing-library.com/docs/example-re
    "testing-library/no-render-in-setup": ["error", {"renderFunctions": ["renderWithRedux", "renderWithRouter"]}],
 ```
 
-If you would like to allow the use of `render` (or custom render function) in _either_ `beforeAll` or `beforeEach`, this can be configured using the option `allowTestingFrameworkSetupHook`. This may be useful if you have configured your tests to [skip auto cleanup](https://testing-library.com/docs/react-testing-library/setup#skipping-auto-cleanup). `allowTestingFrameworkSetupHook` is an enum that accepts either `"beforeAll"` or `"beforeEach"`.
+If you would like to allow the use of `render` (or a custom render function) in _either_ `beforeAll` or `beforeEach`, this can be configured using the option `allowTestingFrameworkSetupHook`. This may be useful if you have configured your tests to [skip auto cleanup](https://testing-library.com/docs/react-testing-library/setup#skipping-auto-cleanup). `allowTestingFrameworkSetupHook` is an enum that accepts either `"beforeAll"` or `"beforeEach"`.
 
 ```
    "testing-library/no-render-in-setup": ["error", {"allowTestingFrameworkSetupHook": "beforeAll"}],

--- a/docs/rules/no-render-in-setup.md
+++ b/docs/rules/no-render-in-setup.md
@@ -2,7 +2,7 @@
 
 ## Rule Details
 
-This rule disallows the usage of `render` in setup functions (`beforeEach` or `beforeAll`) in favor of a single test with multiple assertions.
+This rule disallows the usage of `render` in setup functions (`beforeEach` and `beforeAll`) in favor of moving `render` closer to test assertions.
 
 Examples of **incorrect** code for this rule:
 
@@ -38,5 +38,11 @@ it('Should have foo, bar and baz', () => {
 If you use [custom render functions](https://testing-library.com/docs/example-react-redux) then you can set a config option in your `.eslintrc` to look for these.
 
 ```
-   "testing-library/no-render-in-setup": ["error", {"renderFunctions":["renderWithRedux", "renderWithRouter"]}],
+   "testing-library/no-render-in-setup": ["error", {"renderFunctions": ["renderWithRedux", "renderWithRouter"]}],
+```
+
+If you would would like to allow the use of `render` (or custom render function) in _either_ `beforeAll` or `beforeEach`, this can be configured using the option `allowTestingFrameworkSetupHook`. This may be useful if you have configured your tests to [skip auto cleanup](https://testing-library.com/docs/react-testing-library/setup#skipping-auto-cleanup). `allowTestingFrameworkSetupHook` is an enum that accepts either `"beforeAll"` or `"beforeEach"`.
+
+```
+   "testing-library/no-render-in-setup": ["error", {"allowTestingFrameworkSetupHook": "beforeAll"}],
 ```

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,6 +6,7 @@ import noAwaitSyncQuery from './rules/no-await-sync-query';
 import noDebug from './rules/no-debug';
 import noDomImport from './rules/no-dom-import';
 import noManualCleanup from './rules/no-manual-cleanup';
+import noRenderInSetup from './rules/no-render-in-setup';
 import noWaitForEmptyCallback from './rules/no-wait-for-empty-callback';
 import preferExplicitAssert from './rules/prefer-explicit-assert';
 import preferPresenceQueries from './rules/prefer-presence-queries';
@@ -22,6 +23,7 @@ const rules = {
   'no-debug': noDebug,
   'no-dom-import': noDomImport,
   'no-manual-cleanup': noManualCleanup,
+  'no-render-in-setup': noRenderInSetup,
   'no-wait-for-empty-callback': noWaitForEmptyCallback,
   'prefer-explicit-assert': preferExplicitAssert,
   'prefer-find-by': preferFindBy,

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -56,7 +56,7 @@ export function isRenderFunction(
 ) {
   // returns true for `render` and e.g. `customRenderFn`
   // as well as `someLib.render` and `someUtils.customRenderFn`
-  return ['render', ...renderFunctions].some(name => {
+  return renderFunctions.some(name => {
     return (
       (isIdentifier(callNode.callee) && name === callNode.callee.name) ||
       (isMemberExpression(callNode.callee) &&

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -50,6 +50,15 @@ export function isVariableDeclarator(
   return node && node.type === AST_NODE_TYPES.VariableDeclarator;
 }
 
+export function isRenderFunction(
+  callNode: TSESTree.CallExpression,
+  renderFunctions: string[]
+) {
+  return ['render', ...renderFunctions].some(
+    name => isIdentifier(callNode.callee) && name === callNode.callee.name
+  );
+}
+
 export function isObjectPattern(
   node: TSESTree.Node
 ): node is TSESTree.ObjectPattern {

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -54,9 +54,16 @@ export function isRenderFunction(
   callNode: TSESTree.CallExpression,
   renderFunctions: string[]
 ) {
-  return ['render', ...renderFunctions].some(
-    name => isIdentifier(callNode.callee) && name === callNode.callee.name
-  );
+  // returns true for `render` and e.g. `customRenderFn`
+  // as well as `someLib.render` and `someUtils.customRenderFn`
+  return ['render', ...renderFunctions].some(name => {
+    return (
+      (isIdentifier(callNode.callee) && name === callNode.callee.name) ||
+      (isMemberExpression(callNode.callee) &&
+        isIdentifier(callNode.callee.property) &&
+        name === callNode.callee.property.name)
+    );
+  });
 }
 
 export function isObjectPattern(

--- a/lib/rules/no-debug.ts
+++ b/lib/rules/no-debug.ts
@@ -9,18 +9,10 @@ import {
   isAwaitExpression,
   isMemberExpression,
   isImportSpecifier,
+  isRenderFunction,
 } from '../node-utils';
 
 export const RULE_NAME = 'no-debug';
-
-function isRenderFunction(
-  callNode: TSESTree.CallExpression,
-  renderFunctions: string[]
-) {
-  return ['render', ...renderFunctions].some(
-    name => isIdentifier(callNode.callee) && name === callNode.callee.name
-  );
-}
 
 function isRenderVariableDeclarator(
   node: TSESTree.VariableDeclarator,

--- a/lib/rules/no-debug.ts
+++ b/lib/rules/no-debug.ts
@@ -22,15 +22,15 @@ function isRenderVariableDeclarator(
     if (isAwaitExpression(node.init)) {
       return (
         node.init.argument &&
-        isRenderFunction(
-          node.init.argument as TSESTree.CallExpression,
-          renderFunctions
-        )
+        isRenderFunction(node.init.argument as TSESTree.CallExpression, [
+          'render',
+          ...renderFunctions,
+        ])
       );
     } else {
       return (
         isCallExpression(node.init) &&
-        isRenderFunction(node.init, renderFunctions)
+        isRenderFunction(node.init, ['render', ...renderFunctions])
       );
     }
   }

--- a/lib/rules/no-manual-cleanup.ts
+++ b/lib/rules/no-manual-cleanup.ts
@@ -21,7 +21,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
   meta: {
     type: 'problem',
     docs: {
-      description: ' Disallow the use of `cleanup`',
+      description: 'Disallow the use of `cleanup`',
       category: 'Best Practices',
       recommended: false,
     },
@@ -121,7 +121,6 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
               messageId: 'noManualCleanup',
             });
           }
-
         } else {
           defaultRequireFromTestingLibrary = declaratorNode.id;
         }

--- a/lib/rules/no-render-in-setup.ts
+++ b/lib/rules/no-render-in-setup.ts
@@ -97,15 +97,16 @@ export default ESLintUtils.RuleCreator(getDocsUrl)({
       [`VariableDeclarator > CallExpression > Identifier[name="require"]`](
         node: TSESTree.Identifier
       ) {
-        if (!isCallExpression(node.parent)) return;
-        const { arguments: callExpressionArgs } = node.parent;
-        const literalNodeScreenModuleName = callExpressionArgs.find(
+        const {
+          arguments: callExpressionArgs,
+        } = node.parent as TSESTree.CallExpression;
+        const testingLibImport = callExpressionArgs.find(
           args =>
             isLiteral(args) &&
             typeof args.value === 'string' &&
             RegExp(/testing-library/, 'g').test(args.value)
         );
-        if (!literalNodeScreenModuleName) {
+        if (!testingLibImport) {
           return;
         }
         const declaratorNode = node.parent

--- a/lib/rules/no-render-in-setup.ts
+++ b/lib/rules/no-render-in-setup.ts
@@ -1,0 +1,74 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { getDocsUrl, BEFORE_HOOKS } from '../utils';
+import {
+  isIdentifier,
+  isCallExpression,
+  isRenderFunction,
+} from '../node-utils';
+
+export const RULE_NAME = 'no-render-in-setup';
+export type MessageIds = 'noRenderInSetup';
+
+export function findClosestBeforeHook(
+  node: TSESTree.Node
+): TSESTree.Identifier | null {
+  if (node === null) return null;
+  if (
+    isCallExpression(node) &&
+    isIdentifier(node.callee) &&
+    BEFORE_HOOKS.includes(node.callee.name)
+  ) {
+    return node.callee;
+  }
+
+  return findClosestBeforeHook(node.parent);
+}
+
+export default ESLintUtils.RuleCreator(getDocsUrl)({
+  name: RULE_NAME,
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow the use of `render` in setup functions',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    messages: {
+      noRenderInSetup:
+        'Combine assertions into a single test instead of re-rendering the component.',
+    },
+    fixable: null,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          renderFunctions: {
+            type: 'array',
+          },
+        },
+      },
+    ],
+  },
+  defaultOptions: [
+    {
+      renderFunctions: [],
+    },
+  ],
+
+  create(context, [{ renderFunctions }]) {
+    return {
+      CallExpression(node) {
+        const beforeHook = findClosestBeforeHook(node);
+        if (isRenderFunction(node, renderFunctions) && beforeHook) {
+          context.report({
+            node,
+            messageId: 'noRenderInSetup',
+            data: {
+              name: beforeHook.name,
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -63,6 +63,8 @@ const ASYNC_UTILS = [
   'waitForDomChange',
 ];
 
+const BEFORE_HOOKS = ['beforeEach', 'beforeAll'];
+
 export {
   getDocsUrl,
   SYNC_QUERIES_VARIANTS,
@@ -73,5 +75,6 @@ export {
   ASYNC_QUERIES_COMBINATIONS,
   ALL_QUERIES_COMBINATIONS,
   ASYNC_UTILS,
+  BEFORE_HOOKS,
   LIBRARY_MODULES,
 };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -63,7 +63,7 @@ const ASYNC_UTILS = [
   'waitForDomChange',
 ];
 
-const BEFORE_HOOKS = ['beforeEach', 'beforeAll'];
+const TESTING_FRAMEWORK_SETUP_HOOKS = ['beforeEach', 'beforeAll'];
 
 export {
   getDocsUrl,
@@ -75,6 +75,6 @@ export {
   ASYNC_QUERIES_COMBINATIONS,
   ALL_QUERIES_COMBINATIONS,
   ASYNC_UTILS,
-  BEFORE_HOOKS,
+  TESTING_FRAMEWORK_SETUP_HOOKS,
   LIBRARY_MODULES,
 };

--- a/tests/lib/rules/no-render-in-setup.test.ts
+++ b/tests/lib/rules/no-render-in-setup.test.ts
@@ -65,6 +65,20 @@ ruleTester.run(RULE_NAME, rule, {
         ],
       };
     }),
+    ...TESTING_FRAMEWORK_SETUP_HOOKS.map(setupHook => ({
+      code: `
+        const { render } = require('imNoTestingLibrary')
+
+        ${setupHook}(() => {
+          render(<Component/>)
+        })
+      `,
+      errors: [
+        {
+          messageId: 'noRenderInSetup',
+        },
+      ],
+    })),
   ],
 
   invalid: [

--- a/tests/lib/rules/no-render-in-setup.test.ts
+++ b/tests/lib/rules/no-render-in-setup.test.ts
@@ -17,13 +17,11 @@ ruleTester.run(RULE_NAME, rule, {
         })
       `,
     },
+    // test config options
     ...TESTING_FRAMEWORK_SETUP_HOOKS.map(setupHook => ({
       code: `
         ${setupHook}(() => {
-          const wrapper = () => {
-            renderWithRedux(<Component/>)
-          }
-          wrapper();
+          renderWithRedux(<Component/>)
         })
       `,
       options: [
@@ -33,6 +31,14 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     })),
+    // // test usage of a non-Testing Library render fn
+    // ...TESTING_FRAMEWORK_SETUP_HOOKS.map(setupHook => ({
+    //   code: `import { render } from 'imNoTestingLibrary';
+
+    //   ${setupHook}(() => {
+    //     render(<Component/>)
+    //   })`,
+    // })),
   ],
 
   invalid: [
@@ -85,7 +91,7 @@ ruleTester.run(RULE_NAME, rule, {
           const wrapper = () => {
             render(<Component/>)
           }
-          wrapper();
+          wrapper()
         })
       `,
       errors: [
@@ -101,10 +107,7 @@ ruleTester.run(RULE_NAME, rule, {
       return {
         code: `
         ${disallowedHook}(() => {
-          const wrapper = () => {
-            render(<Component/>)
-          }
-          wrapper();
+          render(<Component/>)
         })
       `,
         options: [
@@ -119,5 +122,52 @@ ruleTester.run(RULE_NAME, rule, {
         ],
       };
     }),
+    ...TESTING_FRAMEWORK_SETUP_HOOKS.map(setupHook => ({
+      code: `import { render } from '@testing-library/foo';
+
+      ${setupHook}(() => {
+        render(<Component/>)
+      })`,
+      errors: [
+        {
+          messageId: 'noRenderInSetup',
+        },
+      ],
+    })),
+    ...TESTING_FRAMEWORK_SETUP_HOOKS.map(setupHook => ({
+      code: `import * as testingLibrary from '@testing-library/foo';
+
+      ${setupHook}(() => {
+        testingLibrary.render(<Component/>)
+      })`,
+      errors: [
+        {
+          messageId: 'noRenderInSetup',
+        },
+      ],
+    })),
+    ...TESTING_FRAMEWORK_SETUP_HOOKS.map(setupHook => ({
+      code: `import { render } from 'imNoTestingLibrary';
+      import * as testUtils from '../utils';
+
+      ${setupHook}(() => {
+        testUtils.renderWithRedux(<Component/>)
+      })
+
+      it('Test', () => {
+        render(<Component/>)
+      })
+      `,
+      options: [
+        {
+          renderFunctions: ['renderWithRedux'],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'noRenderInSetup',
+        },
+      ],
+    })),
   ],
 });

--- a/tests/lib/rules/no-render-in-setup.test.ts
+++ b/tests/lib/rules/no-render-in-setup.test.ts
@@ -1,0 +1,82 @@
+import { createRuleTester } from '../test-utils';
+import { BEFORE_HOOKS } from '../../../lib/utils';
+import rule, { RULE_NAME } from '../../../lib/rules/no-render-in-setup';
+
+const ruleTester = createRuleTester({
+  ecmaFeatures: {
+    jsx: true,
+  },
+});
+
+ruleTester.run(RULE_NAME, rule, {
+  valid: [
+    {
+      code: `
+        it('Test', () => {
+          render(<Component/>)
+        })
+      `,
+    },
+  ],
+
+  invalid: [
+    ...BEFORE_HOOKS.map(beforeHook => ({
+      code: `
+        ${beforeHook}(() => {
+          render(<Component/>)
+        })
+      `,
+      errors: [
+        {
+          messageId: 'noRenderInSetup',
+        },
+      ],
+    })),
+    ...BEFORE_HOOKS.map(beforeHook => ({
+      code: `
+        ${beforeHook}(function() {
+          render(<Component/>)
+        })
+      `,
+      errors: [
+        {
+          messageId: 'noRenderInSetup',
+        },
+      ],
+    })),
+    // custom render function
+    ...BEFORE_HOOKS.map(beforeHook => ({
+      code: `
+        ${beforeHook}(() => {
+          renderWithRedux(<Component/>)
+        })
+      `,
+      options: [
+        {
+          renderFunctions: ['renderWithRedux'],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'noRenderInSetup',
+        },
+      ],
+    })),
+    // call render within a wrapper function
+    ...BEFORE_HOOKS.map(beforeHook => ({
+      code: `
+        ${beforeHook}(() => {
+          const wrapper = () => {
+            render(<Component/>)
+          }
+          wrapper();
+        })
+      `,
+      errors: [
+        {
+          messageId: 'noRenderInSetup',
+        },
+      ],
+    })),
+  ],
+});


### PR DESCRIPTION
Added a `no-render-in-setup` rule with tests to address https://github.com/testing-library/eslint-plugin-testing-library/issues/207.

The rule looks for uses of `render` (or a custom render function who name can be passed in via config options) inside of two "before hooks": `beforeEach` and `beforeAll`.