### PR TITLE
feat: add support for multiple test id attributes

### DIFF
--- a/docs/rules/consistent-data-testid.md
+++ b/docs/rules/consistent-data-testid.md
@@ -24,10 +24,10 @@ const baz = props => <div>...</div>;
 
 ## Options
 
-| Option            | Required | Default       | Details                                                                                                                                                                                                                                                       | Example                                |
-| ----------------- | -------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
-| `testIdPattern`   | Yes      | None          | A regex used to validate the format of the `data-testid` value. `{fileName}` can optionally be used as a placeholder and will be substituted with the name of the file OR the name of the files parent directory in the case when the file name is `index.js` | `^{fileName}(\_\_([A-Z]+[a-z]_?)+)_\$` |
-| `testIdAttribute` | No       | `data-testid` | A string used to specify the attribute used for querying by ID. This is only required if data-testid has been explicitly overridden in the [RTL configuration](https://testing-library.com/docs/dom-testing-library/api-queries#overriding-data-testid)       | `data-my-test-attribute`               |
+| Option            | Required | Default       | Details                                                                                                                                                                                                                                                                       | Example                                               |
+| ----------------- | -------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `testIdPattern`   | Yes      | None          | A regex used to validate the format of the `data-testid` value. `{fileName}` can optionally be used as a placeholder and will be substituted with the name of the file OR the name of the files parent directory in the case when the file name is `index.js`                 | `^{fileName}(\_\_([A-Z]+[a-z]_?)+)_\$`                |
+| `testIdAttribute` | No       | `data-testid` | A string (or array of strings) used to specify the attribute used for querying by ID. This is only required if data-testid has been explicitly overridden in the [RTL configuration](https://testing-library.com/docs/dom-testing-library/api-queries#overriding-data-testid) | `data-my-test-attribute`, `["data-testid", "testId"]` |
 
 ## Example
 
@@ -37,6 +37,17 @@ const baz = props => <div>...</div>;
     2,
     {
       "testIdPattern": "^TestId(__[A-Z]*)?$"
+    }
+  ]
+}
+```
+
+```json
+{
+  "testing-library/consistent-data-testid": [
+    2,
+    {
+      "testIdAttribute": ["data-testid", "testId"]
     }
   ]
 }

--- a/tests/lib/rules/consistent-data-testid.test.ts
+++ b/tests/lib/rules/consistent-data-testid.test.ts
@@ -138,6 +138,25 @@ ruleTester.run(RULE_NAME, rule, {
             
             const TestComponent = props => {
               return (
+                <div another-custom-attr="right-1" custom-attr="right-2">
+                  Hello
+                </div>
+              )
+            };
+          `,
+      options: [
+        {
+          testIdPattern: '^right(.*)$',
+          testIdAttribute: ['custom-attr', 'another-custom-attr'],
+        },
+      ],
+    },
+    {
+      code: `
+            import React from 'react';
+            
+            const TestComponent = props => {
+              return (
                 <div data-test-id="Parent">
                   Hello
                 </div>
@@ -248,6 +267,44 @@ ruleTester.run(RULE_NAME, rule, {
             attr: 'my-custom-attr',
             value: 'WrongComponent__cool',
             regex: '/^Parent(__([A-Z]+[a-z]*?)+)*$/',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+            import React from 'react';
+            
+            const TestComponent = props => {
+              return (
+                <div custom-attr="wrong" another-custom-attr="wrong">
+                  Hello
+                </div>
+              )
+            };
+          `,
+      options: [
+        {
+          testIdPattern: '^right$',
+          testIdAttribute: ['custom-attr', 'another-custom-attr'],
+        },
+      ],
+      filename: '/my/cool/__tests__/Parent/index.js',
+      errors: [
+        {
+          messageId: 'invalidTestId',
+          data: {
+            attr: 'custom-attr',
+            value: 'wrong',
+            regex: '/^right$/',
+          },
+        },
+        {
+          messageId: 'invalidTestId',
+          data: {
+            attr: 'another-custom-attr',
+            value: 'wrong',
+            regex: '/^right$/',
           },
         },
       ],


### PR DESCRIPTION
This PR proposes adding support for multiple test id attributes (via `testIdAttribute`) to the `consistent-data-testid` rule. 

### Movitation

When making shared components, some prefer to expose a `testId` prop ([example in Atlastkit](https://atlaskit.atlassian.com/packages/design-system/button)) in addition to using the `data-testid` prop. Ideally, this linting rule could handle more than one test id attribute to handle cases like this.

### Changes

The configuration was updated to allow either a `string` (existing API) or now an array of strings.  This was done so the rule continues to work with existing configurations. I also considered adding regex support which could also achieve this and happy to update with that approach if preferred.