### PR TITLE
feat: add 'assertion' config option to prefer-explicit-assert

### DIFF
--- a/docs/rules/prefer-explicit-assert.md
+++ b/docs/rules/prefer-explicit-assert.md
@@ -50,7 +50,17 @@ getByNonTestingLibraryVariant('foo');
 
 ## Options
 
-This rule accepts a single options argument:
+This rule has a few options:
+
+- `assertion`: this string allows defining the preferred assertion to use
+  with `getBy*` queries. By default, any assertion is valid (`toBeTruthy`,
+  `toBeDefined`, etc.). However, they all assert slightly different things.
+  This option ensures all `getBy*` assertions are consistent and use the same
+  assertion.
+
+  ```js
+  "testing-library/prefer-explicit-assert": ["error", {"assertion": "toBeInTheDocument"}],
+  ```
 
 - `customQueryNames`: this array option allows to extend default Testing
   Library queries with custom ones for including them into rule

--- a/tests/lib/rules/prefer-explicit-assert.test.ts
+++ b/tests/lib/rules/prefer-explicit-assert.test.ts
@@ -66,6 +66,14 @@ ruleTester.run(RULE_NAME, rule, {
     {
       code: `queryByText("foo")`,
     },
+    {
+      code: `expect(getByText('foo')).toBeTruthy()`,
+      options: [
+        {
+          assertion: 'toBeTruthy',
+        },
+      ],
+    },
   ],
 
   invalid: [
@@ -129,6 +137,21 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [
         {
           messageId: 'preferExplicitAssert',
+        },
+      ],
+    },
+    {
+      code: `expect(getByText('foo')).toBeDefined()`,
+      options: [
+        {
+          assertion: 'toBeInDocument',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'preferExplicitAssertAssertion',
+          column: 26,
+          data: { assertion: 'toBeInDocument' },
         },
       ],
     },


### PR DESCRIPTION
Resolves https://github.com/testing-library/eslint-plugin-testing-library/issues/218.

This Pull Request adds support for the `assertion` rule configuration option to the `prefer-explicit-assert` rule. See the linked issue for more details on the rationale. The general idea is to allow enforcing a consistent assertion (eg: `toBeInDocument`) when requiring `getBy*` queries to be wrapped in an expectation.

