### PR TITLE
fix: consider promise.all() in await-async-utils

### DIFF
--- a/docs/rules/await-async-utils.md
+++ b/docs/rules/await-async-utils.md
@@ -59,6 +59,12 @@ test('something correctly', async () => {
   // return the promise within a function is correct too!
   const makeCustomWait = () =>
     waitForElementToBeRemoved(() => document.querySelector('div.getOuttaHere'));
+
+  // using Promise.all combining the methods
+  await Promise.all([
+    waitFor(() => getByLabelText('email')),
+    waitForElementToBeRemoved(() => document.querySelector('div.getOuttaHere')),
+  ]);
 });
 ```
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,5 +10,12 @@ module.exports = {
       lines: 100,
       statements: 100,
     },
+    // TODO drop this custom threshold in v4
+    "./lib/node-utils.ts": {
+      branches: 90,
+      functions: 90,
+      lines: 90,
+      statements: 90,
+    }
   },
 };

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -30,6 +30,12 @@ export function isImportSpecifier(
   return node && node.type === AST_NODE_TYPES.ImportSpecifier;
 }
 
+export function isImportNamespaceSpecifier(
+  node: TSESTree.Node
+): node is TSESTree.ImportNamespaceSpecifier {
+  return node?.type === AST_NODE_TYPES.ImportNamespaceSpecifier
+}
+
 export function isImportDefaultSpecifier(
   node: TSESTree.Node
 ): node is TSESTree.ImportDefaultSpecifier {
@@ -141,6 +147,12 @@ export function isReturnStatement(
   node: TSESTree.Node
 ): node is TSESTree.ReturnStatement {
   return node && node.type === AST_NODE_TYPES.ReturnStatement;
+}
+
+export function isArrayExpression(
+  node: TSESTree.Node
+): node is TSESTree.ArrayExpression {
+  return node?.type === AST_NODE_TYPES.ArrayExpression
 }
 
 export function isAwaited(node: TSESTree.Node) {

--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -120,7 +120,50 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
     })),
-
+    ...ASYNC_UTILS.map(asyncUtil => ({
+      code: `
+        import { ${asyncUtil} } from '@testing-library/dom';
+        test('${asyncUtil} util used in with Promise.all() does not trigger an error', async () => {
+          await Promise.all([
+            ${asyncUtil}(callback1),
+            ${asyncUtil}(callback2),
+          ]);
+        });
+      `,
+    })),
+    ...ASYNC_UTILS.map(asyncUtil => ({
+      code: `
+        import { ${asyncUtil} } from '@testing-library/dom';
+        test('${asyncUtil} util used in with Promise.all() with an await does not trigger an error', async () => {
+          await Promise.all([
+            await ${asyncUtil}(callback1),
+            await ${asyncUtil}(callback2),
+          ]);
+        });
+      `,
+    })),
+    ...ASYNC_UTILS.map(asyncUtil => ({
+      code: `
+        import { ${asyncUtil} } from '@testing-library/dom';
+        test('${asyncUtil} util used in with Promise.all() with ".then" does not trigger an error', async () => {
+          Promise.all([
+            ${asyncUtil}(callback1),
+            ${asyncUtil}(callback2),
+          ]).then(() => console.log('foo'));
+        });
+      `,
+    })),
+    {
+      code: `
+        import { waitFor, waitForElementToBeRemoved } from '@testing-library/dom';
+        test('combining different async methods with Promise.all does not throw an error', async () => {
+          await Promise.all([
+            waitFor(() => getByLabelText('email')),
+            waitForElementToBeRemoved(() => document.querySelector('div.getOuttaHere')),
+          ])
+        });
+      `
+    },
     {
       code: `
         import { waitForElementToBeRemoved } from '@testing-library/dom';
@@ -139,6 +182,17 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
     },
+    {
+      code: `
+      test('using unrelated promises with Promise.all do not throw an error', async () => {
+        await Promise.all([
+          someMethod(),
+          promise1,
+          await foo().then(() => baz())
+        ])
+      })
+      `
+    }
   ],
   invalid: [
     ...ASYNC_UTILS.map(asyncUtil => ({


### PR DESCRIPTION
closes #227 

After a while, trying to program a Lil' bit outside of my regular work again. Here I'm just fixing the referenced ticket. I also added a bunch of helpers to `node-utils` instead of checking the node's type directly in the rule