### PR TITLE
fix(prefer-explicit-assert): only enforce assertion when presence/absence matcher

### DIFF
--- a/docs/rules/prefer-explicit-assert.md
+++ b/docs/rules/prefer-explicit-assert.md
@@ -56,7 +56,11 @@ This rule has a few options:
   with `getBy*` queries. By default, any assertion is valid (`toBeTruthy`,
   `toBeDefined`, etc.). However, they all assert slightly different things.
   This option ensures all `getBy*` assertions are consistent and use the same
-  assertion.
+  assertion. This rule only allows defining a presence matcher
+  (`toBeInTheDocument`, `toBeTruthy`, or `toBeDefined`), but checks for both
+  presence and absence matchers (`not.toBeFalsy` and `not.toBeNull`). This means
+  other assertions such as `toHaveValue` or `toBeDisabled` will not trigger this
+  rule since these are valid uses with `getBy*`.
 
   ```js
   "testing-library/prefer-explicit-assert": ["error", {"assertion": "toBeInTheDocument"}],

--- a/lib/rules/prefer-presence-queries.ts
+++ b/lib/rules/prefer-presence-queries.ts
@@ -1,5 +1,5 @@
 import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
-import { getDocsUrl, ALL_QUERIES_METHODS } from '../utils';
+import { getDocsUrl, ALL_QUERIES_METHODS, PRESENCE_MATCHERS, ABSENCE_MATCHERS } from '../utils';
 import {
   findClosestCallNode,
   isMemberExpression,
@@ -13,8 +13,6 @@ type Options = [];
 const QUERIES_REGEXP = new RegExp(
   `^(get|query)(All)?(${ALL_QUERIES_METHODS.join('|')})$`
 );
-const PRESENCE_MATCHERS = ['toBeInTheDocument', 'toBeTruthy', 'toBeDefined'];
-const ABSENCE_MATCHERS = ['toBeNull', 'toBeFalsy'];
 
 function isThrowingQuery(node: TSESTree.Identifier) {
   return node.name.startsWith('get');

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -65,6 +65,9 @@ const ASYNC_UTILS = [
 
 const TESTING_FRAMEWORK_SETUP_HOOKS = ['beforeEach', 'beforeAll'];
 
+const PRESENCE_MATCHERS = ['toBeInTheDocument', 'toBeTruthy', 'toBeDefined'];
+const ABSENCE_MATCHERS = ['toBeNull', 'toBeFalsy'];
+
 export {
   getDocsUrl,
   SYNC_QUERIES_VARIANTS,
@@ -77,4 +80,6 @@ export {
   ASYNC_UTILS,
   TESTING_FRAMEWORK_SETUP_HOOKS,
   LIBRARY_MODULES,
+  PRESENCE_MATCHERS,
+  ABSENCE_MATCHERS
 };

--- a/tests/lib/rules/prefer-explicit-assert.test.ts
+++ b/tests/lib/rules/prefer-explicit-assert.test.ts
@@ -74,6 +74,14 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     },
+    {
+      code: `expect(getByText('foo')).toBeEnabled()`,
+      options: [
+        {
+          assertion: 'toBeInTheDocument',
+        },
+      ],
+    },
   ],
 
   invalid: [
@@ -144,14 +152,44 @@ ruleTester.run(RULE_NAME, rule, {
       code: `expect(getByText('foo')).toBeDefined()`,
       options: [
         {
-          assertion: 'toBeInDocument',
+          assertion: 'toBeInTheDocument',
         },
       ],
       errors: [
         {
           messageId: 'preferExplicitAssertAssertion',
           column: 26,
-          data: { assertion: 'toBeInDocument' },
+          data: { assertion: 'toBeInTheDocument' },
+        },
+      ],
+    },
+    {
+      code: `expect(getByText('foo')).not.toBeNull()`,
+      options: [
+        {
+          assertion: 'toBeInTheDocument',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'preferExplicitAssertAssertion',
+          column: 26,
+          data: { assertion: 'toBeInTheDocument' },
+        },
+      ],
+    },
+    {
+      code: `expect(getByText('foo')).not.toBeFalsy()`,
+      options: [
+        {
+          assertion: 'toBeInTheDocument',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'preferExplicitAssertAssertion',
+          column: 26,
+          data: { assertion: 'toBeInTheDocument' },
         },
       ],
     },


### PR DESCRIPTION
### Problem

This is a follow-up improvement to issue https://github.com/testing-library/eslint-plugin-testing-library/issues/218.

The original implementation was flawed.  With the way this was implemented, any `getBy*` query will trigger a linting error if it's not using `toBeInTheDocument` (assuming the config defined the `assertion` to use as `toBeInTheDocument`). However, there are still valid cases to use a different assertion. For example, if you want to check if a button is disabled (`toBeDisabled`) or maybe check if an anchor has the appropriate `href` attribute (`toHaveAttribute`).

With the way the rule was implemented, both of these examples would trigger as violations (since they're not using `toBeInTheDocument`) but they're both still valid uses of `getBy*` and thus are false positives.
### Solution

Now, this rule only triggers if the matchers used are `toBeInTheDocument`, `toBeTruthy`, `toBeDefined`, `not.toBeNull`, or `not.toBeFalsy` _and_ doesn't match the configured `assertion`. These matches already existed as a constant for another rule (`prefer-presence-queries`), so I moved them to `utils` so they could be reused. This rule also had somewhat related logic for handling negated matchers. This logic was adapted for this rule.