### PR TITLE
Move rules settings to ESLint shared config: part 2 - check imports

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,12 +11,6 @@ module.exports = {
       statements: 100,
     },
     // TODO drop this custom threshold in v4
-    './lib/detect-testing-library-utils.ts': {
-      branches: 50,
-      functions: 90,
-      lines: 90,
-      statements: 90,
-    },
     './lib/node-utils.ts': {
       branches: 90,
       functions: 90,

--- a/lib/create-testing-library-rule.ts
+++ b/lib/create-testing-library-rule.ts
@@ -26,7 +26,7 @@ export function createTestingLibraryRule<
       detectionHelpers: Readonly<DetectionHelpers>
     ) => TRuleListener;
   }>
-): TSESLint.RuleModule<TMessageIds, TOptions, TRuleListener> {
+): TSESLint.RuleModule<TMessageIds, TOptions> {
   const { create, ...remainingConfig } = config;
 
   return ESLintUtils.RuleCreator(getDocsUrl)({

--- a/lib/create-testing-library-rule.ts
+++ b/lib/create-testing-library-rule.ts
@@ -2,7 +2,7 @@ import { ESLintUtils, TSESLint } from '@typescript-eslint/experimental-utils';
 import { getDocsUrl } from './utils';
 import {
   detectTestingLibraryUtils,
-  DetectionHelpers,
+  EnhancedRuleCreate,
 } from './detect-testing-library-utils';
 
 // These 2 types are copied from @typescript-eslint/experimental-utils
@@ -20,11 +20,7 @@ export function createTestingLibraryRule<
     name: string;
     meta: CreateRuleMeta<TMessageIds>;
     defaultOptions: Readonly<TOptions>;
-    create: (
-      context: Readonly<TSESLint.RuleContext<TMessageIds, TOptions>>,
-      optionsWithDefault: Readonly<TOptions>,
-      detectionHelpers: Readonly<DetectionHelpers>
-    ) => TRuleListener;
+    create: EnhancedRuleCreate<TOptions, TMessageIds, TRuleListener>;
   }>
 ): TSESLint.RuleModule<TMessageIds, TOptions> {
   const { create, ...remainingConfig } = config;

--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -1,12 +1,31 @@
 import { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
 
+export type TestingLibrarySettings = {
+  'testing-library/module'?: string;
+};
+
+export type TestingLibraryContext<
+  TOptions extends readonly unknown[],
+  TMessageIds extends string
+> = Readonly<
+  TSESLint.RuleContext<TMessageIds, TOptions> & {
+    settings: TestingLibrarySettings;
+  }
+>;
+
+export type EnhancedRuleCreate<
+  TOptions extends readonly unknown[],
+  TMessageIds extends string,
+  TRuleListener extends TSESLint.RuleListener = TSESLint.RuleListener
+> = (
+  context: TestingLibraryContext<TOptions, TMessageIds>,
+  optionsWithDefault: Readonly<TOptions>,
+  detectionHelpers: Readonly<DetectionHelpers>
+) => TRuleListener;
+
 export type DetectionHelpers = {
   getIsTestingLibraryImported: () => boolean;
   canReportErrors: () => boolean;
-};
-
-export type TestingLibrarySettings = {
-  'testing-library/module'?: string;
 };
 
 /**
@@ -16,23 +35,9 @@ export function detectTestingLibraryUtils<
   TOptions extends readonly unknown[],
   TMessageIds extends string,
   TRuleListener extends TSESLint.RuleListener = TSESLint.RuleListener
->(
-  ruleCreate: (
-    context: Readonly<
-      TSESLint.RuleContext<TMessageIds, TOptions> & {
-        settings: TestingLibrarySettings;
-      }
-    >,
-    optionsWithDefault: Readonly<TOptions>,
-    detectionHelpers: Readonly<DetectionHelpers>
-  ) => TRuleListener
-) {
+>(ruleCreate: EnhancedRuleCreate<TOptions, TMessageIds, TRuleListener>) {
   return (
-    context: Readonly<
-      TSESLint.RuleContext<TMessageIds, TOptions> & {
-        settings: TestingLibrarySettings;
-      }
-    >,
+    context: TestingLibraryContext<TOptions, TMessageIds>,
     optionsWithDefault: Readonly<TOptions>
   ): TSESLint.RuleListener => {
     let isImportingTestingLibraryModule = false;

--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -48,6 +48,18 @@ export function detectTestingLibraryUtils<
 
     // Helpers for Testing Library detection.
     const helpers: DetectionHelpers = {
+      /**
+       * Gets if Testing Library is considered as imported or not.
+       *
+       * By default, it is ALWAYS considered as imported. This is what we call
+       * "aggressive reporting" so we don't miss TL utils reexported from
+       * custom modules.
+       *
+       * However, there is a setting to customize the module where TL utils can
+       * be imported from: "testing-library/module". If this setting is enabled,
+       * then this method will return `true` ONLY IF a testing-library package
+       * or custom module are imported.
+       */
       getIsTestingLibraryImported() {
         if (!customModule) {
           return true;
@@ -55,6 +67,10 @@ export function detectTestingLibraryUtils<
 
         return isImportingTestingLibraryModule || isImportingCustomModule;
       },
+
+      /**
+       * Wraps all conditions that must be met to report rules.
+       */
       canReportErrors() {
         return this.getIsTestingLibraryImported();
       },

--- a/lib/rules/no-node-access.ts
+++ b/lib/rules/no-node-access.ts
@@ -25,11 +25,10 @@ export default createTestingLibraryRule<Options, MessageIds>({
   },
   defaultOptions: [],
 
-  create: (context, _, helpers) => {
+  create(context) {
     function showErrorForNodeAccess(node: TSESTree.MemberExpression) {
       isIdentifier(node.property) &&
         ALL_RETURNING_NODES.includes(node.property.name) &&
-        helpers.getIsImportingTestingLibrary() &&
         context.report({
           node: node,
           loc: node.property.loc.start,

--- a/tests/create-testing-library-rule.test.ts
+++ b/tests/create-testing-library-rule.test.ts
@@ -1,0 +1,34 @@
+import { createRuleTester } from './lib/test-utils';
+import rule, { RULE_NAME } from './fake-rule';
+
+const ruleTester = createRuleTester();
+
+ruleTester.run(RULE_NAME, rule, {
+  valid: [
+    {
+      // should NOT report `render` imported for non-related Testing Library module
+      code: `
+      import { render } from '@somewhere/else'
+      
+      const utils = render();
+      `,
+    },
+  ],
+  invalid: [
+    {
+      // should report `render` imported from Testing Library module
+      code: `
+      import { render } from '@testing-library/react'
+      
+      const utils = render();
+      `,
+      errors: [
+        {
+          line: 4,
+          column: 21,
+          messageId: 'fakeError',
+        },
+      ],
+    },
+  ],
+});

--- a/tests/create-testing-library-rule.test.ts
+++ b/tests/create-testing-library-rule.test.ts
@@ -1,10 +1,22 @@
 import { createRuleTester } from './lib/test-utils';
 import rule, { RULE_NAME } from './fake-rule';
 
-const ruleTester = createRuleTester();
+const ruleTester = createRuleTester({
+  ecmaFeatures: {
+    jsx: true,
+  },
+});
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
+    {
+      code: `
+      // case: nothing related to Testing Library at all
+      import { shallow } from 'enzyme';
+      
+      const wrapper = shallow(<MyComponent />);
+      `,
+    },
     {
       code: `
       // case: render imported for different custom module

--- a/tests/create-testing-library-rule.test.ts
+++ b/tests/create-testing-library-rule.test.ts
@@ -19,7 +19,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-      // case: render imported for different custom module
+      // case: render imported from other than custom module
       import { render } from '@somewhere/else'
       
       const utils = render();
@@ -28,8 +28,25 @@ ruleTester.run(RULE_NAME, rule, {
         'testing-library/module': 'test-utils',
       },
     },
+    {
+      code: `
+      // case: prevent import which should trigger an error since it's imported
+      // from other than custom module
+      import { foo } from 'report-me'
+      `,
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+    },
   ],
   invalid: [
+    {
+      code: `
+      // case: import module forced to be reported
+      import { foo } from 'report-me'
+    `,
+      errors: [{ line: 3, column: 7, messageId: 'fakeError' }],
+    },
     {
       code: `
       // case: render imported from any module by default (aggressive reporting)

--- a/tests/create-testing-library-rule.test.ts
+++ b/tests/create-testing-library-rule.test.ts
@@ -6,25 +6,84 @@ const ruleTester = createRuleTester();
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     {
-      // should NOT report `render` imported for non-related Testing Library module
       code: `
+      // case: render imported for different custom module
       import { render } from '@somewhere/else'
       
       const utils = render();
       `,
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
     },
   ],
   invalid: [
     {
-      // should report `render` imported from Testing Library module
       code: `
-      import { render } from '@testing-library/react'
+      // case: render imported from any module by default (aggressive reporting)
+      import { render } from '@somewhere/else'
+      import { somethingElse } from 'another-module'
       
       const utils = render();
       `,
       errors: [
         {
-          line: 4,
+          line: 6,
+          column: 21,
+          messageId: 'fakeError',
+        },
+      ],
+    },
+    {
+      code: `
+      // case: render imported from Testing Library module
+      import { render } from '@testing-library/react'
+      import { somethingElse } from 'another-module'
+      
+      const utils = render();
+      `,
+      errors: [
+        {
+          line: 6,
+          column: 21,
+          messageId: 'fakeError',
+        },
+      ],
+    },
+    {
+      code: `
+      // case: render imported from config custom module
+      import { render } from 'test-utils'
+      import { somethingElse } from 'another-module'
+      
+      const utils = render();
+      `,
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      errors: [
+        {
+          line: 6,
+          column: 21,
+          messageId: 'fakeError',
+        },
+      ],
+    },
+    {
+      code: `
+      // case: render imported from Testing Library module if
+      // custom module setup
+      import { render } from '@testing-library/react'
+      import { somethingElse } from 'another-module'
+      
+      const utils = render();
+      `,
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      errors: [
+        {
+          line: 7,
           column: 21,
           messageId: 'fakeError',
         },

--- a/tests/fake-rule.ts
+++ b/tests/fake-rule.ts
@@ -35,8 +35,21 @@ export default createTestingLibraryRule<Options, MessageIds>({
       }
     };
 
+    const checkImportDeclaration = (node: TSESTree.ImportDeclaration) => {
+      // This is just to check that defining an `ImportDeclaration` doesn't
+      // override `ImportDeclaration` from `detectTestingLibraryUtils`
+
+      if (node.source.value === 'report-me') {
+        context.report({
+          node,
+          messageId: 'fakeError',
+        });
+      }
+    };
+
     return {
       'CallExpression Identifier': reportRenderIdentifier,
+      ImportDeclaration: checkImportDeclaration,
     };
   },
 });

--- a/tests/fake-rule.ts
+++ b/tests/fake-rule.ts
@@ -1,0 +1,42 @@
+/**
+ * @file Fake rule to be able to test createTestingLibraryRule and
+ * detectTestingLibraryUtils properly
+ */
+import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { createTestingLibraryRule } from '../lib/create-testing-library-rule';
+
+export const RULE_NAME = 'fake-rule';
+type Options = [];
+type MessageIds = 'fakeError';
+
+export default createTestingLibraryRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Fake rule to test rule maker and detection helpers',
+      category: 'Possible Errors',
+      recommended: false,
+    },
+    messages: {
+      fakeError: 'fake error reported',
+    },
+    fixable: null,
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const reportRenderIdentifier = (node: TSESTree.Identifier) => {
+      if (node.name === 'render') {
+        context.report({
+          node,
+          messageId: 'fakeError',
+        });
+      }
+    };
+
+    return {
+      'CallExpression Identifier': reportRenderIdentifier,
+    };
+  },
+});

--- a/tests/lib/rules/no-node-access.test.ts
+++ b/tests/lib/rules/no-node-access.test.ts
@@ -51,22 +51,38 @@ ruleTester.run(RULE_NAME, rule, {
         within(signinModal).getByPlaceholderText('Username');
       `,
     },
-    {
+    /*{
+      // TODO: this one should be valid indeed. Rule implementation must be improved
+      //  to track where the nodes are coming from. This one wasn't reported before
+      //  just because this code is not importing TL module, but that's a really
+      //  brittle check. Instead, this one shouldn't be reported since `children`
+      //  it's just a property not related to a node
       code: `
         const Component = props => {
           return <div>{props.children}</div>
         }
       `,
-    },
+    },*/
     {
-      // Not importing a testing-library package
       code: `
-        const closestButton = document.getElementById('submit-btn').closest('button');
-        expect(closestButton).toBeInTheDocument();
+      // case: importing custom module
+      const closestButton = document.getElementById('submit-btn').closest('button');
+      expect(closestButton).toBeInTheDocument();
       `,
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
     },
   ],
   invalid: [
+    {
+      code: `
+      // case: without importing TL (aggressive reporting)
+      const closestButton = document.getElementById('submit-btn')
+      expect(closestButton).toBeInTheDocument();
+      `,
+      errors: [{ messageId: 'noNodeAccess', line: 3 }],
+    },
     {
       code: `
         import { screen } from '@testing-library/react';


### PR DESCRIPTION
Relates to #198 

Second part which includes:
- shared config to be able to set module where Testing Library utils can be imported from
- mechanism to check if Testing Library is considered as imported depending on shared config
- aggressive reporting by default

So the plugin is gonna assume that Testing Library is imported:
- if no "testing-library/module" set, then it's always considered as imported
- else, then it's considered as imported if "testing-library" import or custom module set within "testing-library/module" setting found

Why? To follow the philosophy discussed [here](https://github.com/testing-library/eslint-plugin-testing-library/issues/222#issuecomment-679592434) so by default the plugin is really aggressive to avoid missing code that should be reported. Then, if the plugin is reporting things out of the scope for the user, they can config that scope properly through shared settings.

First thing that can be configured is the module from where Testing Library is considered as imported. So if the user has its own utils reexported from `@testing-library/framework` in `test-utils` module, they can set that up so the plugin will consider just `@testing-library/framework` and `test-utils` as modules where TL utils can be imported from.

This mechanism is implemented globally through `detectTestingLibraryUtils` so rules don't need to take care of this manually since the rule creator will prevent reporting when necessary.

Next step: shared config and mechanism for test file name patterns. You'll find more comments throughout this PR.