### PR TITLE
Move rules settings to ESLint shared config: part 3 - check reported file name

### DIFF
--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -2,6 +2,7 @@ import { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
 
 export type TestingLibrarySettings = {
   'testing-library/module'?: string;
+  'testing-library/file-name'?: string;
 };
 
 export type TestingLibraryContext<
@@ -25,8 +26,11 @@ export type EnhancedRuleCreate<
 
 export type DetectionHelpers = {
   getIsTestingLibraryImported: () => boolean;
+  getIsValidFileName: () => boolean;
   canReportErrors: () => boolean;
 };
+
+const DEFAULT_FILE_NAME_PATTERN = '^.*\\.(test|spec)\\.[jt]sx?$';
 
 /**
  * Enhances a given rule `create` with helpers to detect Testing Library utils.
@@ -45,6 +49,9 @@ export function detectTestingLibraryUtils<
 
     // Init options based on shared ESLint settings
     const customModule = context.settings['testing-library/module'];
+    const fileNamePattern =
+      context.settings['testing-library/file-name'] ??
+      DEFAULT_FILE_NAME_PATTERN;
 
     // Helpers for Testing Library detection.
     const helpers: DetectionHelpers = {
@@ -69,10 +76,20 @@ export function detectTestingLibraryUtils<
       },
 
       /**
+       * Gets if file name being analyzed is valid or not.
+       *
+       * This is based on "testing-library/file-name" setting.
+       */
+      getIsValidFileName() {
+        const fileName = context.getFilename();
+        return !!fileName.match(fileNamePattern);
+      },
+
+      /**
        * Wraps all conditions that must be met to report rules.
        */
       canReportErrors() {
-        return this.getIsTestingLibraryImported();
+        return this.getIsTestingLibraryImported() && this.getIsValidFileName();
       },
     };
 

--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -76,7 +76,7 @@ export function detectTestingLibraryUtils<
       },
 
       /**
-       * Gets if file name being analyzed is valid or not.
+       * Gets if name of the file being analyzed is valid or not.
        *
        * This is based on "testing-library/file-name" setting.
        */

--- a/tests/create-testing-library-rule.test.ts
+++ b/tests/create-testing-library-rule.test.ts
@@ -1,15 +1,12 @@
 import { createRuleTester } from './lib/test-utils';
 import rule, { RULE_NAME } from './fake-rule';
 
-const ruleTester = createRuleTester({
-  ecmaFeatures: {
-    jsx: true,
-  },
-});
+const ruleTester = createRuleTester();
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     {
+      filename: 'MyComponent.test.js',
       code: `
       // case: nothing related to Testing Library at all
       import { shallow } from 'enzyme';
@@ -18,6 +15,7 @@ ruleTester.run(RULE_NAME, rule, {
       `,
     },
     {
+      filename: 'MyComponent.test.js',
       code: `
       // case: render imported from other than custom module
       import { render } from '@somewhere/else'
@@ -29,6 +27,7 @@ ruleTester.run(RULE_NAME, rule, {
       },
     },
     {
+      filename: 'MyComponent.test.js',
       code: `
       // case: prevent import which should trigger an error since it's imported
       // from other than custom module
@@ -38,9 +37,20 @@ ruleTester.run(RULE_NAME, rule, {
         'testing-library/module': 'test-utils',
       },
     },
+    {
+      filename: 'MyComponent.test.js',
+      code: `
+      // case: import module forced to be reported but not matching file name
+      import { foo } from 'report-me'
+    `,
+      settings: {
+        'testing-library/file-name': 'testing-library\\.js',
+      },
+    },
   ],
   invalid: [
     {
+      filename: 'MyComponent.test.js',
       code: `
       // case: import module forced to be reported
       import { foo } from 'report-me'
@@ -48,6 +58,26 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [{ line: 3, column: 7, messageId: 'fakeError' }],
     },
     {
+      filename: 'MyComponent.spec.js',
+      code: `
+      // case: import module forced to be reported but from .spec.js named file
+      import { foo } from 'report-me'
+    `,
+      errors: [{ line: 3, column: 7, messageId: 'fakeError' }],
+    },
+    {
+      filename: 'MyComponent.testing-library.js',
+      code: `
+      // case: import module forced to be reported with custom file name
+      import { foo } from 'report-me'
+    `,
+      settings: {
+        'testing-library/file-name': 'testing-library\\.js',
+      },
+      errors: [{ line: 3, column: 7, messageId: 'fakeError' }],
+    },
+    {
+      filename: 'MyComponent.test.js',
       code: `
       // case: render imported from any module by default (aggressive reporting)
       import { render } from '@somewhere/else'
@@ -64,6 +94,7 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
+      filename: 'MyComponent.test.js',
       code: `
       // case: render imported from Testing Library module
       import { render } from '@testing-library/react'
@@ -80,6 +111,7 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
+      filename: 'MyComponent.test.js',
       code: `
       // case: render imported from config custom module
       import { render } from 'test-utils'
@@ -99,6 +131,7 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
+      filename: 'MyComponent.test.js',
       code: `
       // case: render imported from Testing Library module if
       // custom module setup

--- a/tests/create-testing-library-rule.test.ts
+++ b/tests/create-testing-library-rule.test.ts
@@ -6,7 +6,6 @@ const ruleTester = createRuleTester();
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     {
-      filename: 'MyComponent.test.js',
       code: `
       // case: nothing related to Testing Library at all
       import { shallow } from 'enzyme';
@@ -15,7 +14,6 @@ ruleTester.run(RULE_NAME, rule, {
       `,
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
       // case: render imported from other than custom module
       import { render } from '@somewhere/else'
@@ -27,7 +25,6 @@ ruleTester.run(RULE_NAME, rule, {
       },
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
       // case: prevent import which should trigger an error since it's imported
       // from other than custom module
@@ -38,7 +35,6 @@ ruleTester.run(RULE_NAME, rule, {
       },
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
       // case: import module forced to be reported but not matching file name
       import { foo } from 'report-me'
@@ -50,7 +46,6 @@ ruleTester.run(RULE_NAME, rule, {
   ],
   invalid: [
     {
-      filename: 'MyComponent.test.js',
       code: `
       // case: import module forced to be reported
       import { foo } from 'report-me'
@@ -77,7 +72,6 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [{ line: 3, column: 7, messageId: 'fakeError' }],
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
       // case: render imported from any module by default (aggressive reporting)
       import { render } from '@somewhere/else'
@@ -94,7 +88,6 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
       // case: render imported from Testing Library module
       import { render } from '@testing-library/react'
@@ -111,7 +104,6 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
       // case: render imported from config custom module
       import { render } from 'test-utils'
@@ -131,7 +123,6 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
       // case: render imported from Testing Library module if
       // custom module setup

--- a/tests/lib/rules/consistent-data-testid.test.ts
+++ b/tests/lib/rules/consistent-data-testid.test.ts
@@ -1,11 +1,7 @@
 import { createRuleTester } from '../test-utils';
 import rule, { RULE_NAME } from '../../../lib/rules/consistent-data-testid';
 
-const ruleTester = createRuleTester({
-  ecmaFeatures: {
-    jsx: true,
-  },
-});
+const ruleTester = createRuleTester();
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [

--- a/tests/lib/rules/no-container.test.ts
+++ b/tests/lib/rules/no-container.test.ts
@@ -1,11 +1,7 @@
 import { createRuleTester } from '../test-utils';
 import rule, { RULE_NAME } from '../../../lib/rules/no-container';
 
-const ruleTester = createRuleTester({
-  ecmaFeatures: {
-    jsx: true,
-  },
-});
+const ruleTester = createRuleTester();
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [

--- a/tests/lib/rules/no-debug.test.ts
+++ b/tests/lib/rules/no-debug.test.ts
@@ -1,11 +1,7 @@
 import { createRuleTester } from '../test-utils';
 import rule, { RULE_NAME } from '../../../lib/rules/no-debug';
 
-const ruleTester = createRuleTester({
-  ecmaFeatures: {
-    jsx: true,
-  },
-});
+const ruleTester = createRuleTester();
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [

--- a/tests/lib/rules/no-multiple-assertions-wait-for.test.ts
+++ b/tests/lib/rules/no-multiple-assertions-wait-for.test.ts
@@ -3,11 +3,7 @@ import rule, {
   RULE_NAME,
 } from '../../../lib/rules/no-multiple-assertions-wait-for';
 
-const ruleTester = createRuleTester({
-  ecmaFeatures: {
-    jsx: true,
-  },
-});
+const ruleTester = createRuleTester();
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [

--- a/tests/lib/rules/no-node-access.test.ts
+++ b/tests/lib/rules/no-node-access.test.ts
@@ -1,16 +1,11 @@
 import { createRuleTester } from '../test-utils';
 import rule, { RULE_NAME } from '../../../lib/rules/no-node-access';
 
-const ruleTester = createRuleTester({
-  ecmaFeatures: {
-    jsx: true,
-  },
-});
+const ruleTester = createRuleTester();
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     {
-      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';
         
@@ -18,7 +13,6 @@ ruleTester.run(RULE_NAME, rule, {
       `,
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';
 
@@ -28,7 +22,6 @@ ruleTester.run(RULE_NAME, rule, {
       `,
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';
 
@@ -37,7 +30,6 @@ ruleTester.run(RULE_NAME, rule, {
       `,
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';  
         
@@ -47,7 +39,6 @@ ruleTester.run(RULE_NAME, rule, {
       `,
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
         import { render, within } from '@testing-library/react';
 
@@ -57,7 +48,6 @@ ruleTester.run(RULE_NAME, rule, {
       `,
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
         const Component = props => {
           return <div>{props.children}</div>
@@ -68,7 +58,6 @@ ruleTester.run(RULE_NAME, rule, {
       },
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
       // case: importing custom module
       const closestButton = document.getElementById('submit-btn').closest('button');
@@ -81,7 +70,6 @@ ruleTester.run(RULE_NAME, rule, {
   ],
   invalid: [
     {
-      filename: 'MyComponent.test.js',
       code: `
       // case: without importing TL (aggressive reporting)
       const closestButton = document.getElementById('submit-btn')
@@ -90,7 +78,6 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [{ messageId: 'noNodeAccess', line: 3 }],
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';
     
@@ -106,7 +93,6 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';
 
@@ -119,7 +105,6 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';
         
@@ -135,7 +120,6 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';
       
@@ -148,7 +132,6 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
         import { render } from '@testing-library/react';  
         
@@ -162,7 +145,6 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';
 
@@ -187,7 +169,6 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';
         
@@ -201,7 +182,6 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
         import { render } from '@testing-library/react';
         
@@ -216,7 +196,6 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
         import { render } from '@testing-library/react';
         
@@ -230,7 +209,6 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';
         
@@ -261,7 +239,6 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
-      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';
 

--- a/tests/lib/rules/no-node-access.test.ts
+++ b/tests/lib/rules/no-node-access.test.ts
@@ -10,6 +10,7 @@ const ruleTester = createRuleTester({
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     {
+      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';
         
@@ -17,6 +18,7 @@ ruleTester.run(RULE_NAME, rule, {
       `,
     },
     {
+      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';
 
@@ -26,6 +28,7 @@ ruleTester.run(RULE_NAME, rule, {
       `,
     },
     {
+      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';
 
@@ -34,6 +37,7 @@ ruleTester.run(RULE_NAME, rule, {
       `,
     },
     {
+      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';  
         
@@ -43,6 +47,7 @@ ruleTester.run(RULE_NAME, rule, {
       `,
     },
     {
+      filename: 'MyComponent.test.js',
       code: `
         import { render, within } from '@testing-library/react';
 
@@ -51,19 +56,19 @@ ruleTester.run(RULE_NAME, rule, {
         within(signinModal).getByPlaceholderText('Username');
       `,
     },
-    /*{
-      // TODO: this one should be valid indeed. Rule implementation must be improved
-      //  to track where the nodes are coming from. This one wasn't reported before
-      //  just because this code is not importing TL module, but that's a really
-      //  brittle check. Instead, this one shouldn't be reported since `children`
-      //  it's just a property not related to a node
+    {
+      filename: 'MyComponent.test.js',
       code: `
         const Component = props => {
           return <div>{props.children}</div>
         }
       `,
-    },*/
+      settings: {
+        'testing-library/file-name': 'testing-library\\.js',
+      },
+    },
     {
+      filename: 'MyComponent.test.js',
       code: `
       // case: importing custom module
       const closestButton = document.getElementById('submit-btn').closest('button');
@@ -76,6 +81,7 @@ ruleTester.run(RULE_NAME, rule, {
   ],
   invalid: [
     {
+      filename: 'MyComponent.test.js',
       code: `
       // case: without importing TL (aggressive reporting)
       const closestButton = document.getElementById('submit-btn')
@@ -84,6 +90,7 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [{ messageId: 'noNodeAccess', line: 3 }],
     },
     {
+      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';
     
@@ -99,6 +106,7 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
+      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';
 
@@ -111,6 +119,7 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
+      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';
         
@@ -126,6 +135,7 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
+      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';
       
@@ -138,6 +148,7 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
+      filename: 'MyComponent.test.js',
       code: `
         import { render } from '@testing-library/react';  
         
@@ -151,6 +162,7 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
+      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';
 
@@ -175,6 +187,7 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
+      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';
         
@@ -188,6 +201,7 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
+      filename: 'MyComponent.test.js',
       code: `
         import { render } from '@testing-library/react';
         
@@ -202,6 +216,7 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
+      filename: 'MyComponent.test.js',
       code: `
         import { render } from '@testing-library/react';
         
@@ -215,6 +230,7 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
+      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';
         
@@ -245,6 +261,7 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
+      filename: 'MyComponent.test.js',
       code: `
         import { screen } from '@testing-library/react';
 

--- a/tests/lib/rules/no-render-in-setup.test.ts
+++ b/tests/lib/rules/no-render-in-setup.test.ts
@@ -2,11 +2,7 @@ import { createRuleTester } from '../test-utils';
 import { TESTING_FRAMEWORK_SETUP_HOOKS } from '../../../lib/utils';
 import rule, { RULE_NAME } from '../../../lib/rules/no-render-in-setup';
 
-const ruleTester = createRuleTester({
-  ecmaFeatures: {
-    jsx: true,
-  },
-});
+const ruleTester = createRuleTester();
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [

--- a/tests/lib/rules/no-side-effects-wait-for.test.ts
+++ b/tests/lib/rules/no-side-effects-wait-for.test.ts
@@ -1,11 +1,7 @@
 import { createRuleTester } from '../test-utils';
 import rule, { RULE_NAME } from '../../../lib/rules/no-side-effects-wait-for';
 
-const ruleTester = createRuleTester({
-  ecmaFeatures: {
-    jsx: true,
-  },
-});
+const ruleTester = createRuleTester();
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [

--- a/tests/lib/rules/prefer-find-by.test.ts
+++ b/tests/lib/rules/prefer-find-by.test.ts
@@ -14,11 +14,7 @@ import rule, {
   MessageIds,
 } from '../../../lib/rules/prefer-find-by';
 
-const ruleTester = createRuleTester({
-  ecmaFeatures: {
-    jsx: true,
-  },
-});
+const ruleTester = createRuleTester();
 
 function buildFindByMethod(queryMethod: string) {
   return `${getFindByQueryVariant(queryMethod)}${queryMethod.split('By')[1]}`;

--- a/tests/lib/rules/render-result-naming-convention.test.ts
+++ b/tests/lib/rules/render-result-naming-convention.test.ts
@@ -3,11 +3,7 @@ import rule, {
   RULE_NAME,
 } from '../../../lib/rules/render-result-naming-convention';
 
-const ruleTester = createRuleTester({
-  ecmaFeatures: {
-    jsx: true,
-  },
-});
+const ruleTester = createRuleTester();
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [

--- a/tests/lib/test-utils.ts
+++ b/tests/lib/test-utils.ts
@@ -1,8 +1,6 @@
 import { resolve } from 'path';
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 
-// TODO: remove ecmaFeatures object from other tests files
-
 const DEFAULT_TEST_CASE_CONFIG = {
   filename: 'MyComponent.test.js',
 };
@@ -42,7 +40,6 @@ export const createRuleTester = (
     parserOptions: {
       ecmaVersion: 2018,
       sourceType: 'module',
-      // TODO: should we deep merge here?
       ecmaFeatures: {
         jsx: true,
       },

--- a/tests/lib/test-utils.ts
+++ b/tests/lib/test-utils.ts
@@ -1,18 +1,52 @@
 import { resolve } from 'path';
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 
+// TODO: remove ecmaFeatures object from other tests files
+
+const DEFAULT_TEST_CASE_CONFIG = {
+  filename: 'MyComponent.test.js',
+};
+
+class TestingLibraryRuleTester extends TSESLint.RuleTester {
+  run<TMessageIds extends string, TOptions extends Readonly<unknown[]>>(
+    ruleName: string,
+    rule: TSESLint.RuleModule<TMessageIds, TOptions>,
+    tests: TSESLint.RunTests<TMessageIds, TOptions>
+  ): void {
+    const { valid, invalid } = tests;
+
+    const finalValid = valid.map((testCase) => {
+      if (typeof testCase === 'string') {
+        return {
+          ...DEFAULT_TEST_CASE_CONFIG,
+          code: testCase,
+        };
+      }
+
+      return { ...DEFAULT_TEST_CASE_CONFIG, ...testCase };
+    });
+    const finalInvalid = invalid.map((testCase) => ({
+      ...DEFAULT_TEST_CASE_CONFIG,
+      ...testCase,
+    }));
+
+    super.run(ruleName, rule, { valid: finalValid, invalid: finalInvalid });
+  }
+}
+
 export const createRuleTester = (
   parserOptions: Partial<TSESLint.ParserOptions> = {}
-): TSESLint.RuleTester =>
-  new TSESLint.RuleTester({
+): TSESLint.RuleTester => {
+  return new TestingLibraryRuleTester({
     parser: resolve('./node_modules/@typescript-eslint/parser'),
     parserOptions: {
       ecmaVersion: 2018,
       sourceType: 'module',
-      // TODO: we should deep merge here
+      // TODO: should we deep merge here?
       ecmaFeatures: {
         jsx: true,
       },
       ...parserOptions,
     },
   });
+};

--- a/tests/lib/test-utils.ts
+++ b/tests/lib/test-utils.ts
@@ -9,6 +9,10 @@ export const createRuleTester = (
     parserOptions: {
       ecmaVersion: 2018,
       sourceType: 'module',
+      // TODO: we should deep merge here
+      ecmaFeatures: {
+        jsx: true,
+      },
       ...parserOptions,
     },
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,


### PR DESCRIPTION
Relates to #198 

Third part which includes:
- checking file name in testing library detection so we only report desired files
- new setting to customize file name pattern for desired reported files. It defaults to `.(test|spec).(t|j)sx?` (same as jest)
- new RuleTester for Testing Library which makes sure valid and invalid test cases have default config (just file name for now)
- common parserOptions for tests updated

With this PR we already have 2/3 necessary settings for v4: module where testing library utils can be imported and file name pattern for desired reported files. The final one will be the setting for customizing other methods than `render` to be considered as Testing Library render (e.g. `renderWithRedux`, `setUp`).

We are missing also the "aggressive reporting" mode for Testing Library queries so everything starting by `findBy*`, `getBy*` and `queryBy*` are considered queries, not just different combinations from Testing Library.

So, after this one is merged, next steps are:

1. refactor rules not reporting anything related to `render` or queries (that's in my analysis attached on #198 )
2. implement the setting for customize `render` method and use it in one existing rule
3. implement "aggressive reporting" for queries and use it in one existing rule
4. refactor remaining rules