### PR TITLE
Move rules settings to ESLint shared config: part 5 - refactor no-manual-cleanup rule

### DIFF
--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -1,9 +1,5 @@
 import { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
-import {
-  getImportModuleName,
-  isLiteral,
-  ModuleImportation,
-} from './node-utils';
+import { getImportModuleName, isLiteral, ImportModuleNode } from './node-utils';
 
 export type TestingLibrarySettings = {
   'testing-library/module'?: string;
@@ -30,8 +26,8 @@ export type EnhancedRuleCreate<
 ) => TRuleListener;
 
 export type DetectionHelpers = {
-  getTestingLibraryImportNode: () => ModuleImportation | null;
-  getCustomModuleImportNode: () => ModuleImportation | null;
+  getTestingLibraryImportNode: () => ImportModuleNode | null;
+  getCustomModuleImportNode: () => ImportModuleNode | null;
   getTestingLibraryImportName: () => string | undefined;
   getCustomModuleImportName: () => string | undefined;
   getIsTestingLibraryImported: () => boolean;
@@ -53,8 +49,8 @@ export function detectTestingLibraryUtils<
     context: TestingLibraryContext<TOptions, TMessageIds>,
     optionsWithDefault: Readonly<TOptions>
   ): TSESLint.RuleListener => {
-    let importedTestingLibraryNode: ModuleImportation | null = null;
-    let importedCustomModuleNode: ModuleImportation | null = null;
+    let importedTestingLibraryNode: ImportModuleNode | null = null;
+    let importedCustomModuleNode: ImportModuleNode | null = null;
 
     // Init options based on shared ESLint settings
     const customModule = context.settings['testing-library/module'];

--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -30,8 +30,8 @@ export type EnhancedRuleCreate<
 ) => TRuleListener;
 
 export type DetectionHelpers = {
-  getTestingLibraryImportNode: () => ModuleImportation;
-  getCustomModuleImportNode: () => ModuleImportation;
+  getTestingLibraryImportNode: () => ModuleImportation | null;
+  getCustomModuleImportNode: () => ModuleImportation | null;
   getTestingLibraryImportName: () => string | undefined;
   getCustomModuleImportName: () => string | undefined;
   getIsTestingLibraryImported: () => boolean;
@@ -53,8 +53,8 @@ export function detectTestingLibraryUtils<
     context: TestingLibraryContext<TOptions, TMessageIds>,
     optionsWithDefault: Readonly<TOptions>
   ): TSESLint.RuleListener => {
-    let importedTestingLibraryNode: ModuleImportation = null;
-    let importedCustomModuleNode: ModuleImportation = null;
+    let importedTestingLibraryNode: ModuleImportation | null = null;
+    let importedCustomModuleNode: ModuleImportation | null = null;
 
     // Init options based on shared ESLint settings
     const customModule = context.settings['testing-library/module'];

--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -1,5 +1,9 @@
 import { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
-import { isLiteral } from './node-utils';
+import {
+  getImportModuleName,
+  isLiteral,
+  ModuleImportation,
+} from './node-utils';
 
 export type TestingLibrarySettings = {
   'testing-library/module'?: string;
@@ -25,14 +29,11 @@ export type EnhancedRuleCreate<
   detectionHelpers: Readonly<DetectionHelpers>
 ) => TRuleListener;
 
-type ModuleImportation =
-  | TSESTree.ImportDeclaration
-  | TSESTree.CallExpression
-  | null;
-
 export type DetectionHelpers = {
   getTestingLibraryImportNode: () => ModuleImportation;
   getCustomModuleImportNode: () => ModuleImportation;
+  getTestingLibraryImportName: () => string | undefined;
+  getCustomModuleImportName: () => string | undefined;
   getIsTestingLibraryImported: () => boolean;
   getIsValidFilename: () => boolean;
   canReportErrors: () => boolean;
@@ -68,6 +69,12 @@ export function detectTestingLibraryUtils<
       },
       getCustomModuleImportNode() {
         return importedCustomModuleNode;
+      },
+      getTestingLibraryImportName() {
+        return getImportModuleName(importedTestingLibraryNode);
+      },
+      getCustomModuleImportName() {
+        return getImportModuleName(importedCustomModuleNode);
       },
       /**
        * Gets if Testing Library is considered as imported or not.

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -226,12 +226,12 @@ export function isRenderVariableDeclarator(
 }
 
 // TODO: extract into types file?
-export type ModuleImportation =
+export type ImportModuleNode =
   | TSESTree.ImportDeclaration
   | TSESTree.CallExpression;
 
 export function getImportModuleName(
-  node: ModuleImportation | undefined | null
+  node: ImportModuleNode | undefined | null
 ): string | undefined {
   // import node of shape: import { foo } from 'bar'
   if (

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -225,13 +225,13 @@ export function isRenderVariableDeclarator(
   return false;
 }
 
+// TODO: extract into types file?
 export type ModuleImportation =
   | TSESTree.ImportDeclaration
-  | TSESTree.CallExpression
-  | null;
+  | TSESTree.CallExpression;
 
 export function getImportModuleName(
-  node: ModuleImportation | undefined
+  node: ModuleImportation | undefined | null
 ): string | undefined {
   // import node of shape: import { foo } from 'bar'
   if (

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -6,9 +6,9 @@ import {
 import { RuleContext } from '@typescript-eslint/experimental-utils/dist/ts-eslint';
 
 export function isCallExpression(
-  node: TSESTree.Node
+  node: TSESTree.Node | null | undefined
 ): node is TSESTree.CallExpression {
-  return node && node.type === AST_NODE_TYPES.CallExpression;
+  return node?.type === AST_NODE_TYPES.CallExpression;
 }
 
 export function isNewExpression(
@@ -154,6 +154,12 @@ export function isArrayExpression(
   return node?.type === AST_NODE_TYPES.ArrayExpression;
 }
 
+export function isImportDeclaration(
+  node: TSESTree.Node | null | undefined
+): node is TSESTree.ImportDeclaration {
+  return node?.type === AST_NODE_TYPES.ImportDeclaration;
+}
+
 export function isAwaited(node: TSESTree.Node): boolean {
   return (
     isAwaitExpression(node) ||
@@ -234,16 +240,13 @@ export function getImportModuleName(
   node: ImportModuleNode | undefined | null
 ): string | undefined {
   // import node of shape: import { foo } from 'bar'
-  if (
-    node?.type === AST_NODE_TYPES.ImportDeclaration &&
-    typeof node.source.value === 'string'
-  ) {
+  if (isImportDeclaration(node) && typeof node.source.value === 'string') {
     return node.source.value;
   }
 
   // import node of shape: const { foo } = require('bar')
   if (
-    node?.type === AST_NODE_TYPES.CallExpression &&
+    isCallExpression(node) &&
     isLiteral(node.arguments[0]) &&
     typeof node.arguments[0].value === 'string'
   ) {

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -17,6 +17,7 @@ export function isNewExpression(
   return node && node.type === 'NewExpression';
 }
 
+// TODO: remove this one and use ASTUtils one instead
 export function isIdentifier(node: TSESTree.Node): node is TSESTree.Identifier {
   return node && node.type === AST_NODE_TYPES.Identifier;
 }
@@ -69,8 +70,10 @@ export function isObjectPattern(
   return node && node.type === AST_NODE_TYPES.ObjectPattern;
 }
 
-export function isProperty(node: TSESTree.Node): node is TSESTree.Property {
-  return node && node.type === AST_NODE_TYPES.Property;
+export function isProperty(
+  node: TSESTree.Node | null | undefined
+): node is TSESTree.Property {
+  return node?.type === AST_NODE_TYPES.Property;
 }
 
 export function isJSXAttribute(
@@ -126,6 +129,7 @@ export function hasThenProperty(node: TSESTree.Node): boolean {
   );
 }
 
+// TODO: remove this one and use ASTUtils one instead
 export function isAwaitExpression(
   node: TSESTree.Node
 ): node is TSESTree.AwaitExpression {
@@ -176,7 +180,7 @@ export function getVariableReferences(
 ): TSESLint.Scope.Reference[] {
   return (
     (isVariableDeclarator(node) &&
-      context.getDeclaredVariables(node)[0].references.slice(1)) ||
+      context.getDeclaredVariables(node)[0]?.references?.slice(1)) ||
     []
   );
 }

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -220,3 +220,29 @@ export function isRenderVariableDeclarator(
 
   return false;
 }
+
+export type ModuleImportation =
+  | TSESTree.ImportDeclaration
+  | TSESTree.CallExpression
+  | null;
+
+export function getImportModuleName(
+  node: ModuleImportation | undefined
+): string | undefined {
+  // import node of shape: import { foo } from 'bar'
+  if (
+    node?.type === AST_NODE_TYPES.ImportDeclaration &&
+    typeof node.source.value === 'string'
+  ) {
+    return node.source.value;
+  }
+
+  // import node of shape: const { foo } = require('bar')
+  if (
+    node?.type === AST_NODE_TYPES.CallExpression &&
+    isLiteral(node.arguments[0]) &&
+    typeof node.arguments[0].value === 'string'
+  ) {
+    return node.arguments[0].value;
+  }
+}

--- a/lib/rules/no-container.ts
+++ b/lib/rules/no-container.ts
@@ -105,7 +105,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
         }
       },
 
-      CallExpression(node: TSESTree.CallExpression) {
+      CallExpression(node) {
         if (isMemberExpression(node.callee)) {
           showErrorIfChainedContainerMethod(node.callee);
         } else {

--- a/lib/rules/no-dom-import.ts
+++ b/lib/rules/no-dom-import.ts
@@ -1,7 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import { isCallExpression } from '../node-utils';
 

--- a/lib/rules/no-dom-import.ts
+++ b/lib/rules/no-dom-import.ts
@@ -3,6 +3,7 @@ import {
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
 import { createTestingLibraryRule } from '../create-testing-library-rule';
+import { isCallExpression } from '../node-utils';
 
 export const RULE_NAME = 'no-dom-import';
 export type MessageIds = 'noDomImport' | 'noDomImportFramework';
@@ -51,7 +52,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
             module: correctModuleName,
           },
           fix(fixer) {
-            if (node.type === AST_NODE_TYPES.CallExpression) {
+            if (isCallExpression(node)) {
               const name = node.arguments[0] as TSESTree.Literal;
 
               // Replace the module name with the raw module name as we can't predict which punctuation the user is going to use

--- a/lib/rules/no-manual-cleanup.ts
+++ b/lib/rules/no-manual-cleanup.ts
@@ -40,8 +40,6 @@ export default createTestingLibraryRule<Options, MessageIds>({
   defaultOptions: [],
 
   create(context, _, helpers) {
-    // can't find the right type?
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     function reportImportReferences(references: TSESLint.Scope.Reference[]) {
       references.forEach((reference) => {
         const utilsUsage = reference.identifier.parent;

--- a/lib/rules/no-manual-cleanup.ts
+++ b/lib/rules/no-manual-cleanup.ts
@@ -1,5 +1,4 @@
 import {
-  AST_NODE_TYPES,
   ASTUtils,
   TSESTree,
   TSESLint,

--- a/lib/rules/no-manual-cleanup.ts
+++ b/lib/rules/no-manual-cleanup.ts
@@ -11,7 +11,7 @@ import {
   isMemberExpression,
   isObjectPattern,
   isProperty,
-  ModuleImportation,
+  ImportModuleNode,
 } from '../node-utils';
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 
@@ -58,7 +58,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
       });
     }
 
-    function reportCandidateModule(moduleNode: ModuleImportation) {
+    function reportCandidateModule(moduleNode: ImportModuleNode) {
       if (moduleNode.type === AST_NODE_TYPES.ImportDeclaration) {
         // case: import utils from 'testing-library-module'
         if (isImportDefaultSpecifier(moduleNode.specifiers[0])) {

--- a/lib/rules/no-manual-cleanup.ts
+++ b/lib/rules/no-manual-cleanup.ts
@@ -1,14 +1,14 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
-import { getDocsUrl } from '../utils';
+import { TSESTree } from '@typescript-eslint/experimental-utils';
 import {
-  isImportDefaultSpecifier,
-  isLiteral,
   isIdentifier,
+  isImportDefaultSpecifier,
+  isImportSpecifier,
+  isLiteral,
+  isMemberExpression,
   isObjectPattern,
   isProperty,
-  isMemberExpression,
-  isImportSpecifier,
 } from '../node-utils';
+import { createTestingLibraryRule } from '../create-testing-library-rule';
 
 export const RULE_NAME = 'no-manual-cleanup';
 export type MessageIds = 'noManualCleanup';
@@ -16,7 +16,7 @@ type Options = [];
 
 const CLEANUP_LIBRARY_REGEX = /(@testing-library\/(preact|react|svelte|vue))|@marko\/testing-library/;
 
-export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
+export default createTestingLibraryRule<Options, MessageIds>({
   name: RULE_NAME,
   meta: {
     type: 'problem',

--- a/lib/rules/no-manual-cleanup.ts
+++ b/lib/rules/no-manual-cleanup.ts
@@ -12,6 +12,7 @@ import {
   isObjectPattern,
   isProperty,
   ImportModuleNode,
+  isImportDeclaration,
 } from '../node-utils';
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 
@@ -59,7 +60,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
     }
 
     function reportCandidateModule(moduleNode: ImportModuleNode) {
-      if (moduleNode.type === AST_NODE_TYPES.ImportDeclaration) {
+      if (isImportDeclaration(moduleNode)) {
         // case: import utils from 'testing-library-module'
         if (isImportDefaultSpecifier(moduleNode.specifiers[0])) {
           const { references } = context.getDeclaredVariables(moduleNode)[0];

--- a/tests/fake-rule.ts
+++ b/tests/fake-rule.ts
@@ -55,14 +55,12 @@ export default createTestingLibraryRule<Options, MessageIds>({
       ImportDeclaration: checkImportDeclaration,
       'Program:exit'() {
         const importNode = helpers.getCustomModuleImportNode();
+        const importName = helpers.getCustomModuleImportName();
         if (!importNode) {
           return;
         }
 
-        if (
-          importNode.type === AST_NODE_TYPES.ImportDeclaration &&
-          importNode.source.value === 'custom-module-forced-report'
-        ) {
+        if (importName === 'custom-module-forced-report') {
           context.report({
             node: importNode,
             messageId: 'fakeError',

--- a/tests/fake-rule.ts
+++ b/tests/fake-rule.ts
@@ -2,10 +2,7 @@
  * @file Fake rule to be able to test createTestingLibraryRule and
  * detectTestingLibraryUtils properly
  */
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createTestingLibraryRule } from '../lib/create-testing-library-rule';
 
 export const RULE_NAME = 'fake-rule';

--- a/tests/lib/rules/no-manual-cleanup.test.ts
+++ b/tests/lib/rules/no-manual-cleanup.test.ts
@@ -53,6 +53,14 @@ ruleTester.run(RULE_NAME, rule, {
     {
       code: `const utils = require(moduleName)`,
     },
+    {
+      settings: {
+        'testing-library/filename-pattern': 'testing-library\\.js',
+      },
+      code: `
+      import { render, cleanup } from "${ALL_TESTING_LIBRARIES_WITH_CLEANUP[0]}"
+      `,
+    },
   ],
   invalid: [
     ...ALL_TESTING_LIBRARIES_WITH_CLEANUP.map((lib) => ({
@@ -61,6 +69,20 @@ ruleTester.run(RULE_NAME, rule, {
         {
           line: 1,
           column: 18, // error points to `cleanup`
+          messageId: 'noManualCleanup',
+        },
+      ],
+    })),
+    ...ALL_TESTING_LIBRARIES_WITH_CLEANUP.map((lib) => ({
+      // official testing-library packages should be reported with custom module setting
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `import { cleanup, render } from "${lib}"`,
+      errors: [
+        {
+          line: 1,
+          column: 10, // error points to `cleanup`
           messageId: 'noManualCleanup',
         },
       ],

--- a/tests/lib/rules/no-manual-cleanup.test.ts
+++ b/tests/lib/rules/no-manual-cleanup.test.ts
@@ -17,9 +17,10 @@ ruleTester.run(RULE_NAME, rule, {
       code: `import "@testing-library/react"`,
     },
     {
-      code: `import { cleanup } from "any-other-library"`,
+      code: `import { cleanup } from "test-utils"`,
     },
     {
+      // Angular Testing Library doesn't have `cleanup` util
       code: `import { cleanup } from "@testing-library/angular"`,
     },
     ...ALL_TESTING_LIBRARIES_WITH_CLEANUP.map((lib) => ({
@@ -87,6 +88,15 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+        import { render, cleanup } from 'test-utils'
+      `,
+      errors: [{ line: 2, column: 26, messageId: 'noManualCleanup' }],
+    },
     ...ALL_TESTING_LIBRARIES_WITH_CLEANUP.map((lib) => ({
       code: `import { cleanup as myCustomCleanup } from "${lib}"`,
       errors: [
@@ -97,6 +107,15 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+        import { cleanup as myCustomCleanup } from 'test-utils'
+      `,
+      errors: [{ line: 2, column: 18, messageId: 'noManualCleanup' }],
+    },
     ...ALL_TESTING_LIBRARIES_WITH_CLEANUP.map((lib) => ({
       code: `import utils, { cleanup } from "${lib}"`,
       errors: [
@@ -107,6 +126,15 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+        import utils, { cleanup } from 'test-utils'
+      `,
+      errors: [{ line: 2, column: 25, messageId: 'noManualCleanup' }],
+    },
     ...ALL_TESTING_LIBRARIES_WITH_CLEANUP.map((lib) => ({
       code: `
         import utils from "${lib}"
@@ -120,6 +148,16 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+        import utils from 'test-utils'
+        afterEach(() => utils.cleanup())
+      `,
+      errors: [{ line: 3, column: 31, messageId: 'noManualCleanup' }],
+    },
     ...ALL_TESTING_LIBRARIES_WITH_CLEANUP.map((lib) => ({
       code: `
         import utils from "${lib}"
@@ -143,6 +181,15 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+        const { render, cleanup } = require('test-utils')
+      `,
+      errors: [{ line: 2, column: 25, messageId: 'noManualCleanup' }],
+    },
     ...ALL_TESTING_LIBRARIES_WITH_CLEANUP.map((lib) => ({
       code: `
         const utils = require("${lib}")

--- a/tests/lib/rules/no-manual-cleanup.test.ts
+++ b/tests/lib/rules/no-manual-cleanup.test.ts
@@ -13,12 +13,18 @@ const ALL_TESTING_LIBRARIES_WITH_CLEANUP = [
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
-    ...ALL_TESTING_LIBRARIES_WITH_CLEANUP.map((lib) => ({
-      code: `import { render } from "${lib}"`,
-    })),
+    {
+      code: `import "@testing-library/react"`,
+    },
     {
       code: `import { cleanup } from "any-other-library"`,
     },
+    {
+      code: `import { cleanup } from "@testing-library/angular"`,
+    },
+    ...ALL_TESTING_LIBRARIES_WITH_CLEANUP.map((lib) => ({
+      code: `import { render } from "${lib}"`,
+    })),
     ...ALL_TESTING_LIBRARIES_WITH_CLEANUP.map((lib) => ({
       code: `import utils from "${lib}"`,
     })),


### PR DESCRIPTION
Relates to #198 

6th part which includes:
-  refactor `no-manual-cleanup` rule to use custom rule creator + detection helpers
- extract some detection helpers for getting imported module name related to Testing Library (either official or custom modules)
- improve rule to detect custom module from settings