### PR TITLE
feat: add new settings for prefer-user-event

### DIFF
--- a/docs/rules/prefer-user-event.md
+++ b/docs/rules/prefer-user-event.md
@@ -18,6 +18,7 @@ Examples of **incorrect** code for this rule:
 ```ts
 // a method in fireEvent that has a userEvent equivalent
 import { fireEvent } from '@testing-library/dom';
+// or const { fireEvent } = require('@testing-library/dom');
 fireEvent.click(node);
 
 // using fireEvent with an alias
@@ -26,6 +27,7 @@ fireEventAliased.click(node);
 
 // using fireEvent after importing the entire library
 import * as dom from '@testing-library/dom';
+// or const dom = require(@testing-library/dom');
 dom.fireEvent.click(node);
 ```
 
@@ -33,14 +35,18 @@ Examples of **correct** code for this rule:
 
 ```ts
 import userEvent from '@testing-library/user-event';
+// or const userEvent = require('@testing-library/user-event');
 
 // any userEvent method
 userEvent.click();
 
 // fireEvent method that does not have an alternative in userEvent
+import { fireEvent } from '@testing-library/dom';
+// or const { fireEvent } = require('@testing-library/dom');
 fireEvent.cut(node);
 
 import * as dom from '@testing-library/dom';
+// or const dom = require('@testing-library/dom');
 dom.fireEvent.cut(node);
 ```
 
@@ -69,6 +75,7 @@ With this configuration example, the following use cases are considered valid
 ```ts
 // using a named import
 import { fireEvent } from '@testing-library/dom';
+// or const { fireEvent } = require('@testing-library/dom');
 fireEvent.click(node);
 fireEvent.change(node, { target: { value: 'foo' } });
 
@@ -79,6 +86,7 @@ fireEventAliased.change(node, { target: { value: 'foo' } });
 
 // using fireEvent after importing the entire library
 import * as dom from '@testing-library/dom';
+// or const dom = require('@testing-library/dom');
 dom.fireEvent.click(node);
 dom.fireEvent.change(node, { target: { value: 'foo' } });
 ```

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -253,22 +253,3 @@ export function getImportModuleName(
     return node.arguments[0].value;
   }
 }
-
-export function getSpecifierFromImport(
-  node: ImportModuleNode,
-  specifierName: string
-) {
-  if (isImportDeclaration(node)) {
-    const namedExport = node.specifiers.find(
-      (node) => isImportSpecifier(node) && node.imported.name === specifierName
-    );
-    // it is "import { foo } from 'baz'""
-    if (namedExport) {
-      return namedExport;
-    }
-    // it could be "import * as rtl from 'baz'"
-    return node.specifiers.find((n) => isImportNamespaceSpecifier(n));
-  } else {
-    // TODO make it work for require
-  }
-}

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -253,3 +253,22 @@ export function getImportModuleName(
     return node.arguments[0].value;
   }
 }
+
+export function getSpecifierFromImport(
+  node: ImportModuleNode,
+  specifierName: string
+) {
+  if (isImportDeclaration(node)) {
+    const namedExport = node.specifiers.find(
+      (node) => isImportSpecifier(node) && node.imported.name === specifierName
+    );
+    // it is "import { foo } from 'baz'""
+    if (namedExport) {
+      return namedExport;
+    }
+    // it could be "import * as rtl from 'baz'"
+    return node.specifiers.find((n) => isImportNamespaceSpecifier(n));
+  } else {
+    // TODO make it work for require
+  }
+}

--- a/lib/rules/prefer-user-event.ts
+++ b/lib/rules/prefer-user-event.ts
@@ -93,14 +93,14 @@ export default createTestingLibraryRule<Options, MessageIds>({
     return {
       ['CallExpression > MemberExpression'](node: TSESTree.MemberExpression) {
         const util = helpers.findImportedUtilSpecifier('fireEvent');
-        const fireEventAliasOrWildcard = isIdentifier(util)
-          ? util?.name
-          : util?.local.name;
-
-        if (!fireEventAliasOrWildcard) {
+        if (!util) {
           // testing library was imported, but fireEvent was not imported
           return;
         }
+        const fireEventAliasOrWildcard = isIdentifier(util)
+          ? util.name
+          : util.local.name;
+
         const fireEventUsed =
           isIdentifier(node.object) &&
           node.object.name === fireEventAliasOrWildcard;

--- a/lib/rules/prefer-user-event.ts
+++ b/lib/rules/prefer-user-event.ts
@@ -1,10 +1,6 @@
 import { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createTestingLibraryRule } from '../create-testing-library-rule';
-import {
-  isIdentifier,
-  isMemberExpression,
-  getSpecifierFromImport,
-} from '../node-utils';
+import { isIdentifier, isMemberExpression } from '../node-utils';
 
 export const RULE_NAME = 'prefer-user-event';
 
@@ -96,14 +92,10 @@ export default createTestingLibraryRule<Options, MessageIds>({
 
     return {
       ['CallExpression > MemberExpression'](node: TSESTree.MemberExpression) {
-        if (!helpers.getIsTestingLibraryImported()) {
-          return;
-        }
-        const testingLibraryImportNode = helpers.getTestingLibraryImportNode();
-        const fireEventAliasOrWildcard = getSpecifierFromImport(
-          testingLibraryImportNode,
-          'fireEvent'
-        )?.local.name;
+        const util = helpers.findImportedUtilSpecifier('fireEvent');
+        const fireEventAliasOrWildcard = isIdentifier(util)
+          ? util?.name
+          : util?.local.name;
 
         if (!fireEventAliasOrWildcard) {
           // testing library was imported, but fireEvent was not imported

--- a/tests/lib/rules/prefer-user-event.test.ts
+++ b/tests/lib/rules/prefer-user-event.test.ts
@@ -105,6 +105,67 @@ ruleTester.run(RULE_NAME, rule, {
         fireEvent()
     `,
     })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+        import { screen } from 'test-utils'
+        const element = screen.getByText(foo)
+      `,
+    },
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+        import { render } from 'test-utils'
+        const utils = render(baz)
+        const element = utils.getByText(foo)
+      `,
+    },
+    ...UserEventMethods.map((userEventMethod) => ({
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+        import userEvent from 'test-utils'
+        const node = document.createElement(elementType)
+        userEvent.${userEventMethod}(foo)
+      `,
+    })),
+    ...Object.keys(MappingToUserEvent).map((fireEventMethod: string) => ({
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+      import { fireEvent } from 'test-utils'
+      const node = document.createElement(elementType)
+      fireEvent.${fireEventMethod}(foo)
+    `,
+      options: [{ allowedMethods: [fireEventMethod] }],
+    })),
+    ...Object.keys(MappingToUserEvent).map((fireEventMethod: string) => ({
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+      import { fireEvent as fireEventAliased } from 'test-utils'
+      const node = document.createElement(elementType)
+      fireEventAliased.${fireEventMethod}(foo)
+    `,
+      options: [{ allowedMethods: [fireEventMethod] }],
+    })),
+    ...Object.keys(MappingToUserEvent).map((fireEventMethod: string) => ({
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+      import * as dom from 'test-utils'
+      dom.fireEvent.${fireEventMethod}(foo)
+    `,
+      options: [{ allowedMethods: [fireEventMethod] }],
+    })),
   ],
   invalid: [
     ...createScenarioWithImport<InvalidTestCase<MessageIds, Options>>(
@@ -130,5 +191,53 @@ ruleTester.run(RULE_NAME, rule, {
         errors: [{ messageId: 'preferUserEvent' }],
       })
     ),
+    ...createScenarioWithImport<InvalidTestCase<MessageIds, Options>>(
+      (libraryModule: string, fireEventMethod: string) => ({
+        code: `
+        const { fireEvent } = require('${libraryModule}')
+        fireEvent.${fireEventMethod}(foo)
+      `,
+        errors: [{ messageId: 'preferUserEvent' }],
+      })
+    ),
+    ...createScenarioWithImport<InvalidTestCase<MessageIds, Options>>(
+      (libraryModule: string, fireEventMethod: string) => ({
+        code: `
+        const rtl = require('${libraryModule}')
+        rtl.fireEvent.${fireEventMethod}(foo)
+      `,
+        errors: [{ messageId: 'preferUserEvent' }],
+      })
+    ),
+    ...Object.keys(MappingToUserEvent).map((fireEventMethod: string) => ({
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+        import * as dom from 'test-utils'
+        dom.fireEvent.${fireEventMethod}(foo)
+      `,
+      errors: [{ messageId: 'preferUserEvent' }],
+    })),
+    ...Object.keys(MappingToUserEvent).map((fireEventMethod: string) => ({
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+        import { fireEvent } from 'test-utils'
+        fireEvent.${fireEventMethod}(foo)
+      `,
+      errors: [{ messageId: 'preferUserEvent' }],
+    })),
+    ...Object.keys(MappingToUserEvent).map((fireEventMethod: string) => ({
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+        import { fireEvent as fireEventAliased } from 'test-utils'
+        fireEventAliased.${fireEventMethod}(foo)
+      `,
+      errors: [{ messageId: 'preferUserEvent' }],
+    })),
   ],
 });

--- a/tests/lib/rules/prefer-user-event.test.ts
+++ b/tests/lib/rules/prefer-user-event.test.ts
@@ -178,6 +178,8 @@ ruleTester.run(RULE_NAME, rule, {
         errors: [
           {
             messageId: 'preferUserEvent',
+            line: 4,
+            column: 9,
           },
         ],
       })
@@ -188,7 +190,7 @@ ruleTester.run(RULE_NAME, rule, {
         import * as dom from '${libraryModule}'
         dom.fireEvent.${fireEventMethod}(foo)
       `,
-        errors: [{ messageId: 'preferUserEvent' }],
+        errors: [{ messageId: 'preferUserEvent', line: 3, column: 9 }],
       })
     ),
     ...createScenarioWithImport<InvalidTestCase<MessageIds, Options>>(
@@ -197,7 +199,7 @@ ruleTester.run(RULE_NAME, rule, {
         const { fireEvent } = require('${libraryModule}')
         fireEvent.${fireEventMethod}(foo)
       `,
-        errors: [{ messageId: 'preferUserEvent' }],
+        errors: [{ messageId: 'preferUserEvent', line: 3, column: 9 }],
       })
     ),
     ...createScenarioWithImport<InvalidTestCase<MessageIds, Options>>(
@@ -206,7 +208,7 @@ ruleTester.run(RULE_NAME, rule, {
         const rtl = require('${libraryModule}')
         rtl.fireEvent.${fireEventMethod}(foo)
       `,
-        errors: [{ messageId: 'preferUserEvent' }],
+        errors: [{ messageId: 'preferUserEvent', line: 3, column: 9 }],
       })
     ),
     ...Object.keys(MappingToUserEvent).map((fireEventMethod: string) => ({
@@ -217,7 +219,7 @@ ruleTester.run(RULE_NAME, rule, {
         import * as dom from 'test-utils'
         dom.fireEvent.${fireEventMethod}(foo)
       `,
-      errors: [{ messageId: 'preferUserEvent' }],
+      errors: [{ messageId: 'preferUserEvent', line: 3, column: 9 }],
     })),
     ...Object.keys(MappingToUserEvent).map((fireEventMethod: string) => ({
       settings: {
@@ -227,7 +229,7 @@ ruleTester.run(RULE_NAME, rule, {
         import { fireEvent } from 'test-utils'
         fireEvent.${fireEventMethod}(foo)
       `,
-      errors: [{ messageId: 'preferUserEvent' }],
+      errors: [{ messageId: 'preferUserEvent', line: 3, column: 9 }],
     })),
     ...Object.keys(MappingToUserEvent).map((fireEventMethod: string) => ({
       settings: {
@@ -237,7 +239,7 @@ ruleTester.run(RULE_NAME, rule, {
         import { fireEvent as fireEventAliased } from 'test-utils'
         fireEventAliased.${fireEventMethod}(foo)
       `,
-      errors: [{ messageId: 'preferUserEvent' }],
+      errors: [{ messageId: 'preferUserEvent', line: 3, column: 9 }],
     })),
   ],
 });


### PR DESCRIPTION
refactor draft to include all the changes from #198 

this should make all the current scenarios and tests to pass, using the new helpers instead. What's pending:

- add tests with custom import libraries (the new ability from v4)
- add tests scenarios with `const { fireEvent } = require('module')` (the original implementation was not considering it, but now should be easier)
- add tests scenarios with `const rtl= require('module'); rtl.fireEvent()` (the original implementation was not considering it, but now should be easier)

I gotta say the rule's code is cleaner now 🎉 🚀 