### PR TITLE
Move rules settings to ESLint shared config: refactor prefer-presence-queries rule

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,6 +1,6 @@
 {
   "*.{js,ts}": [
-    "eslint --fix",
+    "eslint --max-warnings 0 --fix",
     "prettier --write",
     "jest --findRelatedTests"
   ],

--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -1,4 +1,8 @@
-import { ASTUtils, TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
+import {
+  ASTUtils,
+  TSESLint,
+  TSESTree,
+} from '@typescript-eslint/experimental-utils';
 import {
   getImportModuleName,
   getAssertNodeInfo,

--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -135,12 +135,19 @@ export function detectTestingLibraryUtils<
       },
 
       /**
-       * Determines whether a given node is sync query.
+       * Determines whether a given node is sync query or not.
        */
       isSyncQuery(node) {
         return this.isGetByQuery(node) || this.isQueryByQuery(node);
       },
 
+      /**
+       * Determines whether a given MemberExpression node is a presence assert
+       *
+       * Presence asserts could have shape of:
+       *  - expect(element).toBeInTheDocument()
+       *  - expect(element).not.toBeNull()
+       */
       isPresenceAssert(node) {
         const { matcher, isNegated } = getAssertNodeInfo(node);
 
@@ -153,6 +160,13 @@ export function detectTestingLibraryUtils<
           : PRESENCE_MATCHERS.includes(matcher);
       },
 
+      /**
+       * Determines whether a given MemberExpression node is an absence assert
+       *
+       * Absence asserts could have shape of:
+       *  - expect(element).toBeNull()
+       *  - expect(element).not.toBeInTheDocument()
+       */
       isAbsenceAssert(node) {
         const { matcher, isNegated } = getAssertNodeInfo(node);
 

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -279,12 +279,11 @@ export function getAssertNodeInfo(
   }
 
   let matcher = ASTUtils.getPropertyName(node);
-  let isNegated = false;
-  if (matcher === 'not') {
+  const isNegated = matcher === 'not';
+  if (isNegated) {
     matcher = isMemberExpression(node.parent)
       ? ASTUtils.getPropertyName(node.parent)
       : null;
-    isNegated = true;
   }
 
   if (!matcher) {

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -1,5 +1,6 @@
 import {
   AST_NODE_TYPES,
+  ASTUtils,
   TSESLint,
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
@@ -252,4 +253,43 @@ export function getImportModuleName(
   ) {
     return node.arguments[0].value;
   }
+}
+
+type AssertNodeInfo = {
+  matcher: string | null;
+  isNegated: boolean;
+};
+/**
+ * Extracts matcher info from MemberExpression node representing an assert.
+ */
+export function getAssertNodeInfo(
+  node: TSESTree.MemberExpression
+): AssertNodeInfo {
+  const emptyInfo = { matcher: null, isNegated: false } as AssertNodeInfo;
+
+  if (
+    !isCallExpression(node.object) ||
+    !ASTUtils.isIdentifier(node.object.callee)
+  ) {
+    return emptyInfo;
+  }
+
+  if (node.object.callee.name !== 'expect') {
+    return emptyInfo;
+  }
+
+  let matcher = ASTUtils.getPropertyName(node);
+  let isNegated = false;
+  if (matcher === 'not') {
+    matcher = isMemberExpression(node.parent)
+      ? ASTUtils.getPropertyName(node.parent)
+      : null;
+    isNegated = true;
+  }
+
+  if (!matcher) {
+    return emptyInfo;
+  }
+
+  return { matcher, isNegated };
 }

--- a/lib/rules/prefer-presence-queries.ts
+++ b/lib/rules/prefer-presence-queries.ts
@@ -1,18 +1,18 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { TSESTree } from '@typescript-eslint/experimental-utils';
 import {
-  getDocsUrl,
+  ABSENCE_MATCHERS,
   ALL_QUERIES_METHODS,
   PRESENCE_MATCHERS,
-  ABSENCE_MATCHERS,
 } from '../utils';
 import {
   findClosestCallNode,
-  isMemberExpression,
   isIdentifier,
+  isMemberExpression,
 } from '../node-utils';
+import { createTestingLibraryRule } from '../create-testing-library-rule';
 
 export const RULE_NAME = 'prefer-presence-queries';
-export type MessageIds = 'presenceQuery' | 'absenceQuery' | 'expectQueryBy';
+export type MessageIds = 'presenceQuery' | 'absenceQuery';
 type Options = [];
 
 const QUERIES_REGEXP = new RegExp(
@@ -23,7 +23,7 @@ function isThrowingQuery(node: TSESTree.Identifier) {
   return node.name.startsWith('get');
 }
 
-export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
+export default createTestingLibraryRule<Options, MessageIds>({
   name: RULE_NAME,
   meta: {
     docs: {
@@ -37,8 +37,6 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
         'Use `getBy*` queries rather than `queryBy*` for checking element is present',
       absenceQuery:
         'Use `queryBy*` queries rather than `getBy*` for checking element is NOT present',
-      expectQueryBy:
-        'Use `getBy*` only when checking elements are present, otherwise use `queryBy*`',
     },
     schema: [],
     type: 'suggestion',

--- a/lib/rules/prefer-presence-queries.ts
+++ b/lib/rules/prefer-presence-queries.ts
@@ -4,7 +4,7 @@ import { findClosestCallNode, isMemberExpression } from '../node-utils';
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 
 export const RULE_NAME = 'prefer-presence-queries';
-export type MessageIds = 'presenceQuery' | 'absenceQuery';
+export type MessageIds = 'wrongPresenceQuery' | 'wrongAbsenceQuery';
 type Options = [];
 
 export default createTestingLibraryRule<Options, MessageIds>({
@@ -17,9 +17,9 @@ export default createTestingLibraryRule<Options, MessageIds>({
       recommended: 'error',
     },
     messages: {
-      presenceQuery:
+      wrongPresenceQuery:
         'Use `getBy*` queries rather than `queryBy*` for checking element is present',
-      absenceQuery:
+      wrongAbsenceQuery:
         'Use `queryBy*` queries rather than `getBy*` for checking element is NOT present',
     },
     schema: [],
@@ -65,7 +65,9 @@ export default createTestingLibraryRule<Options, MessageIds>({
           ? ABSENCE_MATCHERS
           : PRESENCE_MATCHERS;
 
-        const messageId = isPresenceQuery ? 'absenceQuery' : 'presenceQuery';
+        const messageId = isPresenceQuery
+          ? 'wrongAbsenceQuery'
+          : 'wrongPresenceQuery';
 
         if (
           (!isNegatedMatcher && invalidMatchers.includes(matcher)) ||

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -24,6 +24,7 @@ const LIBRARY_MODULES = [
   '@testing-library/svelte',
 ];
 
+// TODO: should be deleted after all rules are migrated to v4
 const hasTestingLibraryImportModule = (
   node: TSESTree.ImportDeclaration
 ): boolean => {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "tsc",
     "postbuild": "cpy README.md ./dist && cpy package.json ./dist && cpy LICENSE ./dist",
-    "lint": "eslint . --ext .js,.ts",
+    "lint": "eslint . --max-warnings 0 --ext .js,.ts",
     "lint:fix": "npm run lint -- --fix",
     "format": "prettier --write README.md \"{lib,docs,tests}/**/*.{js,ts,md}\"",
     "format:check": "prettier --check README.md \"{lib,docs,tests}/**/*.{js,json,yml,ts,md}\"",

--- a/tests/create-testing-library-rule.test.ts
+++ b/tests/create-testing-library-rule.test.ts
@@ -121,6 +121,19 @@ ruleTester.run(RULE_NAME, rule, {
       `,
     },
 
+    // Test Cases for presence/absence assertions
+    // cases: asserts not related to presence/absence
+    'expect(element).toBeDisabled()',
+    'expect(element).toBeEnabled()',
+
+    // cases: presence/absence matcher not related to assert
+    'element.toBeInTheDocument()',
+    'element.not.toBeInTheDocument()',
+
+    // cases: weird scenarios to check guard against parent nodes
+    'expect(element).not()',
+    'expect(element).not()',
+
     // Test Cases for Queries and Aggressive Queries Reporting
     {
       code: `
@@ -360,6 +373,36 @@ ruleTester.run(RULE_NAME, rule, {
       const utils = render();
       `,
       errors: [{ line: 7, column: 21, messageId: 'fakeError' }],
+    },
+
+    // Test Cases for presence/absence assertions
+    {
+      code: `
+      // case: presence matcher .toBeInTheDocument forced to be reported
+      expect(element).toBeInTheDocument()
+      `,
+      errors: [{ line: 3, column: 7, messageId: 'presenceAssertError' }],
+    },
+    {
+      code: `
+      // case: absence matcher .not.toBeInTheDocument forced to be reported
+      expect(element).not.toBeInTheDocument()
+      `,
+      errors: [{ line: 3, column: 7, messageId: 'absenceAssertError' }],
+    },
+    {
+      code: `
+      // case: presence matcher .not.toBeNull forced to be reported
+      expect(element).not.toBeNull()
+      `,
+      errors: [{ line: 3, column: 7, messageId: 'presenceAssertError' }],
+    },
+    {
+      code: `
+      // case: absence matcher .toBeNull forced to be reported
+      expect(element).toBeNull()
+      `,
+      errors: [{ line: 3, column: 7, messageId: 'absenceAssertError' }],
     },
 
     // Test Cases for Queries and Aggressive Queries Reporting

--- a/tests/create-testing-library-rule.test.ts
+++ b/tests/create-testing-library-rule.test.ts
@@ -89,6 +89,89 @@ ruleTester.run(RULE_NAME, rule, {
       import { foo } from 'custom-module-forced-report'
     `,
     },
+
+    // Test Cases for all settings mixed
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+        'testing-library/filename-pattern': 'testing-library\\.js',
+      },
+      code: `
+      // case: matching custom settings partially - module but not filename
+      import { render } from 'test-utils'
+      import { somethingElse } from 'another-module'
+      const foo = require('bar')
+      
+      const utils = render();
+      `,
+    },
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+        'testing-library/filename-pattern': 'testing-library\\.js',
+      },
+      filename: 'MyComponent.testing-library.js',
+      code: `
+      // case: matching custom settings partially - filename but not module
+      import { render } from 'other-utils'
+      import { somethingElse } from 'another-module'
+      const foo = require('bar')
+      
+      const utils = render();
+      `,
+    },
+
+    // Test Cases for Queries and Aggressive Queries Reporting
+    {
+      code: `
+      // case: custom method not matching "getBy*" variant pattern
+      getSomeElement('button')
+    `,
+    },
+    {
+      code: `
+      // case: custom method not matching "queryBy*" variant pattern
+      querySomeElement('button')
+    `,
+    },
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+      // case: built-in "getBy*" query not reported because custom module not imported
+      import { render } from 'other-module'
+      getByRole('button')
+    `,
+    },
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+      // case: built-in "queryBy*" query not reported because custom module not imported
+      import { render } from 'other-module'
+      queryByRole('button')
+    `,
+    },
+    {
+      settings: {
+        'testing-library/filename-pattern': 'testing-library\\.js',
+      },
+      code: `
+      // case: built-in "getBy*" query not reported because custom filename doesn't match
+      getByRole('button')
+    `,
+    },
+    {
+      settings: {
+        'testing-library/filename-pattern': 'testing-library\\.js',
+      },
+      code: `
+      // case: built-in "queryBy*" query not reported because custom filename doesn't match
+      queryByRole('button')
+    `,
+    },
   ],
   invalid: [
     // Test Cases for Imports & Filename
@@ -259,6 +342,136 @@ ruleTester.run(RULE_NAME, rule, {
       import { foo } from 'custom-module-forced-report'
     `,
       errors: [{ line: 3, column: 7, messageId: 'fakeError' }],
+    },
+
+    // Test Cases for all settings mixed
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+        'testing-library/filename-pattern': 'testing-library\\.js',
+      },
+      filename: 'MyComponent.testing-library.js',
+      code: `
+      // case: matching all custom settings
+      import { render } from 'test-utils'
+      import { somethingElse } from 'another-module'
+      const foo = require('bar')
+      
+      const utils = render();
+      `,
+      errors: [{ line: 7, column: 21, messageId: 'fakeError' }],
+    },
+
+    // Test Cases for Queries and Aggressive Queries Reporting
+    {
+      code: `
+      // case: built-in "getBy*" query reported without import (aggressive reporting)
+      getByRole('button')
+    `,
+      errors: [{ line: 3, column: 7, messageId: 'getByError' }],
+    },
+    {
+      code: `
+      // case: built-in "queryBy*" query reported without import (aggressive reporting)
+      queryByRole('button')
+    `,
+      errors: [{ line: 3, column: 7, messageId: 'queryByError' }],
+    },
+    {
+      filename: 'MyComponent.spec.js',
+      code: `
+      // case: custom "getBy*" query reported without import (aggressive reporting)
+      getByIcon('search')
+    `,
+      errors: [{ line: 3, column: 7, messageId: 'getByError' }],
+    },
+    {
+      code: `
+      // case: custom "queryBy*" query reported without import (aggressive reporting)
+      queryByIcon('search')
+    `,
+      errors: [{ line: 3, column: 7, messageId: 'queryByError' }],
+    },
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+      // case: built-in "getBy*" query reported with custom module + Testing Library package import
+      import { render } from '@testing-library/react'
+      getByRole('button')
+    `,
+      errors: [{ line: 4, column: 7, messageId: 'getByError' }],
+    },
+    {
+      filename: 'MyComponent.spec.js',
+      code: `
+      // case: built-in "queryBy*" query reported with custom module + Testing Library package import
+      import { render } from '@testing-library/framework'
+      queryByRole('button')
+    `,
+      errors: [{ line: 4, column: 7, messageId: 'queryByError' }],
+    },
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+      // case: built-in "getBy*" query reported with custom module + custom module import
+      import { render } from 'test-utils'
+      getByRole('button')
+    `,
+      errors: [{ line: 4, column: 7, messageId: 'getByError' }],
+    },
+    {
+      filename: 'MyComponent.spec.js',
+      code: `
+      // case: built-in "queryBy*" query reported with custom module + custom module import
+      import { render } from 'test-utils'
+      queryByRole('button')
+    `,
+      errors: [{ line: 4, column: 7, messageId: 'queryByError' }],
+    },
+
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+      // case: custom "getBy*" query reported with custom module + Testing Library package import
+      import { render } from '@testing-library/react'
+      getByIcon('search')
+    `,
+      errors: [{ line: 4, column: 7, messageId: 'getByError' }],
+    },
+    {
+      filename: 'MyComponent.spec.js',
+      code: `
+      // case: custom "queryBy*" query reported with custom module + Testing Library package import
+      import { render } from '@testing-library/framework'
+      queryByIcon('search')
+    `,
+      errors: [{ line: 4, column: 7, messageId: 'queryByError' }],
+    },
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+      // case: custom "getBy*" query reported with custom module + custom module import
+      import { render } from 'test-utils'
+      getByIcon('search')
+    `,
+      errors: [{ line: 4, column: 7, messageId: 'getByError' }],
+    },
+    {
+      filename: 'MyComponent.spec.js',
+      code: `
+      // case: custom "queryBy*" query reported with custom module + custom module import
+      import { render } from 'test-utils'
+      queryByIcon('search')
+    `,
+      errors: [{ line: 4, column: 7, messageId: 'queryByError' }],
     },
   ],
 });

--- a/tests/lib/rules/prefer-presence-queries.test.ts
+++ b/tests/lib/rules/prefer-presence-queries.test.ts
@@ -374,27 +374,27 @@ ruleTester.run(RULE_NAME, rule, {
         getInvalidAssertion({
           query: queryName,
           matcher: '.toBeNull()',
-          messageId: 'absenceQuery',
+          messageId: 'wrongAbsenceQuery',
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.toBeFalsy()',
-          messageId: 'absenceQuery',
+          messageId: 'wrongAbsenceQuery',
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.not.toBeInTheDocument()',
-          messageId: 'absenceQuery',
+          messageId: 'wrongAbsenceQuery',
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.not.toBeTruthy()',
-          messageId: 'absenceQuery',
+          messageId: 'wrongAbsenceQuery',
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.not.toBeDefined()',
-          messageId: 'absenceQuery',
+          messageId: 'wrongAbsenceQuery',
         }),
       ],
       []
@@ -406,31 +406,31 @@ ruleTester.run(RULE_NAME, rule, {
         getInvalidAssertion({
           query: queryName,
           matcher: '.toBeNull()',
-          messageId: 'absenceQuery',
+          messageId: 'wrongAbsenceQuery',
           shouldUseScreen: true,
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.toBeFalsy()',
-          messageId: 'absenceQuery',
+          messageId: 'wrongAbsenceQuery',
           shouldUseScreen: true,
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.not.toBeInTheDocument()',
-          messageId: 'absenceQuery',
+          messageId: 'wrongAbsenceQuery',
           shouldUseScreen: true,
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.not.toBeTruthy()',
-          messageId: 'absenceQuery',
+          messageId: 'wrongAbsenceQuery',
           shouldUseScreen: true,
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.not.toBeDefined()',
-          messageId: 'absenceQuery',
+          messageId: 'wrongAbsenceQuery',
           shouldUseScreen: true,
         }),
       ],
@@ -443,27 +443,27 @@ ruleTester.run(RULE_NAME, rule, {
         getInvalidAssertion({
           query: queryName,
           matcher: '.toBeNull()',
-          messageId: 'absenceQuery',
+          messageId: 'wrongAbsenceQuery',
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.toBeFalsy()',
-          messageId: 'absenceQuery',
+          messageId: 'wrongAbsenceQuery',
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.not.toBeInTheDocument()',
-          messageId: 'absenceQuery',
+          messageId: 'wrongAbsenceQuery',
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.not.toBeTruthy()',
-          messageId: 'absenceQuery',
+          messageId: 'wrongAbsenceQuery',
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.not.toBeDefined()',
-          messageId: 'absenceQuery',
+          messageId: 'wrongAbsenceQuery',
         }),
       ],
       []
@@ -475,31 +475,31 @@ ruleTester.run(RULE_NAME, rule, {
         getInvalidAssertion({
           query: queryName,
           matcher: '.toBeNull()',
-          messageId: 'absenceQuery',
+          messageId: 'wrongAbsenceQuery',
           shouldUseScreen: true,
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.toBeFalsy()',
-          messageId: 'absenceQuery',
+          messageId: 'wrongAbsenceQuery',
           shouldUseScreen: true,
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.not.toBeInTheDocument()',
-          messageId: 'absenceQuery',
+          messageId: 'wrongAbsenceQuery',
           shouldUseScreen: true,
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.not.toBeTruthy()',
-          messageId: 'absenceQuery',
+          messageId: 'wrongAbsenceQuery',
           shouldUseScreen: true,
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.not.toBeDefined()',
-          messageId: 'absenceQuery',
+          messageId: 'wrongAbsenceQuery',
           shouldUseScreen: true,
         }),
       ],
@@ -512,27 +512,27 @@ ruleTester.run(RULE_NAME, rule, {
         getInvalidAssertion({
           query: queryName,
           matcher: '.toBeTruthy()',
-          messageId: 'presenceQuery',
+          messageId: 'wrongPresenceQuery',
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.toBeDefined()',
-          messageId: 'presenceQuery',
+          messageId: 'wrongPresenceQuery',
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.toBeInTheDocument()',
-          messageId: 'presenceQuery',
+          messageId: 'wrongPresenceQuery',
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.not.toBeFalsy()',
-          messageId: 'presenceQuery',
+          messageId: 'wrongPresenceQuery',
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.not.toBeNull()',
-          messageId: 'presenceQuery',
+          messageId: 'wrongPresenceQuery',
         }),
       ],
       []
@@ -544,31 +544,31 @@ ruleTester.run(RULE_NAME, rule, {
         getInvalidAssertion({
           query: queryName,
           matcher: '.toBeTruthy()',
-          messageId: 'presenceQuery',
+          messageId: 'wrongPresenceQuery',
           shouldUseScreen: true,
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.toBeDefined()',
-          messageId: 'presenceQuery',
+          messageId: 'wrongPresenceQuery',
           shouldUseScreen: true,
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.toBeInTheDocument()',
-          messageId: 'presenceQuery',
+          messageId: 'wrongPresenceQuery',
           shouldUseScreen: true,
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.not.toBeFalsy()',
-          messageId: 'presenceQuery',
+          messageId: 'wrongPresenceQuery',
           shouldUseScreen: true,
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.not.toBeNull()',
-          messageId: 'presenceQuery',
+          messageId: 'wrongPresenceQuery',
           shouldUseScreen: true,
         }),
       ],
@@ -581,27 +581,27 @@ ruleTester.run(RULE_NAME, rule, {
         getInvalidAssertion({
           query: queryName,
           matcher: '.toBeTruthy()',
-          messageId: 'presenceQuery',
+          messageId: 'wrongPresenceQuery',
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.toBeDefined()',
-          messageId: 'presenceQuery',
+          messageId: 'wrongPresenceQuery',
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.toBeInTheDocument()',
-          messageId: 'presenceQuery',
+          messageId: 'wrongPresenceQuery',
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.not.toBeFalsy()',
-          messageId: 'presenceQuery',
+          messageId: 'wrongPresenceQuery',
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.not.toBeNull()',
-          messageId: 'presenceQuery',
+          messageId: 'wrongPresenceQuery',
         }),
       ],
       []
@@ -613,31 +613,31 @@ ruleTester.run(RULE_NAME, rule, {
         getInvalidAssertion({
           query: queryName,
           matcher: '.toBeTruthy()',
-          messageId: 'presenceQuery',
+          messageId: 'wrongPresenceQuery',
           shouldUseScreen: true,
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.toBeDefined()',
-          messageId: 'presenceQuery',
+          messageId: 'wrongPresenceQuery',
           shouldUseScreen: true,
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.toBeInTheDocument()',
-          messageId: 'presenceQuery',
+          messageId: 'wrongPresenceQuery',
           shouldUseScreen: true,
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.not.toBeFalsy()',
-          messageId: 'presenceQuery',
+          messageId: 'wrongPresenceQuery',
           shouldUseScreen: true,
         }),
         getInvalidAssertion({
           query: queryName,
           matcher: '.not.toBeNull()',
-          messageId: 'presenceQuery',
+          messageId: 'wrongPresenceQuery',
           shouldUseScreen: true,
         }),
       ],
@@ -645,25 +645,25 @@ ruleTester.run(RULE_NAME, rule, {
     ),
     {
       code: 'expect(screen.getAllByText("button")[1]).not.toBeInTheDocument()',
-      errors: [{ messageId: 'absenceQuery', line: 1, column: 15 }],
+      errors: [{ messageId: 'wrongAbsenceQuery', line: 1, column: 15 }],
     },
     {
       code: 'expect(screen.queryAllByText("button")[1]).toBeInTheDocument()',
-      errors: [{ messageId: 'presenceQuery', line: 1, column: 15 }],
+      errors: [{ messageId: 'wrongPresenceQuery', line: 1, column: 15 }],
     },
     {
       code: `
       // case: asserting presence incorrectly with custom queryBy* query
         expect(queryByCustomQuery("button")).toBeInTheDocument()
       `,
-      errors: [{ messageId: 'presenceQuery', line: 3, column: 16 }],
+      errors: [{ messageId: 'wrongPresenceQuery', line: 3, column: 16 }],
     },
     {
       code: `
         // case: asserting absence incorrectly with custom getBy* query
         expect(getByCustomQuery("button")).not.toBeInTheDocument()
       `,
-      errors: [{ messageId: 'absenceQuery', line: 3, column: 16 }],
+      errors: [{ messageId: 'wrongAbsenceQuery', line: 3, column: 16 }],
     },
     // TODO: add more tests for importing custom module
   ],

--- a/tests/lib/rules/prefer-presence-queries.test.ts
+++ b/tests/lib/rules/prefer-presence-queries.test.ts
@@ -665,6 +665,27 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [{ messageId: 'wrongAbsenceQuery', line: 3, column: 16 }],
     },
-    // TODO: add more tests for importing custom module
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+      // case: asserting presence incorrectly importing custom module
+      import 'test-utils'
+      expect(queryByRole("button")).toBeInTheDocument()
+      `,
+      errors: [{ line: 4, column: 14, messageId: 'wrongPresenceQuery' }],
+    },
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+      // case: asserting absence incorrectly importing custom module
+      import 'test-utils'
+      expect(getByRole("button")).not.toBeInTheDocument()
+      `,
+      errors: [{ line: 4, column: 14, messageId: 'wrongAbsenceQuery' }],
+    },
   ],
 });

--- a/tests/lib/rules/prefer-presence-queries.test.ts
+++ b/tests/lib/rules/prefer-presence-queries.test.ts
@@ -347,28 +347,24 @@ ruleTester.run(RULE_NAME, rule, {
       code: 'const el = queryByText("button")',
     },
     {
-      // TODO: this one is gonna be reported by aggressive query reporting
-      code:
-        'expect(getByNonTestingLibraryQuery("button")).not.toBeInTheDocument()',
-    },
-    {
-      // TODO: this one is gonna be reported by aggressive query reporting
-      code:
-        'expect(queryByNonTestingLibraryQuery("button")).toBeInTheDocument()',
-    },
-    {
       code: `async () => {
         const el = await findByText('button')
         expect(el).toBeInTheDocument()
       }`,
     },
+    `// case: query an element with getBy but then check its absence after doing
+     // some action which makes it disappear.
+
+     // submit button exists
+     const submitButton = screen.getByRole('button')
+     fireEvent.click(submitButton)
+    
+     // right after clicking submit button it disappears
+     expect(submitButton).not.toBeInTheDocument()
+    `,
     // some weird examples after here to check guard against parent nodes
-    {
-      code: 'expect(getByText("button")).not()',
-    },
-    {
-      code: 'expect(queryByText("button")).not()',
-    },
+    'expect(getByText("button")).not()',
+    'expect(queryByText("button")).not()',
   ],
   invalid: [
     // cases: asserting absence incorrectly with `getBy*` queries
@@ -655,7 +651,20 @@ ruleTester.run(RULE_NAME, rule, {
       code: 'expect(screen.queryAllByText("button")[1]).toBeInTheDocument()',
       errors: [{ messageId: 'presenceQuery', line: 1, column: 15 }],
     },
-    // TODO: add more tests for using custom queries
+    {
+      code: `
+      // case: asserting presence incorrectly with custom queryBy* query
+        expect(queryByCustomQuery("button")).toBeInTheDocument()
+      `,
+      errors: [{ messageId: 'presenceQuery', line: 3, column: 16 }],
+    },
+    {
+      code: `
+        // case: asserting absence incorrectly with custom getBy* query
+        expect(getByCustomQuery("button")).not.toBeInTheDocument()
+      `,
+      errors: [{ messageId: 'absenceQuery', line: 3, column: 16 }],
+    },
     // TODO: add more tests for importing custom module
   ],
 });

--- a/tests/lib/rules/prefer-presence-queries.test.ts
+++ b/tests/lib/rules/prefer-presence-queries.test.ts
@@ -14,83 +14,329 @@ const queryAllByQueries = ALL_QUERIES_METHODS.map(
   (method) => `queryAll${method}`
 );
 
-const allQueryUseInAssertion = (queryName: string) => [
-  queryName,
-  `screen.${queryName}`,
-];
+type AssertionFnParams = {
+  query: string;
+  matcher: string;
+  messageId: MessageIds;
+  shouldUseScreen?: boolean;
+};
 
-const getValidAssertion = (query: string, matcher: string) =>
-  allQueryUseInAssertion(query).map((query) => ({
-    code: `expect(${query}('Hello'))${matcher}`,
-  }));
+const getValidAssertion = ({
+  query,
+  matcher,
+  shouldUseScreen = false,
+}: Omit<AssertionFnParams, 'messageId'>) => {
+  const finalQuery = shouldUseScreen ? `screen.${query}` : query;
+  return {
+    code: `expect(${finalQuery}('Hello'))${matcher}`,
+  };
+};
 
-const getInvalidAssertion = (
-  query: string,
-  matcher: string,
-  messageId: MessageIds
-) =>
-  allQueryUseInAssertion(query).map((query) => ({
-    code: `expect(${query}('Hello'))${matcher}`,
-    // TODO: column can't be checked as queries are generated with and without `screen` prefix
-    //  so this must be generated in a different way to be able to check error column.
-    errors: [{ messageId, line: 1 }],
-  }));
+const getInvalidAssertion = ({
+  query,
+  matcher,
+  messageId,
+  shouldUseScreen = false,
+}: AssertionFnParams) => {
+  const finalQuery = shouldUseScreen ? `screen.${query}` : query;
+  return {
+    code: `expect(${finalQuery}('Hello'))${matcher}`,
+    errors: [{ messageId, line: 1, column: shouldUseScreen ? 15 : 8 }],
+  };
+};
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
+    // cases: methods not matching Testing Library queries pattern
+    `expect(queryElement('foo')).toBeInTheDocument()`,
+    `expect(getElement('foo')).not.toBeInTheDocument()`,
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+        // case: invalid presence assert but not reported because custom module is not imported
+        expect(queryByRole('button')).toBeInTheDocument()
+      `,
+    },
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+        // case: invalid absence assert but not reported because custom module is not imported
+        expect(getByRole('button')).not.toBeInTheDocument()
+      `,
+    },
+    // cases: asserting presence correctly with `getBy*` queries
     ...getByQueries.reduce(
       (validRules, queryName) => [
         ...validRules,
-        ...getValidAssertion(queryName, '.toBeInTheDocument()'),
-        ...getValidAssertion(queryName, '.toBeTruthy()'),
-        ...getValidAssertion(queryName, '.toBeDefined()'),
-        ...getValidAssertion(queryName, '.toBe("foo")'),
-        ...getValidAssertion(queryName, '.toEqual("World")'),
-        ...getValidAssertion(queryName, '.not.toBeFalsy()'),
-        ...getValidAssertion(queryName, '.not.toBeNull()'),
-        ...getValidAssertion(queryName, '.not.toBeDisabled()'),
-        ...getValidAssertion(queryName, '.not.toHaveClass("btn")'),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.toBeInTheDocument()',
+        }),
+        getValidAssertion({ query: queryName, matcher: '.toBeTruthy()' }),
+        getValidAssertion({ query: queryName, matcher: '.toBeDefined()' }),
+        getValidAssertion({ query: queryName, matcher: '.toBe("foo")' }),
+        getValidAssertion({ query: queryName, matcher: '.toEqual("World")' }),
+        getValidAssertion({ query: queryName, matcher: '.not.toBeFalsy()' }),
+        getValidAssertion({ query: queryName, matcher: '.not.toBeNull()' }),
+        getValidAssertion({ query: queryName, matcher: '.not.toBeDisabled()' }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.not.toHaveClass("btn")',
+        }),
       ],
       []
     ),
+    // cases: asserting presence correctly with `screen.getBy*` queries
+    ...getByQueries.reduce(
+      (validRules, queryName) => [
+        ...validRules,
+        getValidAssertion({
+          query: queryName,
+          matcher: '.toBeInTheDocument()',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.toBeTruthy()',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.toBeDefined()',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.toBe("foo")',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.toEqual("World")',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.not.toBeFalsy()',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.not.toBeNull()',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.not.toBeDisabled()',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.not.toHaveClass("btn")',
+          shouldUseScreen: true,
+        }),
+      ],
+      []
+    ),
+    // cases: asserting presence correctly with `getAllBy*` queries
     ...getAllByQueries.reduce(
       (validRules, queryName) => [
         ...validRules,
-        ...getValidAssertion(queryName, '.toBeInTheDocument()'),
-        ...getValidAssertion(queryName, '.toBeTruthy()'),
-        ...getValidAssertion(queryName, '.toBeDefined()'),
-        ...getValidAssertion(queryName, '.toBe("foo")'),
-        ...getValidAssertion(queryName, '.toEqual("World")'),
-        ...getValidAssertion(queryName, '.not.toBeFalsy()'),
-        ...getValidAssertion(queryName, '.not.toBeNull()'),
-        ...getValidAssertion(queryName, '.not.toBeDisabled()'),
-        ...getValidAssertion(queryName, '.not.toHaveClass("btn")'),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.toBeInTheDocument()',
+        }),
+        getValidAssertion({ query: queryName, matcher: '.toBeTruthy()' }),
+        getValidAssertion({ query: queryName, matcher: '.toBeDefined()' }),
+        getValidAssertion({ query: queryName, matcher: '.toBe("foo")' }),
+        getValidAssertion({ query: queryName, matcher: '.toEqual("World")' }),
+        getValidAssertion({ query: queryName, matcher: '.not.toBeFalsy()' }),
+        getValidAssertion({ query: queryName, matcher: '.not.toBeNull()' }),
+        getValidAssertion({ query: queryName, matcher: '.not.toBeDisabled()' }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.not.toHaveClass("btn")',
+        }),
       ],
       []
     ),
+    // cases: asserting presence correctly with `screen.getAllBy*` queries
+    ...getAllByQueries.reduce(
+      (validRules, queryName) => [
+        ...validRules,
+        getValidAssertion({
+          query: queryName,
+          matcher: '.toBeInTheDocument()',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.toBeTruthy()',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.toBeDefined()',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.toBe("foo")',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.toEqual("World")',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.not.toBeFalsy()',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.not.toBeNull()',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.not.toBeDisabled()',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.not.toHaveClass("btn")',
+          shouldUseScreen: true,
+        }),
+      ],
+      []
+    ),
+    // cases: asserting absence correctly with `queryBy*` queries
     ...queryByQueries.reduce(
       (validRules, queryName) => [
         ...validRules,
-        ...getValidAssertion(queryName, '.toBeNull()'),
-        ...getValidAssertion(queryName, '.toBeFalsy()'),
-        ...getValidAssertion(queryName, '.not.toBeInTheDocument()'),
-        ...getValidAssertion(queryName, '.not.toBeTruthy()'),
-        ...getValidAssertion(queryName, '.not.toBeDefined()'),
-        ...getValidAssertion(queryName, '.toEqual("World")'),
-        ...getValidAssertion(queryName, '.not.toHaveClass("btn")'),
+        getValidAssertion({ query: queryName, matcher: '.toBeNull()' }),
+        getValidAssertion({ query: queryName, matcher: '.toBeFalsy()' }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.not.toBeInTheDocument()',
+        }),
+        getValidAssertion({ query: queryName, matcher: '.not.toBeTruthy()' }),
+        getValidAssertion({ query: queryName, matcher: '.not.toBeDefined()' }),
+        getValidAssertion({ query: queryName, matcher: '.toEqual("World")' }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.not.toHaveClass("btn")',
+        }),
       ],
       []
     ),
+    // cases: asserting absence correctly with `screen.queryBy*` queries
+    ...queryByQueries.reduce(
+      (validRules, queryName) => [
+        ...validRules,
+        getValidAssertion({
+          query: queryName,
+          matcher: '.toBeNull()',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.toBeFalsy()',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.not.toBeInTheDocument()',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.not.toBeTruthy()',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.not.toBeDefined()',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.toEqual("World")',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.not.toHaveClass("btn")',
+          shouldUseScreen: true,
+        }),
+      ],
+      []
+    ),
+    // cases: asserting absence correctly with `queryAllBy*` queries
     ...queryAllByQueries.reduce(
       (validRules, queryName) => [
         ...validRules,
-        ...getValidAssertion(queryName, '.toBeNull()'),
-        ...getValidAssertion(queryName, '.toBeFalsy()'),
-        ...getValidAssertion(queryName, '.not.toBeInTheDocument()'),
-        ...getValidAssertion(queryName, '.not.toBeTruthy()'),
-        ...getValidAssertion(queryName, '.not.toBeDefined()'),
-        ...getValidAssertion(queryName, '.toEqual("World")'),
-        ...getValidAssertion(queryName, '.not.toHaveClass("btn")'),
+        getValidAssertion({ query: queryName, matcher: '.toBeNull()' }),
+        getValidAssertion({ query: queryName, matcher: '.toBeFalsy()' }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.not.toBeInTheDocument()',
+        }),
+        getValidAssertion({ query: queryName, matcher: '.not.toBeTruthy()' }),
+        getValidAssertion({ query: queryName, matcher: '.not.toBeDefined()' }),
+        getValidAssertion({ query: queryName, matcher: '.toEqual("World")' }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.not.toHaveClass("btn")',
+        }),
+      ],
+      []
+    ),
+    // cases: asserting absence correctly with `screen.queryAllBy*` queries
+    ...queryAllByQueries.reduce(
+      (validRules, queryName) => [
+        ...validRules,
+        getValidAssertion({
+          query: queryName,
+          matcher: '.toBeNull()',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.toBeFalsy()',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.not.toBeInTheDocument()',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.not.toBeTruthy()',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.not.toBeDefined()',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.toEqual("World")',
+          shouldUseScreen: true,
+        }),
+        getValidAssertion({
+          query: queryName,
+          matcher: '.not.toHaveClass("btn")',
+          shouldUseScreen: true,
+        }),
       ],
       []
     ),
@@ -101,10 +347,12 @@ ruleTester.run(RULE_NAME, rule, {
       code: 'const el = queryByText("button")',
     },
     {
+      // TODO: this one is gonna be reported by aggressive query reporting
       code:
         'expect(getByNonTestingLibraryQuery("button")).not.toBeInTheDocument()',
     },
     {
+      // TODO: this one is gonna be reported by aggressive query reporting
       code:
         'expect(queryByNonTestingLibraryQuery("button")).toBeInTheDocument()',
     },
@@ -123,76 +371,291 @@ ruleTester.run(RULE_NAME, rule, {
     },
   ],
   invalid: [
+    // cases: asserting absence incorrectly with `getBy*` queries
     ...getByQueries.reduce(
       (invalidRules, queryName) => [
         ...invalidRules,
-        ...getInvalidAssertion(queryName, '.toBeNull()', 'absenceQuery'),
-        ...getInvalidAssertion(queryName, '.toBeFalsy()', 'absenceQuery'),
-        ...getInvalidAssertion(
-          queryName,
-          '.not.toBeInTheDocument()',
-          'absenceQuery'
-        ),
-        ...getInvalidAssertion(queryName, '.not.toBeTruthy()', 'absenceQuery'),
-        ...getInvalidAssertion(queryName, '.not.toBeDefined()', 'absenceQuery'),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.toBeNull()',
+          messageId: 'absenceQuery',
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.toBeFalsy()',
+          messageId: 'absenceQuery',
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.not.toBeInTheDocument()',
+          messageId: 'absenceQuery',
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.not.toBeTruthy()',
+          messageId: 'absenceQuery',
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.not.toBeDefined()',
+          messageId: 'absenceQuery',
+        }),
       ],
       []
     ),
+    // cases: asserting absence incorrectly with `screen.getBy*` queries
+    ...getByQueries.reduce(
+      (invalidRules, queryName) => [
+        ...invalidRules,
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.toBeNull()',
+          messageId: 'absenceQuery',
+          shouldUseScreen: true,
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.toBeFalsy()',
+          messageId: 'absenceQuery',
+          shouldUseScreen: true,
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.not.toBeInTheDocument()',
+          messageId: 'absenceQuery',
+          shouldUseScreen: true,
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.not.toBeTruthy()',
+          messageId: 'absenceQuery',
+          shouldUseScreen: true,
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.not.toBeDefined()',
+          messageId: 'absenceQuery',
+          shouldUseScreen: true,
+        }),
+      ],
+      []
+    ),
+    // cases: asserting absence incorrectly with `getAllBy*` queries
     ...getAllByQueries.reduce(
       (invalidRules, queryName) => [
         ...invalidRules,
-        ...getInvalidAssertion(queryName, '.toBeNull()', 'absenceQuery'),
-        ...getInvalidAssertion(queryName, '.toBeFalsy()', 'absenceQuery'),
-        ...getInvalidAssertion(
-          queryName,
-          '.not.toBeInTheDocument()',
-          'absenceQuery'
-        ),
-        ...getInvalidAssertion(queryName, '.not.toBeTruthy()', 'absenceQuery'),
-        ...getInvalidAssertion(queryName, '.not.toBeDefined()', 'absenceQuery'),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.toBeNull()',
+          messageId: 'absenceQuery',
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.toBeFalsy()',
+          messageId: 'absenceQuery',
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.not.toBeInTheDocument()',
+          messageId: 'absenceQuery',
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.not.toBeTruthy()',
+          messageId: 'absenceQuery',
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.not.toBeDefined()',
+          messageId: 'absenceQuery',
+        }),
       ],
       []
     ),
-    {
-      // TODO: improve this case to get error on `queryAllByText` rather than `screen`
-      code: 'expect(screen.getAllByText("button")[1]).not.toBeInTheDocument()',
-      errors: [{ messageId: 'absenceQuery', line: 1, column: 15 }],
-    },
+    // cases: asserting absence incorrectly with `screen.getAllBy*` queries
+    ...getAllByQueries.reduce(
+      (invalidRules, queryName) => [
+        ...invalidRules,
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.toBeNull()',
+          messageId: 'absenceQuery',
+          shouldUseScreen: true,
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.toBeFalsy()',
+          messageId: 'absenceQuery',
+          shouldUseScreen: true,
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.not.toBeInTheDocument()',
+          messageId: 'absenceQuery',
+          shouldUseScreen: true,
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.not.toBeTruthy()',
+          messageId: 'absenceQuery',
+          shouldUseScreen: true,
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.not.toBeDefined()',
+          messageId: 'absenceQuery',
+          shouldUseScreen: true,
+        }),
+      ],
+      []
+    ),
+    // cases: asserting presence incorrectly with `queryBy*` queries
     ...queryByQueries.reduce(
       (validRules, queryName) => [
         ...validRules,
-        ...getInvalidAssertion(queryName, '.toBeTruthy()', 'presenceQuery'),
-        ...getInvalidAssertion(queryName, '.toBeDefined()', 'presenceQuery'),
-        ...getInvalidAssertion(
-          queryName,
-          '.toBeInTheDocument()',
-          'presenceQuery'
-        ),
-        ...getInvalidAssertion(queryName, '.not.toBeFalsy()', 'presenceQuery'),
-        ...getInvalidAssertion(queryName, '.not.toBeNull()', 'presenceQuery'),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.toBeTruthy()',
+          messageId: 'presenceQuery',
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.toBeDefined()',
+          messageId: 'presenceQuery',
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.toBeInTheDocument()',
+          messageId: 'presenceQuery',
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.not.toBeFalsy()',
+          messageId: 'presenceQuery',
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.not.toBeNull()',
+          messageId: 'presenceQuery',
+        }),
       ],
       []
     ),
+    // cases: asserting presence incorrectly with `screen.queryBy*` queries
+    ...queryByQueries.reduce(
+      (validRules, queryName) => [
+        ...validRules,
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.toBeTruthy()',
+          messageId: 'presenceQuery',
+          shouldUseScreen: true,
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.toBeDefined()',
+          messageId: 'presenceQuery',
+          shouldUseScreen: true,
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.toBeInTheDocument()',
+          messageId: 'presenceQuery',
+          shouldUseScreen: true,
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.not.toBeFalsy()',
+          messageId: 'presenceQuery',
+          shouldUseScreen: true,
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.not.toBeNull()',
+          messageId: 'presenceQuery',
+          shouldUseScreen: true,
+        }),
+      ],
+      []
+    ),
+    // cases: asserting presence incorrectly with `queryAllBy*` queries
     ...queryAllByQueries.reduce(
       (validRules, queryName) => [
         ...validRules,
-        ...getInvalidAssertion(queryName, '.toBeTruthy()', 'presenceQuery'),
-        ...getInvalidAssertion(queryName, '.toBeDefined()', 'presenceQuery'),
-        ...getInvalidAssertion(
-          queryName,
-          '.toBeInTheDocument()',
-          'presenceQuery'
-        ),
-        ...getInvalidAssertion(queryName, '.not.toBeFalsy()', 'presenceQuery'),
-        ...getInvalidAssertion(queryName, '.not.toBeNull()', 'presenceQuery'),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.toBeTruthy()',
+          messageId: 'presenceQuery',
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.toBeDefined()',
+          messageId: 'presenceQuery',
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.toBeInTheDocument()',
+          messageId: 'presenceQuery',
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.not.toBeFalsy()',
+          messageId: 'presenceQuery',
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.not.toBeNull()',
+          messageId: 'presenceQuery',
+        }),
+      ],
+      []
+    ),
+    // cases: asserting presence incorrectly with `screen.queryAllBy*` queries
+    ...queryAllByQueries.reduce(
+      (validRules, queryName) => [
+        ...validRules,
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.toBeTruthy()',
+          messageId: 'presenceQuery',
+          shouldUseScreen: true,
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.toBeDefined()',
+          messageId: 'presenceQuery',
+          shouldUseScreen: true,
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.toBeInTheDocument()',
+          messageId: 'presenceQuery',
+          shouldUseScreen: true,
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.not.toBeFalsy()',
+          messageId: 'presenceQuery',
+          shouldUseScreen: true,
+        }),
+        getInvalidAssertion({
+          query: queryName,
+          matcher: '.not.toBeNull()',
+          messageId: 'presenceQuery',
+          shouldUseScreen: true,
+        }),
       ],
       []
     ),
     {
-      // TODO: improve this case to get error on `queryAllByText` rather than `screen`
+      code: 'expect(screen.getAllByText("button")[1]).not.toBeInTheDocument()',
+      errors: [{ messageId: 'absenceQuery', line: 1, column: 15 }],
+    },
+    {
       code: 'expect(screen.queryAllByText("button")[1]).toBeInTheDocument()',
       errors: [{ messageId: 'presenceQuery', line: 1, column: 15 }],
     },
-    // TODO: add more tests for custom queries
+    // TODO: add more tests for using custom queries
+    // TODO: add more tests for importing custom module
   ],
 });

--- a/tests/lib/rules/prefer-presence-queries.test.ts
+++ b/tests/lib/rules/prefer-presence-queries.test.ts
@@ -362,9 +362,6 @@ ruleTester.run(RULE_NAME, rule, {
      // right after clicking submit button it disappears
      expect(submitButton).not.toBeInTheDocument()
     `,
-    // some weird examples after here to check guard against parent nodes
-    'expect(getByText("button")).not()',
-    'expect(queryByText("button")).not()',
   ],
   invalid: [
     // cases: asserting absence incorrectly with `getBy*` queries

--- a/tests/lib/rules/prefer-presence-queries.test.ts
+++ b/tests/lib/rules/prefer-presence-queries.test.ts
@@ -31,7 +31,9 @@ const getInvalidAssertion = (
 ) =>
   allQueryUseInAssertion(query).map((query) => ({
     code: `expect(${query}('Hello'))${matcher}`,
-    errors: [{ messageId }],
+    // TODO: column can't be checked as queries are generated with and without `screen` prefix
+    //  so this must be generated in a different way to be able to check error column.
+    errors: [{ messageId, line: 1 }],
   }));
 
 ruleTester.run(RULE_NAME, rule, {
@@ -152,8 +154,9 @@ ruleTester.run(RULE_NAME, rule, {
       []
     ),
     {
+      // TODO: improve this case to get error on `queryAllByText` rather than `screen`
       code: 'expect(screen.getAllByText("button")[1]).not.toBeInTheDocument()',
-      errors: [{ messageId: 'absenceQuery' }],
+      errors: [{ messageId: 'absenceQuery', line: 1, column: 15 }],
     },
     ...queryByQueries.reduce(
       (validRules, queryName) => [
@@ -186,8 +189,10 @@ ruleTester.run(RULE_NAME, rule, {
       []
     ),
     {
+      // TODO: improve this case to get error on `queryAllByText` rather than `screen`
       code: 'expect(screen.queryAllByText("button")[1]).toBeInTheDocument()',
-      errors: [{ messageId: 'presenceQuery' }],
+      errors: [{ messageId: 'presenceQuery', line: 1, column: 15 }],
     },
+    // TODO: add more tests for custom queries
   ],
 });


### PR DESCRIPTION
Relates to #198 

This refactor for `prefer-presence-queries` includes:
- using custom rule creator + detection helpers
- improve existing tests to check column where the error is reported
- add new detection helpers to determine if a node corresponds to `getBy*`, `queryBy*` or sync queries
- extract detection helpers to determine if a node corresponds to presence/absence assertion