### PR TITLE
refactor: prefer-wait-for with the new settings

### DIFF
--- a/docs/rules/prefer-wait-for.md
+++ b/docs/rules/prefer-wait-for.md
@@ -17,6 +17,9 @@ Deprecated `wait` async utils are:
 Examples of **incorrect** code for this rule:
 
 ```js
+import { wait, waitForElement, waitForDomChange } from '@testing-library/dom';
+// this also works for const { wait, waitForElement, waitForDomChange } = require ('@testing-library/dom')
+
 const foo = async () => {
   await wait();
   await wait(() => {});
@@ -25,17 +28,40 @@ const foo = async () => {
   await waitForDomChange(mutationObserverOptions);
   await waitForDomChange({ timeout: 100 });
 };
+
+import * as tl from '@testing-library/dom';
+// this also works for const tl = require('@testing-library/dom')
+const foo = async () => {
+  await tl.wait();
+  await tl.wait(() => {});
+  await tl.waitForElement(() => {});
+  await tl.waitForDomChange();
+  await tl.waitForDomChange(mutationObserverOptions);
+  await tl.waitForDomChange({ timeout: 100 });
+};
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
+import { waitFor, waitForElementToBeRemoved } from '@testing-library/dom';
+// this also works for const { waitFor, waitForElementToBeRemoved } = require('@testing-library/dom')
 const foo = async () => {
   // new waitFor method
   await waitFor(() => {});
 
   // previous waitForElementToBeRemoved is not deprecated
   await waitForElementToBeRemoved(() => {});
+};
+
+import * as tl from '@testing-library/dom';
+// this also works for const tl = require('@testing-library/dom')
+const foo = async () => {
+  // new waitFor method
+  await tl.waitFor(() => {});
+
+  // previous waitForElementToBeRemoved is not deprecated
+  await tl.waitForElementToBeRemoved(() => {});
 };
 ```
 

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -5,7 +5,6 @@ import {
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
 import { RuleContext } from '@typescript-eslint/experimental-utils/dist/ts-eslint';
-import { DetectionHelpers } from './detect-testing-library-utils';
 
 export function isCallExpression(
   node: TSESTree.Node | null | undefined
@@ -292,85 +291,4 @@ export function getAssertNodeInfo(
   }
 
   return { matcher, isNegated };
-}
-
-/**
- * Returns a boolean indicating if the member expression passed as argument comes from a import clause in the provided node
- */
-function isMemberFromCallExpressionComingFromImport(
-  object: TSESTree.Identifier,
-  importNode: TSESTree.ImportDeclaration
-) {
-  return (
-    isImportDeclaration(importNode) &&
-    isImportNamespaceSpecifier(importNode.specifiers[0]) &&
-    object.name === importNode.specifiers[0].local.name
-  );
-}
-
-/**
- * Returns a boolean indicating if the member expression passed as argument comes from a require clause in the provided node
- */
-function isMemberFromCallExpressionComingFromRequire(
-  object: TSESTree.Identifier,
-  requireNode: TSESTree.CallExpression
-) {
-  return (
-    isCallExpression(requireNode) &&
-    isVariableDeclarator(requireNode.parent) &&
-    isIdentifier(requireNode.parent.id) &&
-    object.name === requireNode.parent.id.name
-  );
-}
-
-/** Returns a boolean if the MemberExpression matches the one imported from RTL in a custom/standard import/require clause */
-export function isMemberFromMethodCallFromTestingLibrary(
-  node: TSESTree.MemberExpression,
-  helpers: DetectionHelpers
-): boolean {
-  const importOrRequire =
-    helpers.getCustomModuleImportNode() ??
-    helpers.getTestingLibraryImportNode();
-  if (!isIdentifier(node.object)) {
-    return false;
-  }
-  if (isImportDeclaration(importOrRequire)) {
-    return isMemberFromCallExpressionComingFromImport(
-      node.object,
-      importOrRequire
-    );
-  }
-  return isMemberFromCallExpressionComingFromRequire(
-    node.object,
-    importOrRequire
-  );
-}
-
-export function isIdentifierInCallExpressionFromTestingLibrary(
-  node: TSESTree.Identifier,
-  helpers: DetectionHelpers
-): boolean {
-  const importOrRequire =
-    helpers.getCustomModuleImportNode() ??
-    helpers.getTestingLibraryImportNode();
-  if (!importOrRequire) {
-    return false;
-  }
-  if (isImportDeclaration(importOrRequire)) {
-    return importOrRequire.specifiers.some(
-      (s) => isImportSpecifier(s) && s.local.name === node.name
-    );
-  } else {
-    return (
-      isVariableDeclarator(importOrRequire.parent) &&
-      isObjectPattern(importOrRequire.parent.id) &&
-      importOrRequire.parent.id.properties.some(
-        (p) =>
-          isProperty(p) &&
-          isIdentifier(p.key) &&
-          isIdentifier(p.value) &&
-          p.value.name === node.name
-      )
-    );
-  }
 }

--- a/lib/rules/prefer-wait-for.ts
+++ b/lib/rules/prefer-wait-for.ts
@@ -9,8 +9,6 @@ import {
   isImportNamespaceSpecifier,
   isObjectPattern,
   isProperty,
-  isMemberFromMethodCallFromTestingLibrary,
-  isIdentifierInCallExpressionFromTestingLibrary,
 } from '../node-utils';
 
 export const RULE_NAME = 'prefer-wait-for';
@@ -158,7 +156,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
           // the method does not match a deprecated method
           return;
         }
-        if (!isMemberFromMethodCallFromTestingLibrary(node, helpers)) {
+        if (!helpers.isNodeComingFromTestingLibrary(node)) {
           // the method does not match from the imported elements from TL (even from custom)
           return;
         }
@@ -170,7 +168,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
           return;
         }
 
-        if (!isIdentifierInCallExpressionFromTestingLibrary(node, helpers)) {
+        if (!helpers.isNodeComingFromTestingLibrary(node)) {
           return;
         }
         addWaitFor = true;

--- a/tests/create-testing-library-rule.test.ts
+++ b/tests/create-testing-library-rule.test.ts
@@ -185,6 +185,16 @@ ruleTester.run(RULE_NAME, rule, {
       queryByRole('button')
     `,
     },
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+        import * as tl from 'test-utils'
+        const obj = { tl }
+        obj.tl.waitFor(() => {})
+      `,
+    },
   ],
   invalid: [
     // Test Cases for Imports & Filename
@@ -515,6 +525,16 @@ ruleTester.run(RULE_NAME, rule, {
       queryByIcon('search')
     `,
       errors: [{ line: 4, column: 7, messageId: 'queryByError' }],
+    },
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `
+        import * as tl from 'test-utils'
+        tl.waitFor(() => {})
+      `,
+      errors: [{ line: 3, column: 9, messageId: 'fakeError' }],
     },
   ],
 });

--- a/tests/fake-rule.ts
+++ b/tests/fake-rule.ts
@@ -73,6 +73,12 @@ export default createTestingLibraryRule<Options, MessageIds>({
     return {
       'CallExpression Identifier': reportCallExpressionIdentifier,
       MemberExpression: reportMemberExpression,
+      'CallExpression > MemberExpression'(node: TSESTree.MemberExpression) {
+        if (!helpers.isNodeComingFromTestingLibrary(node)) {
+          return;
+        }
+        context.report({ node, messageId: 'fakeError' });
+      },
       ImportDeclaration: reportImportDeclaration,
       'Program:exit'() {
         const importNode = helpers.getCustomModuleImportNode();

--- a/tests/lib/rules/prefer-wait-for.test.ts
+++ b/tests/lib/rules/prefer-wait-for.test.ts
@@ -1,33 +1,134 @@
 import { createRuleTester } from '../test-utils';
+import { LIBRARY_MODULES } from '../../../lib/utils';
 import rule, { RULE_NAME } from '../../../lib/rules/prefer-wait-for';
 
 const ruleTester = createRuleTester();
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `import { waitFor, render } from '${libraryModule}';
+      
+      async () => {
+        await waitFor(() => {});
+      }`,
+    })),
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `const { waitFor, render } = require('${libraryModule}');
+      
+      async () => {
+        await waitFor(() => {});
+      }`,
+    })),
     {
-      code: `import { waitFor, render } from '@testing-library/foo';
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `import { waitFor, render } from 'test-utils';
       
       async () => {
         await waitFor(() => {});
       }`,
     },
     {
-      code: `import { waitForElementToBeRemoved, render } from '@testing-library/foo';
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `const { waitFor, render } = require('test-utils');
+      
+      async () => {
+        await waitFor(() => {});
+      }`,
+    },
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `import { waitForElementToBeRemoved, render } from '${libraryModule}';
+      
+      async () => {
+        await waitForElementToBeRemoved(() => {});
+      }`,
+    })),
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `const { waitForElementToBeRemoved, render } = require('${libraryModule}');
+      
+      async () => {
+        await waitForElementToBeRemoved(() => {});
+      }`,
+    })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `import { waitForElementToBeRemoved, render } from 'test-utils';
       
       async () => {
         await waitForElementToBeRemoved(() => {});
       }`,
     },
     {
-      code: `import * as testingLibrary from '@testing-library/foo';
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `const { waitForElementToBeRemoved, render } = require('test-utils');
+      
+      async () => {
+        await waitForElementToBeRemoved(() => {});
+      }`,
+    },
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `import * as testingLibrary from '${libraryModule}';
+      
+      async () => {
+        await testingLibrary.waitForElementToBeRemoved(() => {});
+      }`,
+    })),
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `const testingLibrary = require('${libraryModule}');
+      
+      async () => {
+        await testingLibrary.waitForElementToBeRemoved(() => {});
+      }`,
+    })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `import * as testingLibrary from 'test-utils';
       
       async () => {
         await testingLibrary.waitForElementToBeRemoved(() => {});
       }`,
     },
     {
-      code: `import { render } from '@testing-library/foo';
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `const testingLibrary = require('test-utils');
+      
+      async () => {
+        await testingLibrary.waitForElementToBeRemoved(() => {});
+      }`,
+    },
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `import { render } from '${libraryModule}';
+      import { waitForSomethingElse } from 'other-module';
+      
+      async () => {
+        await waitForSomethingElse(() => {});
+      }`,
+    })),
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `const { render } = require('${libraryModule}');
+      const { waitForSomethingElse } = require('other-module');
+      
+      async () => {
+        await waitForSomethingElse(() => {});
+      }`,
+    })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `import { render } from 'test-utils';
       import { waitForSomethingElse } from 'other-module';
       
       async () => {
@@ -35,14 +136,59 @@ ruleTester.run(RULE_NAME, rule, {
       }`,
     },
     {
-      code: `import * as testingLibrary from '@testing-library/foo';
-
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `const { render } = require('test-utils');
+      const { waitForSomethingElse } = require('other-module');
+      
+      async () => {
+        await waitForSomethingElse(() => {});
+      }`,
+    },
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `import * as testingLibrary from '${libraryModule}';
+  
+      async () => {
+        await testingLibrary.waitFor(() => {}, { timeout: 500 });
+      }`,
+    })),
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `const testingLibrary = require('${libraryModule}');
+  
+      async () => {
+        await testingLibrary.waitFor(() => {}, { timeout: 500 });
+      }`,
+    })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `import * as testingLibrary from 'test-utils';
+  
+      async () => {
+        await testingLibrary.waitFor(() => {}, { timeout: 500 });
+      }`,
+    },
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `const testingLibrary = require('test-utils');
+  
       async () => {
         await testingLibrary.waitFor(() => {}, { timeout: 500 });
       }`,
     },
     {
       code: `import { wait } from 'imNoTestingLibrary';
+
+      async () => {
+        await wait();
+      }`,
+    },
+    {
+      code: `const { wait } = require('imNoTestingLibrary');
 
       async () => {
         await wait();
@@ -56,13 +202,37 @@ ruleTester.run(RULE_NAME, rule, {
       }`,
     },
     {
-      code: `
+      code: `const foo = require('imNoTestingLibrary');
+
+      async () => {
+        await foo.wait();
+      }`,
+    },
+    {
+      code: `import * as foo from 'imNoTestingLibrary';
+      cy.wait();
+      `,
+    },
+    {
+      code: `const foo = require('imNoTestingLibrary');
       cy.wait();
       `,
     },
     {
       // https://github.com/testing-library/eslint-plugin-testing-library/issues/145
-      code: `
+      code: `import * as foo from 'imNoTestingLibrary';
+        async function wait(): Promise<any> {
+          // doesn't matter
+        }
+        
+        function callsWait(): void {
+          await wait();
+        }
+      `,
+    },
+    {
+      // https://github.com/testing-library/eslint-plugin-testing-library/issues/145
+      code: `const foo = require('imNoTestingLibrary');
         async function wait(): Promise<any> {
           // doesn't matter
         }
@@ -75,9 +245,9 @@ ruleTester.run(RULE_NAME, rule, {
   ],
 
   invalid: [
-    {
-      code: `import { wait, render } from '@testing-library/foo';
-
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `import { wait, render } from '${libraryModule}';
+  
       async () => {
         await wait();
       }`,
@@ -93,16 +263,94 @@ ruleTester.run(RULE_NAME, rule, {
           column: 15,
         },
       ],
-      output: `import { render,waitFor } from '@testing-library/foo';
-
+      output: `import { render,waitFor } from '${libraryModule}';
+  
+      async () => {
+        await waitFor(() => {});
+      }`,
+    })),
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `const { wait, render } = require('${libraryModule}');
+  
+      async () => {
+        await wait();
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `const { render,waitFor } = require('${libraryModule}');
+  
+      async () => {
+        await waitFor(() => {});
+      }`,
+    })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `import { wait, render } from 'test-utils';
+  
+      async () => {
+        await wait();
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForImport',
+          line: 1,
+          column: 1,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `import { render,waitFor } from 'test-utils';
+  
+      async () => {
+        await waitFor(() => {});
+      }`,
+    },
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `const { wait, render } = require('test-utils');
+  
+      async () => {
+        await wait();
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `const { render,waitFor } = require('test-utils');
+  
       async () => {
         await waitFor(() => {});
       }`,
     },
     // namespaced wait should be fixed but not its import
-    {
-      code: `import * as testingLibrary from '@testing-library/foo';
-
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `import * as testingLibrary from '${libraryModule}';
+  
       async () => {
         await testingLibrary.wait();
       }`,
@@ -113,16 +361,80 @@ ruleTester.run(RULE_NAME, rule, {
           column: 30,
         },
       ],
-      output: `import * as testingLibrary from '@testing-library/foo';
-
+      output: `import * as testingLibrary from '${libraryModule}';
+  
+      async () => {
+        await testingLibrary.waitFor(() => {});
+      }`,
+    })),
+    // namespaced wait should be fixed but not its import
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `const testingLibrary = require('${libraryModule}');
+  
+      async () => {
+        await testingLibrary.wait();
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 30,
+        },
+      ],
+      output: `const testingLibrary = require('${libraryModule}');
+  
+      async () => {
+        await testingLibrary.waitFor(() => {});
+      }`,
+    })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `import * as testingLibrary from 'test-utils';
+  
+      async () => {
+        await testingLibrary.wait();
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 30,
+        },
+      ],
+      output: `import * as testingLibrary from 'test-utils';
+  
+      async () => {
+        await testingLibrary.waitFor(() => {});
+      }`,
+    },
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `const testingLibrary = require('test-utils');
+  
+      async () => {
+        await testingLibrary.wait();
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 30,
+        },
+      ],
+      output: `const testingLibrary = require('test-utils');
+  
       async () => {
         await testingLibrary.waitFor(() => {});
       }`,
     },
     // namespaced waitForDomChange should be fixed but not its import
-    {
-      code: `import * as testingLibrary from '@testing-library/foo';
-
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `import * as testingLibrary from '${libraryModule}';
+  
       async () => {
         await testingLibrary.waitForDomChange({ timeout: 500 });
       }`,
@@ -133,16 +445,79 @@ ruleTester.run(RULE_NAME, rule, {
           column: 30,
         },
       ],
-      output: `import * as testingLibrary from '@testing-library/foo';
-
+      output: `import * as testingLibrary from '${libraryModule}';
+  
+      async () => {
+        await testingLibrary.waitFor(() => {}, { timeout: 500 });
+      }`,
+    })),
+    // namespaced waitForDomChange should be fixed but not its import
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `const testingLibrary = require('${libraryModule}');
+  
+      async () => {
+        await testingLibrary.waitForDomChange({ timeout: 500 });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 30,
+        },
+      ],
+      output: `const testingLibrary = require('${libraryModule}');
+  
+      async () => {
+        await testingLibrary.waitFor(() => {}, { timeout: 500 });
+      }`,
+    })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `import * as testingLibrary from 'test-utils';
+  
+      async () => {
+        await testingLibrary.waitForDomChange({ timeout: 500 });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 30,
+        },
+      ],
+      output: `import * as testingLibrary from 'test-utils';
+  
       async () => {
         await testingLibrary.waitFor(() => {}, { timeout: 500 });
       }`,
     },
     {
-      // this import doesn't have trailing semicolon but fixer adds it
-      code: `import { render, wait } from '@testing-library/foo'
-
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `const testingLibrary = require('test-utils');
+  
+      async () => {
+        await testingLibrary.waitForDomChange({ timeout: 500 });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 30,
+        },
+      ],
+      output: `const testingLibrary = require('test-utils');
+  
+      async () => {
+        await testingLibrary.waitFor(() => {}, { timeout: 500 });
+      }`,
+    },
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `import { render, wait } from '${libraryModule}'
+  
       async () => {
         await wait(() => {});
       }`,
@@ -158,15 +533,94 @@ ruleTester.run(RULE_NAME, rule, {
           column: 15,
         },
       ],
-      output: `import { render,waitFor } from '@testing-library/foo';
-
+      output: `import { render,waitFor } from '${libraryModule}';
+  
+      async () => {
+        await waitFor(() => {});
+      }`,
+    })),
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `const { render, wait } = require('${libraryModule}');
+  
+      async () => {
+        await wait(() => {});
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `const { render,waitFor } = require('${libraryModule}');
+  
+      async () => {
+        await waitFor(() => {});
+      }`,
+    })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `import { render, wait } from 'test-utils'
+  
+      async () => {
+        await wait(() => {});
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForImport',
+          line: 1,
+          column: 1,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `import { render,waitFor } from 'test-utils';
+  
       async () => {
         await waitFor(() => {});
       }`,
     },
     {
-      code: `import { render, wait, screen } from "@testing-library/foo";
-
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `const { render, wait } = require('test-utils');
+  
+      async () => {
+        await wait(() => {});
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `const { render,waitFor } = require('test-utils');
+  
+      async () => {
+        await waitFor(() => {});
+      }`,
+    },
+    // this import doesn't have trailing semicolon but fixer adds it
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `import { render, wait, screen } from "${libraryModule}";
+  
       async () => {
         await wait(function cb() {
           doSomething();
@@ -184,8 +638,68 @@ ruleTester.run(RULE_NAME, rule, {
           column: 15,
         },
       ],
-      output: `import { render,screen,waitFor } from '@testing-library/foo';
-
+      output: `import { render,screen,waitFor } from '${libraryModule}';
+  
+      async () => {
+        await waitFor(function cb() {
+          doSomething();
+        });
+      }`,
+    })),
+    // this import doesn't have trailing semicolon but fixer adds it
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `import { render, wait, screen } from "${libraryModule}";
+  
+      async () => {
+        await wait(function cb() {
+          doSomething();
+        });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForImport',
+          line: 1,
+          column: 1,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `import { render,screen,waitFor } from '${libraryModule}';
+  
+      async () => {
+        await waitFor(function cb() {
+          doSomething();
+        });
+      }`,
+    })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `import { render, wait, screen } from "test-utils";
+  
+      async () => {
+        await wait(function cb() {
+          doSomething();
+        });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForImport',
+          line: 1,
+          column: 1,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `import { render,screen,waitFor } from 'test-utils';
+  
       async () => {
         await waitFor(function cb() {
           doSomething();
@@ -193,8 +707,39 @@ ruleTester.run(RULE_NAME, rule, {
       }`,
     },
     {
-      code: `import { render, waitForElement, screen } from '@testing-library/foo'
-
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `const { render, wait, screen } = require('test-utils');
+  
+      async () => {
+        await wait(function cb() {
+          doSomething();
+        });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `const { render,screen,waitFor } = require('test-utils');
+  
+      async () => {
+        await waitFor(function cb() {
+          doSomething();
+        });
+      }`,
+    },
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `import { render, waitForElement, screen } from '${libraryModule}'
+  
       async () => {
         await waitForElement(() => {});
       }`,
@@ -210,14 +755,92 @@ ruleTester.run(RULE_NAME, rule, {
           column: 15,
         },
       ],
-      output: `import { render,screen,waitFor } from '@testing-library/foo';
-
+      output: `import { render,screen,waitFor } from '${libraryModule}';
+  
+      async () => {
+        await waitFor(() => {});
+      }`,
+    })),
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `const { render, waitForElement, screen } = require('${libraryModule}');
+  
+      async () => {
+        await waitForElement(() => {});
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `const { render,screen,waitFor } = require('${libraryModule}');
+  
+      async () => {
+        await waitFor(() => {});
+      }`,
+    })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `import { render, waitForElement, screen } from 'test-utils'
+  
+      async () => {
+        await waitForElement(() => {});
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForImport',
+          line: 1,
+          column: 1,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `import { render,screen,waitFor } from 'test-utils';
+  
       async () => {
         await waitFor(() => {});
       }`,
     },
     {
-      code: `import { waitForElement } from '@testing-library/foo';
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `const { render, waitForElement, screen } = require('test-utils');
+  
+      async () => {
+        await waitForElement(() => {});
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `const { render,screen,waitFor } = require('test-utils');
+  
+      async () => {
+        await waitFor(() => {});
+      }`,
+    },
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `import { waitForElement } from '${libraryModule}';
 
       async () => {
         await waitForElement(function cb() {
@@ -236,7 +859,66 @@ ruleTester.run(RULE_NAME, rule, {
           column: 15,
         },
       ],
-      output: `import { waitFor } from '@testing-library/foo';
+      output: `import { waitFor } from '${libraryModule}';
+
+      async () => {
+        await waitFor(function cb() {
+          doSomething();
+        });
+      }`,
+    })),
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `const { waitForElement } = require('${libraryModule}');
+
+      async () => {
+        await waitForElement(function cb() {
+          doSomething();
+        });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `const { waitFor } = require('${libraryModule}');
+
+      async () => {
+        await waitFor(function cb() {
+          doSomething();
+        });
+      }`,
+    })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `import { waitForElement } from 'test-utils';
+
+      async () => {
+        await waitForElement(function cb() {
+          doSomething();
+        });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForImport',
+          line: 1,
+          column: 1,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `import { waitFor } from 'test-utils';
 
       async () => {
         await waitFor(function cb() {
@@ -245,7 +927,38 @@ ruleTester.run(RULE_NAME, rule, {
       }`,
     },
     {
-      code: `import { waitForDomChange } from '@testing-library/foo';
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `const { waitForElement } = require('test-utils');
+
+      async () => {
+        await waitForElement(function cb() {
+          doSomething();
+        });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `const { waitFor } = require('test-utils');
+
+      async () => {
+        await waitFor(function cb() {
+          doSomething();
+        });
+      }`,
+    },
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `import { waitForDomChange } from '${libraryModule}';
 
       async () => {
         await waitForDomChange();
@@ -262,14 +975,92 @@ ruleTester.run(RULE_NAME, rule, {
           column: 15,
         },
       ],
-      output: `import { waitFor } from '@testing-library/foo';
+      output: `import { waitFor } from '${libraryModule}';
+
+      async () => {
+        await waitFor(() => {});
+      }`,
+    })),
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `const { waitForDomChange } = require('${libraryModule}');
+
+      async () => {
+        await waitForDomChange();
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `const { waitFor } = require('${libraryModule}');
+
+      async () => {
+        await waitFor(() => {});
+      }`,
+    })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `import { waitForDomChange } from 'test-utils';
+
+      async () => {
+        await waitForDomChange();
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForImport',
+          line: 1,
+          column: 1,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `import { waitFor } from 'test-utils';
 
       async () => {
         await waitFor(() => {});
       }`,
     },
     {
-      code: `import { waitForDomChange } from '@testing-library/foo';
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `const { waitForDomChange } = require('test-utils');
+
+      async () => {
+        await waitForDomChange();
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `const { waitFor } = require('test-utils');
+
+      async () => {
+        await waitFor(() => {});
+      }`,
+    },
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `import { waitForDomChange } from '${libraryModule}';
 
       async () => {
         await waitForDomChange(mutationObserverOptions);
@@ -286,14 +1077,92 @@ ruleTester.run(RULE_NAME, rule, {
           column: 15,
         },
       ],
-      output: `import { waitFor } from '@testing-library/foo';
+      output: `import { waitFor } from '${libraryModule}';
+
+      async () => {
+        await waitFor(() => {}, mutationObserverOptions);
+      }`,
+    })),
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `const { waitForDomChange } = require('${libraryModule}');
+
+      async () => {
+        await waitForDomChange(mutationObserverOptions);
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `const { waitFor } = require('${libraryModule}');
+
+      async () => {
+        await waitFor(() => {}, mutationObserverOptions);
+      }`,
+    })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `import { waitForDomChange } from 'test-utils';
+
+      async () => {
+        await waitForDomChange(mutationObserverOptions);
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForImport',
+          line: 1,
+          column: 1,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `import { waitFor } from 'test-utils';
 
       async () => {
         await waitFor(() => {}, mutationObserverOptions);
       }`,
     },
     {
-      code: `import { waitForDomChange } from '@testing-library/foo';
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `const { waitForDomChange } = require('test-utils');
+
+      async () => {
+        await waitForDomChange(mutationObserverOptions);
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `const { waitFor } = require('test-utils');
+
+      async () => {
+        await waitFor(() => {}, mutationObserverOptions);
+      }`,
+    },
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `import { waitForDomChange } from '${libraryModule}';
 
       async () => {
         await waitForDomChange({ timeout: 5000 });
@@ -310,14 +1179,92 @@ ruleTester.run(RULE_NAME, rule, {
           column: 15,
         },
       ],
-      output: `import { waitFor } from '@testing-library/foo';
+      output: `import { waitFor } from '${libraryModule}';
+
+      async () => {
+        await waitFor(() => {}, { timeout: 5000 });
+      }`,
+    })),
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `const { waitForDomChange } = require('${libraryModule}');
+
+      async () => {
+        await waitForDomChange({ timeout: 5000 });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `const { waitFor } = require('${libraryModule}');
+
+      async () => {
+        await waitFor(() => {}, { timeout: 5000 });
+      }`,
+    })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `import { waitForDomChange } from 'test-utils';
+
+      async () => {
+        await waitForDomChange({ timeout: 5000 });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForImport',
+          line: 1,
+          column: 1,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `import { waitFor } from 'test-utils';
 
       async () => {
         await waitFor(() => {}, { timeout: 5000 });
       }`,
     },
     {
-      code: `import { waitForDomChange, wait, waitForElement } from '@testing-library/foo';
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `const { waitForDomChange } = require('test-utils');
+
+      async () => {
+        await waitForDomChange({ timeout: 5000 });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `const { waitFor } = require('test-utils');
+
+      async () => {
+        await waitFor(() => {}, { timeout: 5000 });
+      }`,
+    },
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `import { waitForDomChange, wait, waitForElement } from '${libraryModule}';
       import userEvent from '@testing-library/user-event';
 
       async () => {
@@ -353,7 +1300,104 @@ ruleTester.run(RULE_NAME, rule, {
           column: 15,
         },
       ],
-      output: `import { waitFor } from '@testing-library/foo';
+      output: `import { waitFor } from '${libraryModule}';
+      import userEvent from '@testing-library/user-event';
+
+      async () => {
+        await waitFor(() => {}, { timeout: 5000 });
+        await waitFor(() => {});
+        await waitFor(() => {});
+        await waitFor(() => { doSomething() });
+      }`,
+    })),
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `const { waitForDomChange, wait, waitForElement } = require('${libraryModule}');
+      const userEvent = require('@testing-library/user-event');
+
+      async () => {
+        await waitForDomChange({ timeout: 5000 });
+        await waitForElement();
+        await wait();
+        await wait(() => { doSomething() });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 5,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 6,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 7,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 8,
+          column: 15,
+        },
+      ],
+      output: `const { waitFor } = require('${libraryModule}');
+      const userEvent = require('@testing-library/user-event');
+
+      async () => {
+        await waitFor(() => {}, { timeout: 5000 });
+        await waitFor(() => {});
+        await waitFor(() => {});
+        await waitFor(() => { doSomething() });
+      }`,
+    })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `import { waitForDomChange, wait, waitForElement } from 'test-utils';
+      import userEvent from '@testing-library/user-event';
+
+      async () => {
+        await waitForDomChange({ timeout: 5000 });
+        await waitForElement();
+        await wait();
+        await wait(() => { doSomething() });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForImport',
+          line: 1,
+          column: 1,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 5,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 6,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 7,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 8,
+          column: 15,
+        },
+      ],
+      output: `import { waitFor } from 'test-utils';
       import userEvent from '@testing-library/user-event';
 
       async () => {
@@ -364,7 +1408,57 @@ ruleTester.run(RULE_NAME, rule, {
       }`,
     },
     {
-      code: `import { render, waitForDomChange, wait, waitForElement } from '@testing-library/foo';
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `const { waitForDomChange, wait, waitForElement } = require('test-utils');
+      const userEvent = require('@testing-library/user-event');
+
+      async () => {
+        await waitForDomChange({ timeout: 5000 });
+        await waitForElement();
+        await wait();
+        await wait(() => { doSomething() });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 5,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 6,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 7,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 8,
+          column: 15,
+        },
+      ],
+      output: `const { waitFor } = require('test-utils');
+      const userEvent = require('@testing-library/user-event');
+
+      async () => {
+        await waitFor(() => {}, { timeout: 5000 });
+        await waitFor(() => {});
+        await waitFor(() => {});
+        await waitFor(() => { doSomething() });
+      }`,
+    },
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `import { render, waitForDomChange, wait, waitForElement } from '${libraryModule}';
 
       async () => {
         await waitForDomChange({ timeout: 5000 });
@@ -399,7 +1493,7 @@ ruleTester.run(RULE_NAME, rule, {
           column: 15,
         },
       ],
-      output: `import { render,waitFor } from '@testing-library/foo';
+      output: `import { render,waitFor } from '${libraryModule}';
 
       async () => {
         await waitFor(() => {}, { timeout: 5000 });
@@ -407,9 +1501,57 @@ ruleTester.run(RULE_NAME, rule, {
         await waitFor(() => {});
         await waitFor(() => { doSomething() });
       }`,
-    },
+    })),
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `const { render, waitForDomChange, wait, waitForElement } = require('${libraryModule}');
+
+      async () => {
+        await waitForDomChange({ timeout: 5000 });
+        await waitForElement();
+        await wait();
+        await wait(() => { doSomething() });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 5,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 6,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 7,
+          column: 15,
+        },
+      ],
+      output: `const { render,waitFor } = require('${libraryModule}');
+
+      async () => {
+        await waitFor(() => {}, { timeout: 5000 });
+        await waitFor(() => {});
+        await waitFor(() => {});
+        await waitFor(() => { doSomething() });
+      }`,
+    })),
     {
-      code: `import { waitForDomChange, wait, render, waitForElement } from '@testing-library/foo';
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `import { render, waitForDomChange, wait, waitForElement } from 'test-utils';
 
       async () => {
         await waitForDomChange({ timeout: 5000 });
@@ -444,7 +1586,7 @@ ruleTester.run(RULE_NAME, rule, {
           column: 15,
         },
       ],
-      output: `import { render,waitFor } from '@testing-library/foo';
+      output: `import { render,waitFor } from 'test-utils';
 
       async () => {
         await waitFor(() => {}, { timeout: 5000 });
@@ -454,12 +1596,246 @@ ruleTester.run(RULE_NAME, rule, {
       }`,
     },
     {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `const { render, waitForDomChange, wait, waitForElement } = require('test-utils');
+
+      async () => {
+        await waitForDomChange({ timeout: 5000 });
+        await waitForElement();
+        await wait();
+        await wait(() => { doSomething() });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 5,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 6,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 7,
+          column: 15,
+        },
+      ],
+      output: `const { render,waitFor } = require('test-utils');
+
+      async () => {
+        await waitFor(() => {}, { timeout: 5000 });
+        await waitFor(() => {});
+        await waitFor(() => {});
+        await waitFor(() => { doSomething() });
+      }`,
+    },
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `import { waitForDomChange, wait, render, waitForElement } from '${libraryModule}';
+
+      async () => {
+        await waitForDomChange({ timeout: 5000 });
+        await waitForElement();
+        await wait();
+        await wait(() => { doSomething() });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForImport',
+          line: 1,
+          column: 1,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 5,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 6,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 7,
+          column: 15,
+        },
+      ],
+      output: `import { render,waitFor } from '${libraryModule}';
+
+      async () => {
+        await waitFor(() => {}, { timeout: 5000 });
+        await waitFor(() => {});
+        await waitFor(() => {});
+        await waitFor(() => { doSomething() });
+      }`,
+    })),
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `const { waitForDomChange, wait, render, waitForElement } = require('${libraryModule}');
+
+      async () => {
+        await waitForDomChange({ timeout: 5000 });
+        await waitForElement();
+        await wait();
+        await wait(() => { doSomething() });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 5,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 6,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 7,
+          column: 15,
+        },
+      ],
+      output: `const { render,waitFor } = require('${libraryModule}');
+
+      async () => {
+        await waitFor(() => {}, { timeout: 5000 });
+        await waitFor(() => {});
+        await waitFor(() => {});
+        await waitFor(() => { doSomething() });
+      }`,
+    })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `import { waitForDomChange, wait, render, waitForElement } from 'test-utils';
+
+      async () => {
+        await waitForDomChange({ timeout: 5000 });
+        await waitForElement();
+        await wait();
+        await wait(() => { doSomething() });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForImport',
+          line: 1,
+          column: 1,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 5,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 6,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 7,
+          column: 15,
+        },
+      ],
+      output: `import { render,waitFor } from 'test-utils';
+
+      async () => {
+        await waitFor(() => {}, { timeout: 5000 });
+        await waitFor(() => {});
+        await waitFor(() => {});
+        await waitFor(() => { doSomething() });
+      }`,
+    },
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `const { waitForDomChange, wait, render, waitForElement } = require('test-utils');
+
+      async () => {
+        await waitForDomChange({ timeout: 5000 });
+        await waitForElement();
+        await wait();
+        await wait(() => { doSomething() });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 5,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 6,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 7,
+          column: 15,
+        },
+      ],
+      output: `const { render,waitFor } = require('test-utils');
+
+      async () => {
+        await waitFor(() => {}, { timeout: 5000 });
+        await waitFor(() => {});
+        await waitFor(() => {});
+        await waitFor(() => { doSomething() });
+      }`,
+    },
+    ...LIBRARY_MODULES.map((libraryModule) => ({
       code: `import {
         waitForDomChange,
         wait,
         render,
         waitForElement,
-      } from '@testing-library/foo';
+      } from '${libraryModule}';
 
       async () => {
         await waitForDomChange({ timeout: 5000 });
@@ -494,7 +1870,110 @@ ruleTester.run(RULE_NAME, rule, {
           column: 15,
         },
       ],
-      output: `import { render,waitFor } from '@testing-library/foo';
+      output: `import { render,waitFor } from '${libraryModule}';
+
+      async () => {
+        await waitFor(() => {}, { timeout: 5000 });
+        await waitFor(() => {});
+        await waitFor(() => {});
+        await waitFor(() => { doSomething() });
+      }`,
+    })),
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      code: `const {
+        waitForDomChange,
+        wait,
+        render,
+        waitForElement,
+      } = require('${libraryModule}');
+
+      async () => {
+        await waitForDomChange({ timeout: 5000 });
+        await waitForElement();
+        await wait();
+        await wait(() => { doSomething() });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 9,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 10,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 11,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 12,
+          column: 15,
+        },
+      ],
+      output: `const { render,waitFor } = require('${libraryModule}');
+
+      async () => {
+        await waitFor(() => {}, { timeout: 5000 });
+        await waitFor(() => {});
+        await waitFor(() => {});
+        await waitFor(() => { doSomething() });
+      }`,
+    })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `import {
+        waitForDomChange,
+        wait,
+        render,
+        waitForElement,
+      } from 'test-utils';
+
+      async () => {
+        await waitForDomChange({ timeout: 5000 });
+        await waitForElement();
+        await wait();
+        await wait(() => { doSomething() });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForImport',
+          line: 1,
+          column: 1,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 9,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 10,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 11,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 12,
+          column: 15,
+        },
+      ],
+      output: `import { render,waitFor } from 'test-utils';
 
       async () => {
         await waitFor(() => {}, { timeout: 5000 });
@@ -504,8 +1983,61 @@ ruleTester.run(RULE_NAME, rule, {
       }`,
     },
     {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `const {
+        waitForDomChange,
+        wait,
+        render,
+        waitForElement,
+      } = require('test-utils');
+
+      async () => {
+        await waitForDomChange({ timeout: 5000 });
+        await waitForElement();
+        await wait();
+        await wait(() => { doSomething() });
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 9,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 10,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 11,
+          column: 15,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 12,
+          column: 15,
+        },
+      ],
+      output: `const { render,waitFor } = require('test-utils');
+
+      async () => {
+        await waitFor(() => {}, { timeout: 5000 });
+        await waitFor(() => {});
+        await waitFor(() => {});
+        await waitFor(() => { doSomething() });
+      }`,
+    },
+    ...LIBRARY_MODULES.map((libraryModule) => ({
       // if already importing waitFor then it's not imported twice
-      code: `import { wait, waitFor, render } from '@testing-library/foo';
+      code: `import { wait, waitFor, render } from '${libraryModule}';
 
       async () => {
         await wait();
@@ -523,7 +2055,94 @@ ruleTester.run(RULE_NAME, rule, {
           column: 15,
         },
       ],
-      output: `import { render,waitFor } from '@testing-library/foo';
+      output: `import { render,waitFor } from '${libraryModule}';
+
+      async () => {
+        await waitFor(() => {});
+        await waitFor(someCallback);
+      }`,
+    })),
+    ...LIBRARY_MODULES.map((libraryModule) => ({
+      // if already importing waitFor then it's not imported twice
+      code: `const { wait, waitFor, render } = require('${libraryModule}');
+
+      async () => {
+        await wait();
+        await waitFor(someCallback);
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `const { render,waitFor } = require('${libraryModule}');
+
+      async () => {
+        await waitFor(() => {});
+        await waitFor(someCallback);
+      }`,
+    })),
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      // if already importing waitFor then it's not imported twice
+      code: `import { wait, waitFor, render } from 'test-utils';
+
+      async () => {
+        await wait();
+        await waitFor(someCallback);
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForImport',
+          line: 1,
+          column: 1,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `import { render,waitFor } from 'test-utils';
+
+      async () => {
+        await waitFor(() => {});
+        await waitFor(someCallback);
+      }`,
+    },
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      // if already importing waitFor then it's not imported twice
+      code: `const { wait, waitFor, render } = require('test-utils');
+
+      async () => {
+        await wait();
+        await waitFor(someCallback);
+      }`,
+      errors: [
+        {
+          messageId: 'preferWaitForRequire',
+          line: 1,
+          column: 7,
+        },
+        {
+          messageId: 'preferWaitForMethod',
+          line: 4,
+          column: 15,
+        },
+      ],
+      output: `const { render,waitFor } = require('test-utils');
 
       async () => {
         await waitFor(() => {});


### PR DESCRIPTION
#198 migrating prefer-wait-for

I had to reimplement the rule because the implementation was tightly coupled with the imports

- I added support for `require`
- I improved the test coverage, I took all the existing scenarios and I added testing with `require`, with `settings` and all known imports for testing-library
- I improved the docs with the `require` support