### PR TITLE
refactor(ast-utils): migrate custom node-utils to ASTUtils

### DIFF
--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -15,13 +15,13 @@ export function isCallExpression(
 export function isNewExpression(
   node: TSESTree.Node
 ): node is TSESTree.NewExpression {
-  return node && node.type === 'NewExpression';
+  return node?.type === 'NewExpression';
 }
 
 export function isMemberExpression(
   node: TSESTree.Node
 ): node is TSESTree.MemberExpression {
-  return node && node.type === AST_NODE_TYPES.MemberExpression;
+  return node?.type === AST_NODE_TYPES.MemberExpression;
 }
 
 export function isLiteral(
@@ -33,7 +33,7 @@ export function isLiteral(
 export function isImportSpecifier(
   node: TSESTree.Node
 ): node is TSESTree.ImportSpecifier {
-  return node && node.type === AST_NODE_TYPES.ImportSpecifier;
+  return node?.type === AST_NODE_TYPES.ImportSpecifier;
 }
 
 export function isImportNamespaceSpecifier(
@@ -45,25 +45,25 @@ export function isImportNamespaceSpecifier(
 export function isImportDefaultSpecifier(
   node: TSESTree.Node
 ): node is TSESTree.ImportDefaultSpecifier {
-  return node && node.type === AST_NODE_TYPES.ImportDefaultSpecifier;
+  return node?.type === AST_NODE_TYPES.ImportDefaultSpecifier;
 }
 
 export function isBlockStatement(
   node: TSESTree.Node
 ): node is TSESTree.BlockStatement {
-  return node && node.type === AST_NODE_TYPES.BlockStatement;
+  return node?.type === AST_NODE_TYPES.BlockStatement;
 }
 
 export function isVariableDeclarator(
   node: TSESTree.Node
 ): node is TSESTree.VariableDeclarator {
-  return node && node.type === AST_NODE_TYPES.VariableDeclarator;
+  return node?.type === AST_NODE_TYPES.VariableDeclarator;
 }
 
 export function isObjectPattern(
   node: TSESTree.Node
 ): node is TSESTree.ObjectPattern {
-  return node && node.type === AST_NODE_TYPES.ObjectPattern;
+  return node?.type === AST_NODE_TYPES.ObjectPattern;
 }
 
 export function isProperty(
@@ -75,7 +75,7 @@ export function isProperty(
 export function isJSXAttribute(
   node: TSESTree.Node
 ): node is TSESTree.JSXAttribute {
-  return node && node.type === AST_NODE_TYPES.JSXAttribute;
+  return node?.type === AST_NODE_TYPES.JSXAttribute;
 }
 
 export function findClosestCallExpressionNode(
@@ -128,13 +128,13 @@ export function hasThenProperty(node: TSESTree.Node): boolean {
 export function isArrowFunctionExpression(
   node: TSESTree.Node
 ): node is TSESTree.ArrowFunctionExpression {
-  return node && node.type === AST_NODE_TYPES.ArrowFunctionExpression;
+  return node?.type === AST_NODE_TYPES.ArrowFunctionExpression;
 }
 
 export function isReturnStatement(
   node: TSESTree.Node
 ): node is TSESTree.ReturnStatement {
-  return node && node.type === AST_NODE_TYPES.ReturnStatement;
+  return node?.type === AST_NODE_TYPES.ReturnStatement;
 }
 
 export function isArrayExpression(

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -125,13 +125,6 @@ export function hasThenProperty(node: TSESTree.Node): boolean {
   );
 }
 
-// TODO: remove this one and use ASTUtils one instead
-export function isAwaitExpression(
-  node: TSESTree.Node
-): node is TSESTree.AwaitExpression {
-  return node && node.type === AST_NODE_TYPES.AwaitExpression;
-}
-
 export function isArrowFunctionExpression(
   node: TSESTree.Node
 ): node is TSESTree.ArrowFunctionExpression {
@@ -158,7 +151,7 @@ export function isImportDeclaration(
 
 export function isAwaited(node: TSESTree.Node): boolean {
   return (
-    isAwaitExpression(node) ||
+    ASTUtils.isAwaitExpression(node) ||
     isArrowFunctionExpression(node) ||
     isReturnStatement(node)
   );
@@ -209,7 +202,7 @@ export function isRenderVariableDeclarator(
   renderFunctions: string[]
 ): boolean {
   if (node.init) {
-    if (isAwaitExpression(node.init)) {
+    if (ASTUtils.isAwaitExpression(node.init)) {
       return (
         node.init.argument &&
         isRenderFunction(

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -18,11 +18,6 @@ export function isNewExpression(
   return node && node.type === 'NewExpression';
 }
 
-// TODO: remove this one and use ASTUtils one instead
-export function isIdentifier(node: TSESTree.Node): node is TSESTree.Identifier {
-  return node && node.type === AST_NODE_TYPES.Identifier;
-}
-
 export function isMemberExpression(
   node: TSESTree.Node
 ): node is TSESTree.MemberExpression {
@@ -107,7 +102,7 @@ export function findClosestCallNode(
 
   if (
     isCallExpression(node) &&
-    isIdentifier(node.callee) &&
+    ASTUtils.isIdentifier(node.callee) &&
     node.callee.name === name
   ) {
     return node;
@@ -125,7 +120,7 @@ export function isObjectExpression(
 export function hasThenProperty(node: TSESTree.Node): boolean {
   return (
     isMemberExpression(node) &&
-    isIdentifier(node.property) &&
+    ASTUtils.isIdentifier(node.property) &&
     node.property.name === 'then'
   );
 }
@@ -200,9 +195,10 @@ export function isRenderFunction(
   // as well as `someLib.render` and `someUtils.customRenderFn`
   return renderFunctions.some((name) => {
     return (
-      (isIdentifier(callNode.callee) && name === callNode.callee.name) ||
+      (ASTUtils.isIdentifier(callNode.callee) &&
+        name === callNode.callee.name) ||
       (isMemberExpression(callNode.callee) &&
-        isIdentifier(callNode.callee.property) &&
+        ASTUtils.isIdentifier(callNode.callee.property) &&
         name === callNode.callee.property.name)
     );
   });

--- a/lib/rules/await-async-query.ts
+++ b/lib/rules/await-async-query.ts
@@ -1,8 +1,11 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import {
+  ESLintUtils,
+  TSESTree,
+  ASTUtils,
+} from '@typescript-eslint/experimental-utils';
 import { getDocsUrl, LIBRARY_MODULES } from '../utils';
 import {
   isCallExpression,
-  isIdentifier,
   isMemberExpression,
   isAwaited,
   isPromiseResolved,
@@ -23,13 +26,13 @@ function hasClosestExpectResolvesRejects(node: TSESTree.Node): boolean {
 
   if (
     isCallExpression(node) &&
-    isIdentifier(node.callee) &&
+    ASTUtils.isIdentifier(node.callee) &&
     isMemberExpression(node.parent) &&
     node.callee.name === 'expect'
   ) {
     const expectMatcher = node.parent.property;
     return (
-      isIdentifier(expectMatcher) &&
+      ASTUtils.isIdentifier(expectMatcher) &&
       (expectMatcher.name === 'resolves' || expectMatcher.name === 'rejects')
     );
   } else {

--- a/lib/rules/await-async-utils.ts
+++ b/lib/rules/await-async-utils.ts
@@ -1,4 +1,8 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import {
+  ESLintUtils,
+  TSESTree,
+  ASTUtils,
+} from '@typescript-eslint/experimental-utils';
 
 import { getDocsUrl, ASYNC_UTILS, LIBRARY_MODULES } from '../utils';
 import {
@@ -10,7 +14,6 @@ import {
   isImportNamespaceSpecifier,
   isCallExpression,
   isArrayExpression,
-  isIdentifier,
 } from '../node-utils';
 
 export const RULE_NAME = 'await-async-utils';
@@ -23,9 +26,9 @@ const ASYNC_UTILS_REGEXP = new RegExp(`^(${ASYNC_UTILS.join('|')})$`);
 function isPromiseAll(node: TSESTree.CallExpression) {
   return (
     isMemberExpression(node.callee) &&
-    isIdentifier(node.callee.object) &&
+    ASTUtils.isIdentifier(node.callee.object) &&
     node.callee.object.name === 'Promise' &&
-    isIdentifier(node.callee.property) &&
+    ASTUtils.isIdentifier(node.callee.property) &&
     node.callee.property.name === 'all'
   );
 }

--- a/lib/rules/await-fire-event.ts
+++ b/lib/rules/await-fire-event.ts
@@ -1,6 +1,10 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import {
+  ESLintUtils,
+  TSESTree,
+  ASTUtils,
+} from '@typescript-eslint/experimental-utils';
 import { getDocsUrl } from '../utils';
-import { isIdentifier, isAwaited, isPromiseResolved } from '../node-utils';
+import { isAwaited, isPromiseResolved } from '../node-utils';
 
 export const RULE_NAME = 'await-fire-event';
 export type MessageIds = 'awaitFireEvent';
@@ -31,7 +35,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
         const fireEventMethodNode = memberExpression.property;
 
         if (
-          isIdentifier(fireEventMethodNode) &&
+          ASTUtils.isIdentifier(fireEventMethodNode) &&
           !isAwaited(node.parent.parent.parent) &&
           !isPromiseResolved(fireEventMethodNode.parent)
         ) {

--- a/lib/rules/no-await-sync-events.ts
+++ b/lib/rules/no-await-sync-events.ts
@@ -1,6 +1,10 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import {
+  ASTUtils,
+  ESLintUtils,
+  TSESTree,
+} from '@typescript-eslint/experimental-utils';
 import { getDocsUrl, SYNC_EVENTS } from '../utils';
-import { isObjectExpression, isProperty, isIdentifier } from '../node-utils';
+import { isObjectExpression, isProperty } from '../node-utils';
 export const RULE_NAME = 'no-await-sync-events';
 export type MessageIds = 'noAwaitSyncEvents';
 type Options = [];
@@ -41,7 +45,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
           callExpression.arguments[2].properties.some(
             (property) =>
               isProperty(property) &&
-              isIdentifier(property.key) &&
+              ASTUtils.isIdentifier(property.key) &&
               property.key.name === 'delay'
           );
 

--- a/lib/rules/no-container.ts
+++ b/lib/rules/no-container.ts
@@ -1,7 +1,10 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import {
+  ESLintUtils,
+  TSESTree,
+  ASTUtils,
+} from '@typescript-eslint/experimental-utils';
 import { getDocsUrl } from '../utils';
 import {
-  isIdentifier,
   isMemberExpression,
   isObjectPattern,
   isProperty,
@@ -54,12 +57,12 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
       innerNode: TSESTree.MemberExpression
     ) {
       if (isMemberExpression(innerNode)) {
-        if (isIdentifier(innerNode.object)) {
+        if (ASTUtils.isIdentifier(innerNode.object)) {
           const isContainerName = innerNode.object.name === containerName;
           const isRenderWrapper = innerNode.object.name === renderWrapperName;
 
           containerCallsMethod =
-            isIdentifier(innerNode.property) &&
+            ASTUtils.isIdentifier(innerNode.property) &&
             innerNode.property.name === 'container' &&
             isRenderWrapper;
 
@@ -83,24 +86,24 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
             const containerIndex = node.id.properties.findIndex(
               (property) =>
                 isProperty(property) &&
-                isIdentifier(property.key) &&
+                ASTUtils.isIdentifier(property.key) &&
                 property.key.name === 'container'
             );
             const nodeValue =
               containerIndex !== -1 && node.id.properties[containerIndex].value;
-            if (isIdentifier(nodeValue)) {
+            if (ASTUtils.isIdentifier(nodeValue)) {
               containerName = nodeValue.name;
             } else {
               isObjectPattern(nodeValue) &&
                 nodeValue.properties.forEach(
                   (property) =>
                     isProperty(property) &&
-                    isIdentifier(property.key) &&
+                    ASTUtils.isIdentifier(property.key) &&
                     destructuredContainerPropNames.push(property.key.name)
                 );
             }
           } else {
-            renderWrapperName = isIdentifier(node.id) && node.id.name;
+            renderWrapperName = ASTUtils.isIdentifier(node.id) && node.id.name;
           }
         }
       },
@@ -109,7 +112,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
         if (isMemberExpression(node.callee)) {
           showErrorIfChainedContainerMethod(node.callee);
         } else {
-          isIdentifier(node.callee) &&
+          ASTUtils.isIdentifier(node.callee) &&
             destructuredContainerPropNames.includes(node.callee.name) &&
             context.report({
               node,

--- a/lib/rules/no-debug.ts
+++ b/lib/rules/no-debug.ts
@@ -1,4 +1,8 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import {
+  ESLintUtils,
+  TSESTree,
+  ASTUtils,
+} from '@typescript-eslint/experimental-utils';
 import {
   getDocsUrl,
   LIBRARY_MODULES,
@@ -7,7 +11,6 @@ import {
 import {
   isObjectPattern,
   isProperty,
-  isIdentifier,
   isCallExpression,
   isLiteral,
   isMemberExpression,
@@ -66,7 +69,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
             node.id.properties.some(
               (property) =>
                 isProperty(property) &&
-                isIdentifier(property.key) &&
+                ASTUtils.isIdentifier(property.key) &&
                 property.key.name === 'debug'
             )
           ) {
@@ -102,7 +105,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
           declaratorNode.id.properties.some(
             (property) =>
               isProperty(property) &&
-              isIdentifier(property.key) &&
+              ASTUtils.isIdentifier(property.key) &&
               property.key.name === 'screen'
           );
       },
@@ -179,7 +182,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
             const parent = ref.identifier.parent;
             if (
               isMemberExpression(parent) &&
-              isIdentifier(parent.property) &&
+              ASTUtils.isIdentifier(parent.property) &&
               parent.property.name === 'debug' &&
               isCallExpression(parent.parent)
             ) {

--- a/lib/rules/no-multiple-assertions-wait-for.ts
+++ b/lib/rules/no-multiple-assertions-wait-for.ts
@@ -1,10 +1,13 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import {
+  ESLintUtils,
+  TSESTree,
+  ASTUtils,
+} from '@typescript-eslint/experimental-utils';
 import { getDocsUrl } from '../utils';
 import {
   isBlockStatement,
   isMemberExpression,
   isCallExpression,
-  isIdentifier,
 } from '../node-utils';
 
 export const RULE_NAME = 'no-multiple-assertions-wait-for';
@@ -42,7 +45,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
             const object: TSESTree.CallExpression =
               node.expression.callee.object;
             const expressionName: string =
-              isIdentifier(object.callee) && object.callee.name;
+              ASTUtils.isIdentifier(object.callee) && object.callee.name;
             return expressionName === 'expect';
           } else {
             return false;

--- a/lib/rules/no-node-access.ts
+++ b/lib/rules/no-node-access.ts
@@ -1,6 +1,5 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { TSESTree, ASTUtils } from '@typescript-eslint/experimental-utils';
 import { ALL_RETURNING_NODES } from '../utils';
-import { isIdentifier } from '../node-utils';
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 
 export const RULE_NAME = 'no-node-access';
@@ -27,7 +26,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 
   create(context) {
     function showErrorForNodeAccess(node: TSESTree.MemberExpression) {
-      isIdentifier(node.property) &&
+      ASTUtils.isIdentifier(node.property) &&
         ALL_RETURNING_NODES.includes(node.property.name) &&
         context.report({
           node: node,

--- a/lib/rules/no-promise-in-fire-event.ts
+++ b/lib/rules/no-promise-in-fire-event.ts
@@ -1,8 +1,11 @@
-import { TSESTree, ESLintUtils } from '@typescript-eslint/experimental-utils';
+import {
+  TSESTree,
+  ESLintUtils,
+  ASTUtils,
+} from '@typescript-eslint/experimental-utils';
 import { getDocsUrl, ASYNC_QUERIES_VARIANTS } from '../utils';
 import {
   isNewExpression,
-  isIdentifier,
   isImportSpecifier,
   isCallExpression,
 } from '../node-utils';
@@ -52,7 +55,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
             .parent as TSESTree.CallExpression;
           const [element] = callExpression.arguments as TSESTree.Node[];
           if (isCallExpression(element) || isNewExpression(element)) {
-            const methodName = isIdentifier(element.callee)
+            const methodName = ASTUtils.isIdentifier(element.callee)
               ? element.callee.name
               : ((element.callee as TSESTree.MemberExpression)
                   .property as TSESTree.Identifier).name;

--- a/lib/rules/no-render-in-setup.ts
+++ b/lib/rules/no-render-in-setup.ts
@@ -1,9 +1,12 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import {
+  ESLintUtils,
+  TSESTree,
+  ASTUtils,
+} from '@typescript-eslint/experimental-utils';
 import { getDocsUrl, TESTING_FRAMEWORK_SETUP_HOOKS } from '../utils';
 import {
   isLiteral,
   isProperty,
-  isIdentifier,
   isObjectPattern,
   isCallExpression,
   isRenderFunction,
@@ -29,7 +32,7 @@ export function findClosestBeforeHook(
 
   if (
     isCallExpression(node) &&
-    isIdentifier(node.callee) &&
+    ASTUtils.isIdentifier(node.callee) &&
     testingFrameworkSetupHooksToFilter.includes(node.callee.name)
   ) {
     return node.callee;
@@ -126,7 +129,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
           declaratorNode.id.properties.some(
             (property) =>
               isProperty(property) &&
-              isIdentifier(property.key) &&
+              ASTUtils.isIdentifier(property.key) &&
               property.key.name === 'render'
           );
       },

--- a/lib/rules/no-side-effects-wait-for.ts
+++ b/lib/rules/no-side-effects-wait-for.ts
@@ -1,10 +1,13 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import {
+  ESLintUtils,
+  TSESTree,
+  ASTUtils,
+} from '@typescript-eslint/experimental-utils';
 import { getDocsUrl, hasTestingLibraryImportModule } from '../utils';
 import {
   isBlockStatement,
   isMemberExpression,
   isCallExpression,
-  isIdentifier,
 } from '../node-utils';
 
 export const RULE_NAME = 'no-side-effects-wait-for';
@@ -41,7 +44,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
           if (
             isCallExpression(node.expression) &&
             isMemberExpression(node.expression.callee) &&
-            isIdentifier(node.expression.callee.object)
+            ASTUtils.isIdentifier(node.expression.callee.object)
           ) {
             const object: TSESTree.Identifier = node.expression.callee.object;
             const identifierName: string = object.name;

--- a/lib/rules/no-wait-for-empty-callback.ts
+++ b/lib/rules/no-wait-for-empty-callback.ts
@@ -1,10 +1,10 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
-import { getDocsUrl } from '../utils';
 import {
-  isBlockStatement,
-  isCallExpression,
-  isIdentifier,
-} from '../node-utils';
+  ESLintUtils,
+  TSESTree,
+  ASTUtils,
+} from '@typescript-eslint/experimental-utils';
+import { getDocsUrl } from '../utils';
+import { isBlockStatement, isCallExpression } from '../node-utils';
 
 export const RULE_NAME = 'no-wait-for-empty-callback';
 export type MessageIds = 'noWaitForEmptyCallback';
@@ -42,7 +42,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
         isBlockStatement(node.body) &&
         node.body.body.length === 0 &&
         isCallExpression(node.parent) &&
-        isIdentifier(node.parent.callee)
+        ASTUtils.isIdentifier(node.parent.callee)
       ) {
         context.report({
           node,

--- a/lib/rules/prefer-explicit-assert.ts
+++ b/lib/rules/prefer-explicit-assert.ts
@@ -1,15 +1,15 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import {
+  ESLintUtils,
+  TSESTree,
+  ASTUtils,
+} from '@typescript-eslint/experimental-utils';
 import {
   getDocsUrl,
   ALL_QUERIES_METHODS,
   PRESENCE_MATCHERS,
   ABSENCE_MATCHERS,
 } from '../utils';
-import {
-  findClosestCallNode,
-  isIdentifier,
-  isMemberExpression,
-} from '../node-utils';
+import { findClosestCallNode, isMemberExpression } from '../node-utils';
 
 export const RULE_NAME = 'prefer-explicit-assert';
 export type MessageIds =
@@ -104,7 +104,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
             if (
               matcher === 'not' &&
               isMemberExpression(expectStatement.parent) &&
-              isIdentifier(expectStatement.parent.property)
+              ASTUtils.isIdentifier(expectStatement.parent.property)
             ) {
               isNegatedMatcher = true;
               matcher = expectStatement.parent.property.name;

--- a/lib/rules/prefer-find-by.ts
+++ b/lib/rules/prefer-find-by.ts
@@ -1,4 +1,8 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import {
+  ESLintUtils,
+  TSESTree,
+  ASTUtils,
+} from '@typescript-eslint/experimental-utils';
 import {
   ReportFixFunction,
   RuleFix,
@@ -7,7 +11,6 @@ import {
 import {
   isArrowFunctionExpression,
   isCallExpression,
-  isIdentifier,
   isMemberExpression,
   isObjectPattern,
   isProperty,
@@ -41,7 +44,7 @@ function findRenderDefinitionDeclaration(
   if (variable) {
     return variable.defs
       .map(({ name }) => name)
-      .filter(isIdentifier)
+      .filter(ASTUtils.isIdentifier)
       .find(({ name }) => name === query);
   }
 
@@ -104,7 +107,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
     return {
       'AwaitExpression > CallExpression'(node: TSESTree.CallExpression) {
         if (
-          !isIdentifier(node.callee) ||
+          !ASTUtils.isIdentifier(node.callee) ||
           !WAIT_METHODS.includes(node.callee.name)
         ) {
           return;
@@ -121,8 +124,8 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
         // ensure here it's one of the sync methods that we are calling
         if (
           isMemberExpression(argument.body.callee) &&
-          isIdentifier(argument.body.callee.property) &&
-          isIdentifier(argument.body.callee.object) &&
+          ASTUtils.isIdentifier(argument.body.callee.property) &&
+          ASTUtils.isIdentifier(argument.body.callee.object) &&
           SYNC_QUERIES_COMBINATIONS.includes(argument.body.callee.property.name)
         ) {
           // shape of () => screen.getByText
@@ -145,7 +148,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
           return;
         }
         if (
-          isIdentifier(argument.body.callee) &&
+          ASTUtils.isIdentifier(argument.body.callee) &&
           SYNC_QUERIES_COMBINATIONS.includes(argument.body.callee.name)
         ) {
           // shape of () => getByText
@@ -183,7 +186,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
                   allVariableDeclarations.properties.some(
                     (p) =>
                       isProperty(p) &&
-                      isIdentifier(p.key) &&
+                      ASTUtils.isIdentifier(p.key) &&
                       p.key.name === findByMethod
                   )
                 ) {

--- a/lib/rules/prefer-screen-queries.ts
+++ b/lib/rules/prefer-screen-queries.ts
@@ -1,11 +1,14 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import {
+  ESLintUtils,
+  TSESTree,
+  ASTUtils,
+} from '@typescript-eslint/experimental-utils';
 import { getDocsUrl, ALL_QUERIES_COMBINATIONS } from '../utils';
 import {
   isMemberExpression,
   isObjectPattern,
   isCallExpression,
   isProperty,
-  isIdentifier,
   isObjectExpression,
 } from '../node-utils';
 
@@ -26,7 +29,7 @@ function usesContainerOrBaseElement(node: TSESTree.CallExpression) {
     secondArgument.properties.some(
       (property) =>
         isProperty(property) &&
-        isIdentifier(property.key) &&
+        ASTUtils.isIdentifier(property.key) &&
         ALLOWED_RENDER_PROPERTIES_FOR_DESTRUCTURING.includes(property.key.name)
     )
   );
@@ -68,7 +71,10 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
 
     return {
       VariableDeclarator(node) {
-        if (!isCallExpression(node.init) || !isIdentifier(node.init.callee)) {
+        if (
+          !isCallExpression(node.init) ||
+          !ASTUtils.isIdentifier(node.init.callee)
+        ) {
           return;
         }
         const isWithinFunction = node.init.callee.name === 'within';
@@ -87,7 +93,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
             .filter(
               (property) =>
                 isProperty(property) &&
-                isIdentifier(property.key) &&
+                ASTUtils.isIdentifier(property.key) &&
                 queriesRegex.test(property.key.name)
             )
             .map(
@@ -99,7 +105,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
           return;
         }
 
-        if (isIdentifier(node.id)) {
+        if (ASTUtils.isIdentifier(node.id)) {
           withinDeclaredVariables.push(node.id.name);
         }
       },
@@ -122,10 +128,10 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
         }
 
         if (
-          isIdentifier(node) &&
+          ASTUtils.isIdentifier(node) &&
           isMemberExpression(node.parent) &&
           isCallExpression(node.parent.object) &&
-          isIdentifier(node.parent.object.callee) &&
+          ASTUtils.isIdentifier(node.parent.object.callee) &&
           node.parent.object.callee.name !== 'within' &&
           node.parent.object.callee.name === 'render' &&
           !usesContainerOrBaseElement(node.parent.object)
@@ -136,7 +142,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
 
         if (
           isMemberExpression(node.parent) &&
-          isIdentifier(node.parent.object) &&
+          ASTUtils.isIdentifier(node.parent.object) &&
           !isIdentifierAllowed(node.parent.object.name)
         ) {
           reportInvalidUsage(node);

--- a/lib/rules/prefer-user-event.ts
+++ b/lib/rules/prefer-user-event.ts
@@ -1,6 +1,6 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { TSESTree, ASTUtils } from '@typescript-eslint/experimental-utils';
 import { createTestingLibraryRule } from '../create-testing-library-rule';
-import { isIdentifier, isMemberExpression } from '../node-utils';
+import { isMemberExpression } from '../node-utils';
 
 export const RULE_NAME = 'prefer-user-event';
 
@@ -97,19 +97,19 @@ export default createTestingLibraryRule<Options, MessageIds>({
           // testing library was imported, but fireEvent was not imported
           return;
         }
-        const fireEventAliasOrWildcard = isIdentifier(util)
+        const fireEventAliasOrWildcard = ASTUtils.isIdentifier(util)
           ? util.name
           : util.local.name;
 
         const fireEventUsed =
-          isIdentifier(node.object) &&
+          ASTUtils.isIdentifier(node.object) &&
           node.object.name === fireEventAliasOrWildcard;
 
         const fireEventFromWildcardUsed =
           isMemberExpression(node.object) &&
-          isIdentifier(node.object.object) &&
+          ASTUtils.isIdentifier(node.object.object) &&
           node.object.object.name === fireEventAliasOrWildcard &&
-          isIdentifier(node.object.property) &&
+          ASTUtils.isIdentifier(node.object.property) &&
           node.object.property.name === 'fireEvent';
 
         if (!fireEventUsed && !fireEventFromWildcardUsed) {
@@ -118,7 +118,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
         }
 
         if (
-          !isIdentifier(node.property) ||
+          !ASTUtils.isIdentifier(node.property) ||
           !fireEventMappedMethods.includes(node.property.name) ||
           allowedMethods.includes(node.property.name)
         ) {

--- a/lib/rules/prefer-wait-for.ts
+++ b/lib/rules/prefer-wait-for.ts
@@ -1,9 +1,12 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import {
+  ESLintUtils,
+  TSESTree,
+  ASTUtils,
+} from '@typescript-eslint/experimental-utils';
 import { getDocsUrl } from '../utils';
 import {
   isImportSpecifier,
   isMemberExpression,
-  isIdentifier,
   findClosestCallExpressionNode,
 } from '../node-utils';
 
@@ -97,7 +100,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
             // member expression to get `foo.waitFor(() => {})`
             if (
               isMemberExpression(node.parent) &&
-              isIdentifier(node.parent.object)
+              ASTUtils.isIdentifier(node.parent.object)
             ) {
               methodReplacement = `${node.parent.object.name}.${methodReplacement}`;
             }
@@ -143,7 +146,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
           variable.references.forEach((reference) => {
             if (
               isMemberExpression(reference.identifier.parent) &&
-              isIdentifier(reference.identifier.parent.property) &&
+              ASTUtils.isIdentifier(reference.identifier.parent.property) &&
               DEPRECATED_METHODS.includes(
                 reference.identifier.parent.property.name
               )

--- a/lib/rules/render-result-naming-convention.ts
+++ b/lib/rules/render-result-naming-convention.ts
@@ -1,8 +1,11 @@
-import { ESLintUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import {
+  ESLintUtils,
+  TSESTree,
+  ASTUtils,
+} from '@typescript-eslint/experimental-utils';
 import { getDocsUrl, hasTestingLibraryImportModule } from '../utils';
 import {
   isCallExpression,
-  isIdentifier,
   isImportSpecifier,
   isMemberExpression,
   isObjectPattern,
@@ -102,14 +105,14 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
 
         const renderFunctionName =
           isCallExpression(node.init) &&
-          isIdentifier(node.init.callee) &&
+          ASTUtils.isIdentifier(node.init.callee) &&
           node.init.callee.name;
 
         const renderFunctionObjectName =
           isCallExpression(node.init) &&
           isMemberExpression(node.init.callee) &&
-          isIdentifier(node.init.callee.property) &&
-          isIdentifier(node.init.callee.object) &&
+          ASTUtils.isIdentifier(node.init.callee.property) &&
+          ASTUtils.isIdentifier(node.init.callee.object) &&
           node.init.callee.property.name === 'render' &&
           node.init.callee.object.name;
 
@@ -124,7 +127,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
           return;
         }
 
-        const renderResultName = isIdentifier(node.id) && node.id.name;
+        const renderResultName = ASTUtils.isIdentifier(node.id) && node.id.name;
         const isAllowedRenderResultName = ALLOWED_VAR_NAMES.includes(
           renderResultName
         );


### PR DESCRIPTION
Closes #253 

- [x] Migrate `isIdentifier` 
- [x] Migrate `isAwaitExpression`

It seems there are no [further utils](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/experimental-utils/src/ast-utils/predicates.ts) than the two above. I guess they will add it over time, so we should keep an eye on it 🙂 