### PR TITLE
fix(prefer-explicit-assert): handle getBy* without expect

### DIFF
--- a/lib/rules/prefer-explicit-assert.ts
+++ b/lib/rules/prefer-explicit-assert.ts
@@ -95,6 +95,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
             });
           } else if (assertion) {
             const expectCallNode = findClosestCallNode(node, 'expect');
+            if (!expectCallNode) return;
 
             const expectStatement = expectCallNode.parent as TSESTree.MemberExpression;
             const property = expectStatement.property as TSESTree.Identifier;

--- a/tests/lib/rules/prefer-explicit-assert.test.ts
+++ b/tests/lib/rules/prefer-explicit-assert.test.ts
@@ -67,7 +67,9 @@ ruleTester.run(RULE_NAME, rule, {
       code: `queryByText("foo")`,
     },
     {
-      code: `expect(getByText('foo')).toBeTruthy()`,
+      code: `expect(getByText('foo')).toBeTruthy()
+      
+      fireEvent.click(getByText('bar'));`,
       options: [
         {
           assertion: 'toBeTruthy',


### PR DESCRIPTION
This PR fixes an issue with the `prefer-explicit-assert` `assertion` configuration option. If `assertion` is defined, it currently assumes all `getBy*` queries are wrapped in an `expect`. However, even with the `perfer-explicit-assert` there are valid uses that aren't wrapped in an `expect`:

```js
fireEvent.click(getByText('bar'));
const el = getByText('foo');
```