### PR TITLE
Move rules settings to ESLint shared config: refactor await-async-utils

### DIFF
--- a/docs/rules/await-async-query.md
+++ b/docs/rules/await-async-query.md
@@ -12,10 +12,11 @@ found. Those queries variants are:
 - `findAllBy*`
 
 This rule aims to prevent users from forgetting to handle the returned
-promise from those async queries to be fulfilled, which could lead to
-errors in the tests. The promise will be considered as handled when:
+promise from those async queries, which could lead to
+problems in the tests. The promise will be considered as handled when:
 
 - using the `await` operator
+- wrapped within `Promise.all` or `Promise.allSettled` methods
 - chaining the `then` method
 - chaining `resolves` or `rejects` from jest
 - it's returned from a function (in this case, that particular function will be analyzed by this rule too)

--- a/docs/rules/await-async-query.md
+++ b/docs/rules/await-async-query.md
@@ -71,6 +71,19 @@ const someButton = await findMyButton();
 ```
 
 ```js
+// several promises handled with `Promise.all` is correct
+await Promise.all([findByText('my button'), findByText('something else')]);
+```
+
+```js
+// several promises handled `Promise.allSettled` is correct
+await Promise.allSettled([
+  findByText('my button'),
+  findByText('something else'),
+]);
+```
+
+```js
 // using a resolves/rejects matcher is also correct
 expect(findByTestId('alert')).resolves.toBe('Success');
 expect(findByTestId('alert')).rejects.toBe('Error');

--- a/docs/rules/await-async-utils.md
+++ b/docs/rules/await-async-utils.md
@@ -1,4 +1,4 @@
-# Enforce async utils to be awaited properly (await-async-utils)
+# Enforce promises from async utils to be handled (await-async-utils)
 
 Ensure that promises returned by async utils are handled properly.
 
@@ -6,13 +6,21 @@ Ensure that promises returned by async utils are handled properly.
 
 Testing library provides several utilities for dealing with asynchronous code. These are useful to wait for an element until certain criteria or situation happens. The available async utils are:
 
-- `waitFor` _(introduced in dom-testing-library v7)_
+- `waitFor` _(introduced since dom-testing-library v7)_
 - `waitForElementToBeRemoved`
-- `wait` _(**deprecated** in dom-testing-library v7)_
-- `waitForElement` _(**deprecated** in dom-testing-library v7)_
-- `waitForDomChange` _(**deprecated** in dom-testing-library v7)_
+- `wait` _(**deprecated** since dom-testing-library v7)_
+- `waitForElement` _(**deprecated** since dom-testing-library v7)_
+- `waitForDomChange` _(**deprecated** since dom-testing-library v7)_
 
-This rule aims to prevent users from forgetting to handle the returned promise from those async utils, which could lead to unexpected errors in the tests execution. The promises can be handled by using either `await` operator or `then` method.
+This rule aims to prevent users from forgetting to handle the returned
+promise from async utils, which could lead to
+problems in the tests. The promise will be considered as handled when:
+
+- using the `await` operator
+- wrapped within `Promise.all` or `Promise.allSettled` methods
+- chaining the `then` method
+- chaining `resolves` or `rejects` from jest
+- it's returned from a function (in this case, that particular function will be analyzed by this rule too)
 
 Examples of **incorrect** code for this rule:
 
@@ -32,6 +40,14 @@ test('something incorrectly', async () => {
   waitFor(() => {}, { timeout: 100 });
 
   waitForElementToBeRemoved(() => document.querySelector('div.getOuttaHere'));
+
+  // wrap an async util within a function...
+  const makeCustomWait = () => {
+    return waitForElementToBeRemoved(() =>
+      document.querySelector('div.getOuttaHere')
+    );
+  };
+  makeCustomWait(); // ...but not handling promise from it is incorrect
 });
 ```
 
@@ -56,9 +72,13 @@ test('something correctly', async () => {
     .then(() => console.log('DOM changed!'))
     .catch((err) => console.log(`Error you need to deal with: ${err}`));
 
-  // return the promise within a function is correct too!
-  const makeCustomWait = () =>
-    waitForElementToBeRemoved(() => document.querySelector('div.getOuttaHere'));
+  // wrap an async util within a function...
+  const makeCustomWait = () => {
+    return waitForElementToBeRemoved(() =>
+      document.querySelector('div.getOuttaHere')
+    );
+  };
+  await makeCustomWait(); // ...and handling promise from it is correct
 
   // using Promise.all combining the methods
   await Promise.all([

--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -15,7 +15,7 @@ import {
   isCallExpression,
   isObjectPattern,
 } from './node-utils';
-import { ABSENCE_MATCHERS, PRESENCE_MATCHERS } from './utils';
+import { ABSENCE_MATCHERS, ASYNC_UTILS, PRESENCE_MATCHERS } from './utils';
 
 export type TestingLibrarySettings = {
   'testing-library/module'?: string;
@@ -53,6 +53,7 @@ export type DetectionHelpers = {
   isFindByQuery: (node: TSESTree.Identifier) => boolean;
   isSyncQuery: (node: TSESTree.Identifier) => boolean;
   isAsyncQuery: (node: TSESTree.Identifier) => boolean;
+  isAsyncUtil: (node: TSESTree.Identifier) => boolean;
   isPresenceAssert: (node: TSESTree.MemberExpression) => boolean;
   isAbsenceAssert: (node: TSESTree.MemberExpression) => boolean;
   canReportErrors: () => boolean;
@@ -166,6 +167,13 @@ export function detectTestingLibraryUtils<
      */
     const isAsyncQuery: DetectionHelpers['isAsyncQuery'] = (node) => {
       return isFindByQuery(node);
+    };
+
+    /**
+     * Determines whether a given node is async util or not.
+     */
+    const isAsyncUtil: DetectionHelpers['isAsyncUtil'] = (node) => {
+      return ASYNC_UTILS.includes(node.name);
     };
 
     /**
@@ -312,6 +320,7 @@ export function detectTestingLibraryUtils<
       isFindByQuery,
       isSyncQuery,
       isAsyncQuery,
+      isAsyncUtil,
       isPresenceAssert,
       isAbsenceAssert,
       canReportErrors,

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -212,11 +212,45 @@ export function hasChainedThen(node: TSESTree.Node): boolean {
   return hasThenProperty(parent);
 }
 
+export function isPromiseAll(node: TSESTree.CallExpression): boolean {
+  return (
+    isMemberExpression(node.callee) &&
+    ASTUtils.isIdentifier(node.callee.object) &&
+    node.callee.object.name === 'Promise' &&
+    ASTUtils.isIdentifier(node.callee.property) &&
+    node.callee.property.name === 'all'
+  );
+}
+
+export function isPromiseAllSettled(node: TSESTree.CallExpression): boolean {
+  return (
+    isMemberExpression(node.callee) &&
+    ASTUtils.isIdentifier(node.callee.object) &&
+    node.callee.object.name === 'Promise' &&
+    ASTUtils.isIdentifier(node.callee.property) &&
+    node.callee.property.name === 'allSettled'
+  );
+}
+
+export function isPromisesArrayResolved(node: TSESTree.Node): boolean {
+  const parent = node.parent;
+
+  return (
+    isCallExpression(parent) &&
+    isArrayExpression(parent.parent) &&
+    isCallExpression(parent.parent.parent) &&
+    (isPromiseAll(parent.parent.parent) ||
+      isPromiseAllSettled(parent.parent.parent))
+  );
+}
+
 /**
  * Determines whether an Identifier related to a promise is considered as handled.
  *
  * It will be considered as handled if:
  * - it belongs to the `await` expression
+ * - it belongs to the `Promise.all` method
+ * - it belongs to the `Promise.allSettled` method
  * - it's chained with the `then` method
  * - it's returned from a function
  * - has `resolves` or `rejects`
@@ -248,6 +282,10 @@ export function isPromiseHandled(nodeIdentifier: TSESTree.Identifier): boolean {
     }
 
     if (hasChainedThen(node)) {
+      return true;
+    }
+
+    if (isPromisesArrayResolved(node)) {
       return true;
     }
   }

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -514,3 +514,33 @@ export function hasClosestExpectResolvesRejects(node: TSESTree.Node): boolean {
 
   return hasClosestExpectResolvesRejects(node.parent);
 }
+
+/**
+ * Gets the name of the function which returns the given Identifier.
+ */
+export function getInnermostReturningFunctionName(
+  context: RuleContext<string, []>,
+  node: TSESTree.Identifier
+): string | undefined {
+  const functionScope = getInnermostFunctionScope(context, node);
+
+  if (!functionScope) {
+    return;
+  }
+
+  const returnStatementNode = getFunctionReturnStatementNode(
+    functionScope.block
+  );
+
+  if (!returnStatementNode) {
+    return;
+  }
+
+  const returnStatementIdentifier = getIdentifierNode(returnStatementNode);
+
+  if (returnStatementIdentifier?.name !== node.name) {
+    return;
+  }
+
+  return getFunctionName(functionScope.block);
+}

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -516,12 +516,16 @@ export function hasClosestExpectResolvesRejects(node: TSESTree.Node): boolean {
 }
 
 /**
- * Gets the name of the function which returns the given Identifier.
+ * Gets the Function node which returns the given Identifier.
  */
-export function getInnermostReturningFunctionName(
+export function getInnermostReturningFunction(
   context: RuleContext<string, []>,
   node: TSESTree.Identifier
-): string | undefined {
+):
+  | TSESTree.FunctionDeclaration
+  | TSESTree.FunctionExpression
+  | TSESTree.ArrowFunctionExpression
+  | undefined {
   const functionScope = getInnermostFunctionScope(context, node);
 
   if (!functionScope) {
@@ -542,5 +546,5 @@ export function getInnermostReturningFunctionName(
     return;
   }
 
-  return getFunctionName(functionScope.block);
+  return functionScope.block;
 }

--- a/lib/rules/await-async-query.ts
+++ b/lib/rules/await-async-query.ts
@@ -40,7 +40,6 @@ export default createTestingLibraryRule<Options, MessageIds>({
       const functionScope = getInnermostFunctionScope(context, node);
 
       if (functionScope) {
-        // save function wrapper calls rather than async calls to be reported later
         const returnStatementNode = getFunctionReturnStatementNode(
           functionScope.block
         );

--- a/lib/rules/await-async-query.ts
+++ b/lib/rules/await-async-query.ts
@@ -1,10 +1,7 @@
 import { ASTUtils, TSESTree } from '@typescript-eslint/experimental-utils';
 import {
   findClosestCallExpressionNode,
-  getFunctionName,
-  getFunctionReturnStatementNode,
-  getIdentifierNode,
-  getInnermostFunctionScope,
+  getInnermostReturningFunctionName,
   getVariableReferences,
   isPromiseHandled,
 } from '../node-utils';
@@ -37,25 +34,8 @@ export default createTestingLibraryRule<Options, MessageIds>({
     const functionWrappersNames: string[] = [];
 
     function detectAsyncQueryWrapper(node: TSESTree.Identifier) {
-      const functionScope = getInnermostFunctionScope(context, node);
-
-      if (functionScope) {
-        const returnStatementNode = getFunctionReturnStatementNode(
-          functionScope.block
-        );
-
-        if (!returnStatementNode) {
-          return;
-        }
-
-        const returnStatementIdentifier = getIdentifierNode(
-          returnStatementNode
-        );
-
-        if (returnStatementIdentifier?.name === node.name) {
-          functionWrappersNames.push(getFunctionName(functionScope.block));
-        }
-      }
+      const functionName = getInnermostReturningFunctionName(context, node);
+      functionName && functionWrappersNames.push(functionName);
     }
 
     return {

--- a/lib/rules/await-async-query.ts
+++ b/lib/rules/await-async-query.ts
@@ -1,7 +1,8 @@
 import { ASTUtils, TSESTree } from '@typescript-eslint/experimental-utils';
 import {
   findClosestCallExpressionNode,
-  getInnermostReturningFunctionName,
+  getFunctionName,
+  getInnermostReturningFunction,
   getVariableReferences,
   isPromiseHandled,
 } from '../node-utils';
@@ -34,8 +35,10 @@ export default createTestingLibraryRule<Options, MessageIds>({
     const functionWrappersNames: string[] = [];
 
     function detectAsyncQueryWrapper(node: TSESTree.Identifier) {
-      const functionName = getInnermostReturningFunctionName(context, node);
-      functionName && functionWrappersNames.push(functionName);
+      const innerFunction = getInnermostReturningFunction(context, node);
+      if (innerFunction) {
+        functionWrappersNames.push(getFunctionName(innerFunction));
+      }
     }
 
     return {

--- a/lib/rules/await-async-utils.ts
+++ b/lib/rules/await-async-utils.ts
@@ -1,20 +1,17 @@
-import {
-  ESLintUtils,
-  TSESTree,
-  ASTUtils,
-} from '@typescript-eslint/experimental-utils';
+import { ASTUtils, TSESTree } from '@typescript-eslint/experimental-utils';
 
-import { getDocsUrl, ASYNC_UTILS, LIBRARY_MODULES } from '../utils';
+import { ASYNC_UTILS, LIBRARY_MODULES } from '../utils';
 import {
-  isAwaited,
-  hasChainedThen,
   getVariableReferences,
-  isMemberExpression,
-  isImportSpecifier,
-  isImportNamespaceSpecifier,
-  isCallExpression,
+  hasChainedThen,
   isArrayExpression,
+  isAwaited,
+  isCallExpression,
+  isImportNamespaceSpecifier,
+  isImportSpecifier,
+  isMemberExpression,
 } from '../node-utils';
+import { createTestingLibraryRule } from '../create-testing-library-rule';
 
 export const RULE_NAME = 'await-async-utils';
 export type MessageIds = 'awaitAsyncUtil';
@@ -44,12 +41,12 @@ function isInPromiseAll(node: TSESTree.Node) {
   );
 }
 
-export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
+export default createTestingLibraryRule<Options, MessageIds>({
   name: RULE_NAME,
   meta: {
     type: 'problem',
     docs: {
-      description: 'Enforce async utils to be awaited properly',
+      description: 'Enforce promises from async utils to be handled',
       category: 'Best Practices',
       recommended: 'warn',
     },

--- a/lib/rules/await-async-utils.ts
+++ b/lib/rules/await-async-utils.ts
@@ -1,7 +1,8 @@
 import { TSESTree } from '@typescript-eslint/experimental-utils';
 import {
   findClosestCallExpressionNode,
-  getInnermostReturningFunctionName,
+  getFunctionName,
+  getInnermostReturningFunction,
   getVariableReferences,
   isMemberExpression,
   isPromiseHandled,
@@ -35,9 +36,11 @@ export default createTestingLibraryRule<Options, MessageIds>({
     const functionWrappersNames: string[] = [];
 
     function detectAsyncUtilWrapper(node: TSESTree.Identifier) {
-      const functionName = getInnermostReturningFunctionName(context, node);
+      const innerFunction = getInnermostReturningFunction(context, node);
 
-      functionName && functionWrappersNames.push(functionName);
+      if (innerFunction) {
+        functionWrappersNames.push(getFunctionName(innerFunction));
+      }
     }
 
     return {

--- a/tests/lib/rules/await-async-query.test.ts
+++ b/tests/lib/rules/await-async-query.test.ts
@@ -114,6 +114,54 @@ ruleTester.run(RULE_NAME, rule, {
       `
     ),
 
+    // async queries are valid when wrapped within Promise.all + await expression
+    ...createTestCase(
+      (query) => `
+        doSomething()
+        
+        await Promise.all([
+          ${query}('foo'),
+          ${query}('bar'),
+        ]);
+      `
+    ),
+
+    // async queries are valid when wrapped within Promise.all + then chained
+    ...createTestCase(
+      (query) => `
+        doSomething()
+        
+        Promise.all([
+          ${query}('foo'),
+          ${query}('bar'),
+        ]).then()
+      `
+    ),
+
+    // async queries are valid when wrapped within Promise.allSettled + await expression
+    ...createTestCase(
+      (query) => `
+        doSomething()
+        
+        await Promise.allSettled([
+          ${query}('foo'),
+          ${query}('bar'),
+        ]);
+      `
+    ),
+
+    // async queries are valid when wrapped within Promise.allSettled + then chained
+    ...createTestCase(
+      (query) => `
+        doSomething()
+        
+        Promise.allSettled([
+          ${query}('foo'),
+          ${query}('bar'),
+        ]).then()
+      `
+    ),
+
     // async queries are valid with promise returned in arrow function
     ...createTestCase(
       (query) => `const anArrowFunction = () => ${query}('foo')`

--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -4,6 +4,8 @@ import { ASYNC_UTILS } from '../../../lib/utils';
 
 const ruleTester = createRuleTester();
 
+// FIXME: add cases for Promise.allSettled
+
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     ...ASYNC_UTILS.map((asyncUtil) => ({

--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -123,7 +123,7 @@ ruleTester.run(RULE_NAME, rule, {
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
         import { ${asyncUtil} } from '@testing-library/dom';
-        test('${asyncUtil} util used in with Promise.all() does not trigger an error', async () => {
+        test('${asyncUtil} util used in with Promise.all() is valid', async () => {
           await Promise.all([
             ${asyncUtil}(callback1),
             ${asyncUtil}(callback2),
@@ -134,7 +134,7 @@ ruleTester.run(RULE_NAME, rule, {
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
         import { ${asyncUtil} } from '@testing-library/dom';
-        test('${asyncUtil} util used in with Promise.all() with an await does not trigger an error', async () => {
+        test('${asyncUtil} util used in with Promise.all() with an await is valid', async () => {
           await Promise.all([
             await ${asyncUtil}(callback1),
             await ${asyncUtil}(callback2),
@@ -145,7 +145,7 @@ ruleTester.run(RULE_NAME, rule, {
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
         import { ${asyncUtil} } from '@testing-library/dom';
-        test('${asyncUtil} util used in with Promise.all() with ".then" does not trigger an error', async () => {
+        test('${asyncUtil} util used in with Promise.all() with ".then" is valid', async () => {
           Promise.all([
             ${asyncUtil}(callback1),
             ${asyncUtil}(callback2),
@@ -187,7 +187,7 @@ ruleTester.run(RULE_NAME, rule, {
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
         import { ${asyncUtil} } from '@testing-library/dom';
-        test('${asyncUtil} util used in Promise.allSettled + await expression does not trigger an error', async () => {
+        test('${asyncUtil} util used in Promise.allSettled + await expression is valid', async () => {
           await Promise.allSettled([
             ${asyncUtil}(callback1),
             ${asyncUtil}(callback2),
@@ -198,7 +198,7 @@ ruleTester.run(RULE_NAME, rule, {
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
         import { ${asyncUtil} } from '@testing-library/dom';
-        test('${asyncUtil} util used in Promise.allSettled + then method does not trigger an error', async () => {
+        test('${asyncUtil} util used in Promise.allSettled + then method is valid', async () => {
           Promise.allSettled([
             ${asyncUtil}(callback1),
             ${asyncUtil}(callback2),
@@ -206,9 +206,22 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
     })),
+    ...ASYNC_UTILS.map((asyncUtil) => ({
+      code: `
+        import { ${asyncUtil} } from '@testing-library/dom';
+        
+        function waitForSomethingAsync() {
+          return ${asyncUtil}(() => somethingAsync())
+        }
+
+        test('handled promise from function wrapping ${asyncUtil} util is valid', async () => {
+          await waitForSomethingAsync()
+        });
+      `,
+    })),
     {
       code: `
-      test('using unrelated promises with Promise.all do not throw an error', async () => {
+      test('using unrelated promises with Promise.all is valid', async () => {
         Promise.all([
           waitForNotRelatedToTestingLibrary(),
           promise1,
@@ -222,7 +235,7 @@ ruleTester.run(RULE_NAME, rule, {
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
         import { ${asyncUtil} } from '@testing-library/dom';
-        test('${asyncUtil} util not waited', () => {
+        test('${asyncUtil} util not waited is invalid', () => {
           doSomethingElse();
           ${asyncUtil}(() => getByLabelText('email'));
         });
@@ -232,7 +245,7 @@ ruleTester.run(RULE_NAME, rule, {
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
         import * as asyncUtil from '@testing-library/dom';
-        test('asyncUtil.${asyncUtil} util not waited', () => {
+        test('asyncUtil.${asyncUtil} util not handled is invalid', () => {
           doSomethingElse();
           asyncUtil.${asyncUtil}(() => getByLabelText('email'));
         });
@@ -242,7 +255,7 @@ ruleTester.run(RULE_NAME, rule, {
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
         import { ${asyncUtil} } from '@testing-library/dom';
-        test('${asyncUtil} util promise saved not waited', () => {
+        test('${asyncUtil} util promise saved not handled is invalid', () => {
           doSomethingElse();
           const aPromise = ${asyncUtil}(() => getByLabelText('email'));
         });
@@ -252,7 +265,7 @@ ruleTester.run(RULE_NAME, rule, {
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
         import { ${asyncUtil} } from '@testing-library/dom';
-        test('several ${asyncUtil} utils not waited', () => {
+        test('several ${asyncUtil} utils not handled are invalid', () => {
           const aPromise = ${asyncUtil}(() => getByLabelText('username'));
           doSomethingElse(aPromise);
           ${asyncUtil}(() => getByLabelText('email'));
@@ -262,6 +275,21 @@ ruleTester.run(RULE_NAME, rule, {
         { line: 4, column: 28, messageId: 'awaitAsyncUtil' },
         { line: 6, column: 11, messageId: 'awaitAsyncUtil' },
       ],
+    })),
+    ...ASYNC_UTILS.map((asyncUtil) => ({
+      code: `
+        import { ${asyncUtil}, render } from '@testing-library/dom';
+        
+        function waitForSomethingAsync() {
+          return ${asyncUtil}(() => somethingAsync())
+        }
+
+        test('unhandled promise from function wrapping ${asyncUtil} util is invalid', async () => {
+          render()
+          waitForSomethingAsync()
+        });
+      `,
+      errors: [{ messageId: 'asyncUtilWrapper', line: 10, column: 11 }],
     })),
   ],
 });

--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -5,7 +5,6 @@ import { ASYNC_UTILS } from '../../../lib/utils';
 const ruleTester = createRuleTester();
 
 // FIXME: add cases for Promise.allSettled
-// FIXME: check column on invalid cases
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
@@ -207,7 +206,7 @@ ruleTester.run(RULE_NAME, rule, {
           ${asyncUtil}(() => getByLabelText('email'));
         });
       `,
-      errors: [{ line: 5, messageId: 'awaitAsyncUtil' }],
+      errors: [{ line: 5, column: 11, messageId: 'awaitAsyncUtil' }],
     })),
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
@@ -217,7 +216,7 @@ ruleTester.run(RULE_NAME, rule, {
           asyncUtil.${asyncUtil}(() => getByLabelText('email'));
         });
       `,
-      errors: [{ line: 5, messageId: 'awaitAsyncUtil' }],
+      errors: [{ line: 5, column: 21, messageId: 'awaitAsyncUtil' }],
     })),
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `

--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -230,6 +230,16 @@ ruleTester.run(RULE_NAME, rule, {
       })
       `,
     },
+
+    // edge case for coverage
+    // valid async query usage without any function defined
+    // so there is no innermost function scope found
+    `
+    import { waitFor } from '@testing-library/dom';
+    test('edge case for no innermost function scope', () => {
+      const foo = waitFor
+    })
+    `,
   ],
   invalid: [
     ...ASYNC_UTILS.map((asyncUtil) => ({

--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -5,6 +5,7 @@ import { ASYNC_UTILS } from '../../../lib/utils';
 const ruleTester = createRuleTester();
 
 // FIXME: add cases for Promise.allSettled
+// FIXME: check column on invalid cases
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
@@ -176,19 +177,20 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
     },
-    {
+    ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
-        test('util not related to testing library is valid', async () => {
+        import { ${asyncUtil} } from '@somewhere/else';
+        test('util unhandled but not related to testing library is valid', async () => {
           doSomethingElse();
-          waitNotRelatedToTestingLibrary();
+          ${asyncUtil}('not related to testing library')
         });
       `,
-    },
+    })),
     {
       code: `
       test('using unrelated promises with Promise.all do not throw an error', async () => {
         await Promise.all([
-          someMethod(),
+          waitFor('not related to testing library'),
           promise1,
           await foo().then(() => baz())
         ])


### PR DESCRIPTION
Relates to #198 

This refactor for `await-async-utils` includes:
- using custom rule creator +  detection helpers
- extracting `Promise.all` and `Promise.allSettled` to common util when checking if promise is handled
- covering new case to report wrapper functions returning promise from async util (same as `await-async-query`)