### PR TITLE
Move rules settings to ESLint shared config: refactor no-promise-in-fire-event

### DIFF
--- a/docs/rules/no-promise-in-fire-event.md
+++ b/docs/rules/no-promise-in-fire-event.md
@@ -7,11 +7,18 @@ Examples of **incorrect** code for this rule:
 ```js
 import { screen, fireEvent } from '@testing-library/react';
 
-// usage of findBy queries
+// usage of unhandled findBy queries
 fireEvent.click(screen.findByRole('button'));
 
-// usage of promises
+// usage of unhandled promises
 fireEvent.click(new Promise(jest.fn()));
+
+// usage of references to unhandled promises
+const promise = new Promise();
+fireEvent.click(promise);
+
+const anotherPromise = screen.findByRole('button');
+fireEvent.click(anotherPromise);
 ```
 
 Examples of **correct** code for this rule:
@@ -19,15 +26,20 @@ Examples of **correct** code for this rule:
 ```js
 import { screen, fireEvent } from '@testing-library/react';
 
-// use getBy queries
+// usage of getBy queries
 fireEvent.click(screen.getByRole('button'));
 
-// use awaited findBy queries
+// usage of awaited findBy queries
 fireEvent.click(await screen.findByRole('button'));
 
-// this won't give a linting error, but it will throw a runtime error
+// usage of references to handled promises
 const promise = new Promise();
-fireEvent.click(promise);
+const element = await promise;
+fireEvent.click(element);
+
+const anotherPromise = screen.findByRole('button');
+const button = await anotherPromise;
+fireEvent.click(button);
 ```
 
 ## Further Reading

--- a/docs/rules/no-promise-in-fire-event.md
+++ b/docs/rules/no-promise-in-fire-event.md
@@ -1,6 +1,6 @@
 # Disallow the use of promises passed to a `fireEvent` method (no-promise-in-fire-event)
 
-The `fireEvent` method expects that a DOM element is passed.
+Methods from `fireEvent` expect to receive a DOM element. Passing a promise will end up in an error, so it must be prevented.
 
 Examples of **incorrect** code for this rule:
 
@@ -11,7 +11,7 @@ import { screen, fireEvent } from '@testing-library/react';
 fireEvent.click(screen.findByRole('button'));
 
 // usage of promises
-fireEvent.click(new Promise(jest.fn())
+fireEvent.click(new Promise(jest.fn()));
 ```
 
 Examples of **correct** code for this rule:
@@ -27,7 +27,7 @@ fireEvent.click(await screen.findByRole('button'));
 
 // this won't give a linting error, but it will throw a runtime error
 const promise = new Promise();
-fireEvent.click(promise)`,
+fireEvent.click(promise);
 ```
 
 ## Further Reading

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -191,14 +191,6 @@ export function isImportDeclaration(
   return node?.type === AST_NODE_TYPES.ImportDeclaration;
 }
 
-export function isAwaited(node: TSESTree.Node): boolean {
-  return (
-    ASTUtils.isAwaitExpression(node) ||
-    isArrowFunctionExpression(node) ||
-    isReturnStatement(node)
-  );
-}
-
 export function hasChainedThen(node: TSESTree.Node): boolean {
   const parent = node.parent;
 
@@ -211,11 +203,16 @@ export function hasChainedThen(node: TSESTree.Node): boolean {
   return hasThenProperty(parent);
 }
 
+export function isPromiseIdentifier(
+  node: TSESTree.Node
+): node is TSESTree.Identifier & { name: 'Promise' } {
+  return ASTUtils.isIdentifier(node) && node.name === 'Promise';
+}
+
 export function isPromiseAll(node: TSESTree.CallExpression): boolean {
   return (
     isMemberExpression(node.callee) &&
-    ASTUtils.isIdentifier(node.callee.object) &&
-    node.callee.object.name === 'Promise' &&
+    isPromiseIdentifier(node.callee.object) &&
     ASTUtils.isIdentifier(node.callee.property) &&
     node.callee.property.name === 'all'
   );
@@ -224,8 +221,7 @@ export function isPromiseAll(node: TSESTree.CallExpression): boolean {
 export function isPromiseAllSettled(node: TSESTree.CallExpression): boolean {
   return (
     isMemberExpression(node.callee) &&
-    ASTUtils.isIdentifier(node.callee.object) &&
-    node.callee.object.name === 'Promise' &&
+    isPromiseIdentifier(node.callee.object) &&
     ASTUtils.isIdentifier(node.callee.property) &&
     node.callee.property.name === 'allSettled'
   );

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -83,12 +83,6 @@ export function isBlockStatement(
   return node?.type === AST_NODE_TYPES.BlockStatement;
 }
 
-export function isVariableDeclarator(
-  node: TSESTree.Node
-): node is TSESTree.VariableDeclarator {
-  return node?.type === AST_NODE_TYPES.VariableDeclarator;
-}
-
 export function isObjectPattern(
   node: TSESTree.Node
 ): node is TSESTree.ObjectPattern {
@@ -300,7 +294,7 @@ export function getVariableReferences(
   node: TSESTree.Node
 ): TSESLint.Scope.Reference[] {
   return (
-    (isVariableDeclarator(node) &&
+    (ASTUtils.isVariableDeclarator(node) &&
       context.getDeclaredVariables(node)[0]?.references?.slice(1)) ||
     []
   );

--- a/lib/rules/no-promise-in-fire-event.ts
+++ b/lib/rules/no-promise-in-fire-event.ts
@@ -52,10 +52,6 @@ export default createTestingLibraryRule<Options, MessageIds>({
       if (isCallExpression(node)) {
         const domElementIdentifier = getIdentifierNode(node);
 
-        if (!domElementIdentifier) {
-          return;
-        }
-
         if (
           helpers.isAsyncQuery(domElementIdentifier) ||
           isPromiseIdentifier(domElementIdentifier)
@@ -77,10 +73,8 @@ export default createTestingLibraryRule<Options, MessageIds>({
         }
 
         for (const definition of nodeVariable.defs) {
-          if (!ASTUtils.isVariableDeclarator(definition.node)) {
-            return;
-          }
-          checkSuspiciousNode(definition.node.init, node);
+          const variableDeclarator = definition.node as TSESTree.VariableDeclarator;
+          checkSuspiciousNode(variableDeclarator.init, node);
         }
       }
     }

--- a/lib/rules/no-promise-in-fire-event.ts
+++ b/lib/rules/no-promise-in-fire-event.ts
@@ -28,7 +28,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
       noPromiseInFireEvent:
         "A promise shouldn't be passed to a `fireEvent` method, instead pass the DOM element",
     },
-    fixable: 'code',
+    fixable: null,
     schema: [],
   },
   defaultOptions: [],

--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -4,6 +4,8 @@ import { ASYNC_UTILS } from '../../../lib/utils';
 
 const ruleTester = createRuleTester();
 
+// FIXME: add cases for Promise.allSettled
+
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     ...ASYNC_UTILS.map((asyncUtil) => ({

--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -4,8 +4,6 @@ import { ASYNC_UTILS } from '../../../lib/utils';
 
 const ruleTester = createRuleTester();
 
-// FIXME: add cases for Promise.allSettled
-
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     ...ASYNC_UTILS.map((asyncUtil) => ({

--- a/tests/lib/rules/no-promise-in-fire-event.test.ts
+++ b/tests/lib/rules/no-promise-in-fire-event.test.ts
@@ -28,6 +28,7 @@ ruleTester.run(RULE_NAME, rule, {
       code: `fireEvent.click(findByText('submit'))`,
     },
     {
+      // TODO: report this as invalid
       code: `
         import {fireEvent} from '@testing-library/foo';
 
@@ -54,6 +55,9 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [
         {
           messageId: 'noPromiseInFireEvent',
+          line: 4,
+          column: 25,
+          endColumn: 52,
         },
       ],
     },
@@ -65,6 +69,9 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [
         {
           messageId: 'noPromiseInFireEvent',
+          line: 4,
+          column: 25,
+          endColumn: 45,
         },
       ],
     },
@@ -76,6 +83,9 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [
         {
           messageId: 'noPromiseInFireEvent',
+          line: 4,
+          column: 25,
+          endColumn: 39,
         },
       ],
     },
@@ -87,6 +97,9 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [
         {
           messageId: 'noPromiseInFireEvent',
+          line: 4,
+          column: 25,
+          endColumn: 43,
         },
       ],
     },

--- a/tests/lib/rules/no-promise-in-fire-event.test.ts
+++ b/tests/lib/rules/no-promise-in-fire-event.test.ts
@@ -48,6 +48,17 @@ ruleTester.run(RULE_NAME, rule, {
         fireEvent.click(findByText('submit'))
     `,
     },
+    `// edge case for coverage:
+     // valid use case without call expression
+     // so there is no innermost function scope found
+     test('edge case for no innermost function scope', () => {
+      const click = fireEvent.click
+    })
+    `,
+    `// edge case for coverage:
+     // new expression of something else than Promise
+     fireEvent.click(new SomeElement())
+    `,
   ],
   invalid: [
     {

--- a/tests/lib/rules/no-promise-in-fire-event.test.ts
+++ b/tests/lib/rules/no-promise-in-fire-event.test.ts
@@ -25,19 +25,28 @@ ruleTester.run(RULE_NAME, rule, {
         fireEvent.click(someRef)`,
     },
     {
-      // TODO: report this as invalid
-      code: `
-        import {fireEvent} from '@testing-library/foo';
-
-        const promise = new Promise();
-        fireEvent.click(promise)`,
-    },
-    {
       code: `
         import {fireEvent} from '@testing-library/foo';
         
         fireEvent.click(await screen.findByRole('button'))
       `,
+    },
+    {
+      code: `
+        import {fireEvent} from '@testing-library/foo'
+
+        const elementPromise = screen.findByRole('button')
+        const button = await elementPromise
+        fireEvent.click(button)`,
+    },
+    {
+      settings: {
+        'testing-library/module': 'test-utils',
+      },
+      code: `// invalid usage but aggressive reporting opted-out
+        import { fireEvent } from 'somewhere-else'
+        fireEvent.click(findByText('submit'))
+    `,
     },
   ],
   invalid: [
@@ -62,6 +71,36 @@ ruleTester.run(RULE_NAME, rule, {
           line: 1,
           column: 17,
           endColumn: 26,
+        },
+      ],
+    },
+    {
+      code: `
+        import {fireEvent} from '@testing-library/foo';
+
+        const promise = new Promise();
+        fireEvent.click(promise)`,
+      errors: [
+        {
+          messageId: 'noPromiseInFireEvent',
+          line: 5,
+          column: 25,
+          endColumn: 32,
+        },
+      ],
+    },
+    {
+      code: `
+        import {fireEvent} from '@testing-library/foo'
+
+        const elementPromise = screen.findByRole('button')
+        fireEvent.click(elementPromise)`,
+      errors: [
+        {
+          messageId: 'noPromiseInFireEvent',
+          line: 5,
+          column: 25,
+          endColumn: 39,
         },
       ],
     },

--- a/tests/lib/rules/no-promise-in-fire-event.test.ts
+++ b/tests/lib/rules/no-promise-in-fire-event.test.ts
@@ -25,9 +25,6 @@ ruleTester.run(RULE_NAME, rule, {
         fireEvent.click(someRef)`,
     },
     {
-      code: `fireEvent.click(findByText('submit'))`,
-    },
-    {
       // TODO: report this as invalid
       code: `
         import {fireEvent} from '@testing-library/foo';
@@ -42,11 +39,32 @@ ruleTester.run(RULE_NAME, rule, {
         fireEvent.click(await screen.findByRole('button'))
       `,
     },
-    {
-      code: `fireEvent.click(Promise())`,
-    },
   ],
   invalid: [
+    {
+      // aggressive reporting opted-in
+      code: `fireEvent.click(findByText('submit'))`,
+      errors: [
+        {
+          messageId: 'noPromiseInFireEvent',
+          line: 1,
+          column: 17,
+          endColumn: 37,
+        },
+      ],
+    },
+    {
+      // aggressive reporting opted-in
+      code: `fireEvent.click(Promise())`,
+      errors: [
+        {
+          messageId: 'noPromiseInFireEvent',
+          line: 1,
+          column: 17,
+          endColumn: 26,
+        },
+      ],
+    },
     {
       code: `
         import {fireEvent} from '@testing-library/foo';


### PR DESCRIPTION
Relates to #198 

This refactor for `no-promise-in-fire-event` includes:

- using custom rule creator + detection helpers
- covering new case to report promises references from variables