### PR TITLE
chore: rename references to default branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
 jobs:
   include:
     - stage: release
-      if: branch = master AND type != pull_request AND fork = false
+      if: branch = main AND type != pull_request AND fork = false
       node_js: 14
       env: ESLINT=7
       script: npm run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,20 +12,20 @@ Working on your first Pull Request? You can learn how from this free series
 3. Run `npm install` to install corresponding dependencies
 4. Create a branch for your PR named like `pr/your-branch-name` (you can do this through git CLI with `git checkout -b pr/your-branch-name`)
 
-> Tip: Keep your `master` branch pointing at the original repository and make
+> Tip: Keep your `main` branch pointing at the original repository and make
 > pull requests from branches on your fork. To do this, run:
 >
 > ```
 > git remote add upstream https://github.com/testing-library/eslint-plugin-testing-library.git
 > git fetch upstream
-> git branch --set-upstream-to=upstream/master master
+> git branch --set-upstream-to=upstream/main main
 > ```
 >
 > This will add the original repository as a "remote" called "upstream," Then
-> fetch the git information from that remote, then set your local `master`
-> branch to use the upstream master branch whenever you run `git pull`. Then you
-> can make all of your pull request branches based on this `master` branch.
-> Whenever you want to update your version of `master`, do a regular `git pull`.
+> fetch the git information from that remote, then set your local `main`
+> branch to use the upstream main branch whenever you run `git pull`. Then you
+> can make all of your pull request branches based on this `main` branch.
+> Whenever you want to update your version of `main`, do a regular `git pull`.
 
 ## Committing and Pushing changes
 
@@ -65,7 +65,7 @@ Additionally, you need to do a couple of extra things:
 
 - Import the new rule in `lib/index.ts` and include it
   in `rules` constant (there is a test which will make sure you did
- this). Remember to include your rule under corresponding `config` if necessary
+  this). Remember to include your rule under corresponding `config` if necessary
   (a snapshot test will check this too, but you can update it just running
   `npm run test:update`).
 - Include your rule in the "Supported Rules" table within the [README.md](./README.md).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@
 [![Tweet][tweet-badge]][tweet-url]
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-35-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ## Installation
@@ -156,7 +158,7 @@ To enable this configuration use the `extends` property in your
 [version-badge]: https://img.shields.io/npm/v/eslint-plugin-testing-library?style=flat-square
 [version-url]: https://www.npmjs.com/package/eslint-plugin-testing-library
 [license-badge]: https://img.shields.io/npm/l/eslint-plugin-testing-library?style=flat-square
-[license-url]: https://github.com/belco90/eslint-plugin-testing-library/blob/master/license
+[license-url]: https://github.com/belco90/eslint-plugin-testing-library/blob/main/license
 [pr-badge]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square
 [pr-url]: http://makeapullrequest.com
 [gh-watchers-badge]: https://img.shields.io/github/watchers/Belco90/eslint-plugin-testing-library?style=social
@@ -228,6 +230,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,8 +10,8 @@ const combineQueries = (variants: string[], methods: string[]) => {
   return combinedQueries;
 };
 
-const getDocsUrl = (ruleName: string) =>
-  `https://github.com/testing-library/eslint-plugin-testing-library/tree/master/docs/rules/${ruleName}.md`;
+const getDocsUrl = (ruleName: string): string =>
+  `https://github.com/testing-library/eslint-plugin-testing-library/tree/main/docs/rules/${ruleName}.md`;
 
 const LIBRARY_MODULES = [
   '@testing-library/dom',


### PR DESCRIPTION
Rename references to default branch which now is `main`.

If you have a local clone, you can update it by running:
```
git branch -m master main
git fetch origin
git branch -u origin/main main
```