### PR TITLE
Move rules settings to ESLint shared config: Aggressive Render Reporting + refactor render-result-naming-convention

### DIFF
--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -276,12 +276,20 @@ export function detectTestingLibraryUtils<
         return false;
       }
 
-      if (isAggressiveRenderEnabled()) {
-        // TODO: should this be always true?
-        return identifier.name.toLowerCase().startsWith('render');
+      const isNameMatching = (function () {
+        if (isAggressiveRenderEnabled()) {
+          return identifier.name.toLowerCase().includes('render');
+        }
+
+        return ['render', ...customRenders].includes(identifier.name);
+      })();
+
+      if (!isNameMatching) {
+        return false;
       }
 
-      return ['render', ...customRenders].includes(identifier.name);
+      // TODO: check if node comes from testing library if based on aggressive reporting
+      return true;
     };
 
     /**

--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -102,16 +102,25 @@ export function detectTestingLibraryUtils<
     const customRenders = context.settings['testing-library/custom-renders'];
 
     /**
-     * Determines whether aggressive module  reporting is enabled or not.
+     * Determines whether aggressive module reporting is enabled or not.
      *
-     * Aggressive module reporting is considered as enabled when custom module
-     * is not set (so we need to assume everything matching TL utils is related
-     * to TL no matter from where module they are coming from)
+     * This aggressive reporting mechanism is considered as enabled when custom
+     * module is not set, so we need to assume everything matching Testing
+     * Library utils is related to Testing Library no matter from where module
+     * they are coming from. Otherwise, this aggressive reporting mechanism is
+     * opted-out in favour to report only those utils coming from Testing
+     * Library package or custom module set up on settings.
      */
     const isAggressiveModuleReportingEnabled = () => !customModule;
 
     /**
-     * TODO
+     * Determines whether aggressive render reporting is enabled or not.
+     *
+     * This aggressive reporting mechanism is considered as enabled when custom
+     * renders are not set, so we need to assume every method containing
+     * "render" is a valid Testing Library `render`. Otherwise, this aggressive
+     * reporting mechanism is opted-out in favour to report only `render` or
+     * names set up on custom renders setting.
      */
     const isAggressiveRenderReportingEnabled = () =>
       !Array.isArray(customRenders) || customRenders.length === 0;
@@ -268,7 +277,21 @@ export function detectTestingLibraryUtils<
     };
 
     /**
-     * TODO
+     * Determines whether a given node is a valid render util or not.
+     *
+     * A node will be interpreted as a valid render based on two conditions:
+     * the name matches with a valid "render" option, and the node is coming
+     * from Testing Library module. This depends on:
+     *
+     * - Aggressive render reporting: if enabled, then every node name
+     * containing "render" will be assumed as Testing Library render util.
+     * Otherwise, it means `custom-modules` has been set up, so only those nodes
+     * named as "render" or some of the `custom-modules` options will be
+     * considered as Testing Library render util.
+     * - Aggressive module reporting: if enabled, then it doesn't matter from
+     * where the given node was imported from as it will be considered part of
+     * Testing Library. Otherwise, it means `custom-module` has been set up, so
+     * only those nodes coming from Testing Library will be considered as valid.
      */
     const isRenderUtil: DetectionHelpers['isRenderUtil'] = (node) => {
       const identifier = getIdentifierNode(node);

--- a/lib/rules/render-result-naming-convention.ts
+++ b/lib/rules/render-result-naming-convention.ts
@@ -14,6 +14,8 @@ import {
 
 export const RULE_NAME = 'render-result-naming-convention';
 export type MessageIds = 'renderResultNamingConvention';
+
+// TODO: remove renderFunctions option first, and then move it to ESLint settings
 type Options = [{ renderFunctions?: string[] }];
 
 const ALLOWED_VAR_NAMES = ['view', 'utils'];
@@ -57,6 +59,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
     let wildcardImportName: string | undefined;
 
     return {
+      // TODO: this can be removed
       // check named imports
       ImportDeclaration(node: TSESTree.ImportDeclaration) {
         if (!hasTestingLibraryImportModule(node)) {
@@ -72,6 +75,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
 
         renderAlias = renderImport.local.name;
       },
+      // TODO: this can be removed
       // check wildcard imports
       'ImportDeclaration ImportNamespaceSpecifier'(
         node: TSESTree.ImportNamespaceSpecifier
@@ -92,10 +96,14 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
           return;
         }
 
+        // TODO: call `helpers.isRender` with the node.init
+        //  this ini could be Identifier (render) or MemberExpression (rtl.render)
         const isValidRenderDeclarator = isRenderVariableDeclarator(node, [
           ...renderFunctions,
           renderAlias,
         ]);
+
+        // TODO: After this point, most of the checks should be removed
         const isValidWildcardImport = !!wildcardImportName;
 
         // check if is a Testing Library related import

--- a/lib/rules/render-result-naming-convention.ts
+++ b/lib/rules/render-result-naming-convention.ts
@@ -1,29 +1,18 @@
-import {
-  ESLintUtils,
-  TSESTree,
-  ASTUtils,
-} from '@typescript-eslint/experimental-utils';
-import { getDocsUrl, hasTestingLibraryImportModule } from '../utils';
-import {
-  isCallExpression,
-  isImportSpecifier,
-  isMemberExpression,
-  isObjectPattern,
-  isRenderVariableDeclarator,
-} from '../node-utils';
+import { createTestingLibraryRule } from '../create-testing-library-rule';
+import { isObjectPattern } from '../node-utils';
+import { ASTUtils } from '@typescript-eslint/experimental-utils';
 
 export const RULE_NAME = 'render-result-naming-convention';
 export type MessageIds = 'renderResultNamingConvention';
 
-// TODO: remove renderFunctions option first, and then move it to ESLint settings
-type Options = [{ renderFunctions?: string[] }];
+type Options = [];
 
 const ALLOWED_VAR_NAMES = ['view', 'utils'];
 const ALLOWED_VAR_NAMES_TEXT = ALLOWED_VAR_NAMES.map(
   (name) => `\`${name}\``
 ).join(', ');
 
-export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
+export default createTestingLibraryRule<Options, MessageIds>({
   name: RULE_NAME,
   meta: {
     type: 'suggestion',
@@ -33,109 +22,27 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
       recommended: false,
     },
     messages: {
-      renderResultNamingConvention: `\`{{ varName }}\` is not a recommended name for \`render\` returned value. Instead, you should destructure it, or call it using one of the valid choices: ${ALLOWED_VAR_NAMES_TEXT}`,
+      renderResultNamingConvention: `\`{{ renderResultName }}\` is not a recommended name for \`render\` returned value. Instead, you should destructure it, or name it using one of: ${ALLOWED_VAR_NAMES_TEXT}`,
     },
     fixable: null,
-    schema: [
-      {
-        type: 'object',
-        properties: {
-          renderFunctions: {
-            type: 'array',
-          },
-        },
-      },
-    ],
+    schema: [],
   },
-  defaultOptions: [
-    {
-      renderFunctions: [],
-    },
-  ],
+  defaultOptions: [],
 
-  create(context, [options]) {
-    const { renderFunctions } = options;
-    let renderAlias: string | undefined;
-    let wildcardImportName: string | undefined;
-
+  create(context, _, helpers) {
     return {
-      // TODO: this can be removed
-      // check named imports
-      ImportDeclaration(node: TSESTree.ImportDeclaration) {
-        if (!hasTestingLibraryImportModule(node)) {
-          return;
-        }
-        const renderImport = node.specifiers.find(
-          (node) => isImportSpecifier(node) && node.imported.name === 'render'
-        );
-
-        if (!renderImport) {
+      VariableDeclarator(node) {
+        if (!helpers.isRenderUtil(node.init)) {
           return;
         }
 
-        renderAlias = renderImport.local.name;
-      },
-      // TODO: this can be removed
-      // check wildcard imports
-      'ImportDeclaration ImportNamespaceSpecifier'(
-        node: TSESTree.ImportNamespaceSpecifier
-      ) {
-        if (
-          !hasTestingLibraryImportModule(
-            node.parent as TSESTree.ImportDeclaration
-          )
-        ) {
-          return;
-        }
-
-        wildcardImportName = node.local.name;
-      },
-      VariableDeclarator(node: TSESTree.VariableDeclarator) {
         // check if destructuring return value from render
         if (isObjectPattern(node.id)) {
           return;
         }
 
-        // TODO: call `helpers.isRender` with the node.init
-        //  this ini could be Identifier (render) or MemberExpression (rtl.render)
-        const isValidRenderDeclarator = isRenderVariableDeclarator(node, [
-          ...renderFunctions,
-          renderAlias,
-        ]);
-
-        // TODO: After this point, most of the checks should be removed
-        const isValidWildcardImport = !!wildcardImportName;
-
-        // check if is a Testing Library related import
-        if (!isValidRenderDeclarator && !isValidWildcardImport) {
-          return;
-        }
-
-        const renderFunctionName =
-          isCallExpression(node.init) &&
-          ASTUtils.isIdentifier(node.init.callee) &&
-          node.init.callee.name;
-
-        const renderFunctionObjectName =
-          isCallExpression(node.init) &&
-          isMemberExpression(node.init.callee) &&
-          ASTUtils.isIdentifier(node.init.callee.property) &&
-          ASTUtils.isIdentifier(node.init.callee.object) &&
-          node.init.callee.property.name === 'render' &&
-          node.init.callee.object.name;
-
-        const isRenderAlias = !!renderAlias;
-        const isCustomRender = renderFunctions.includes(renderFunctionName);
-        const isWildCardRender =
-          renderFunctionObjectName &&
-          renderFunctionObjectName === wildcardImportName;
-
-        // check if is a qualified render function
-        if (!isRenderAlias && !isCustomRender && !isWildCardRender) {
-          return;
-        }
-
         const renderResultName = ASTUtils.isIdentifier(node.id) && node.id.name;
+
         const isAllowedRenderResultName = ALLOWED_VAR_NAMES.includes(
           renderResultName
         );
@@ -149,7 +56,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
           node,
           messageId: 'renderResultNamingConvention',
           data: {
-            varName: renderResultName,
+            renderResultName,
           },
         });
       },

--- a/tests/fake-rule.ts
+++ b/tests/fake-rule.ts
@@ -9,6 +9,7 @@ export const RULE_NAME = 'fake-rule';
 type Options = [];
 type MessageIds =
   | 'fakeError'
+  | 'renderError'
   | 'getByError'
   | 'queryByError'
   | 'findByError'
@@ -27,6 +28,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
     },
     messages: {
       fakeError: 'fake error reported',
+      renderError: 'some error related to render util reported',
       getByError: 'some error related to getBy reported',
       queryByError: 'some error related to queryBy reported',
       findByError: 'some error related to findBy reported',
@@ -41,8 +43,8 @@ export default createTestingLibraryRule<Options, MessageIds>({
   create(context, _, helpers) {
     const reportCallExpressionIdentifier = (node: TSESTree.Identifier) => {
       // force "render" to be reported
-      if (node.name === 'render') {
-        return context.report({ node, messageId: 'fakeError' });
+      if (helpers.isRenderUtil(node)) {
+        return context.report({ node, messageId: 'renderError' });
       }
 
       if (helpers.isCustomQuery(node)) {

--- a/tests/lib/rules/render-result-naming-convention.test.ts
+++ b/tests/lib/rules/render-result-naming-convention.test.ts
@@ -93,11 +93,7 @@ ruleTester.run(RULE_NAME, rule, {
           const button = screen.getByText('some button');
         });
       `,
-      options: [
-        {
-          renderFunctions: ['customRender'],
-        },
-      ],
+      settings: { 'testing-library/custom-renders': ['customRender'] },
     },
     {
       code: `
@@ -108,11 +104,7 @@ ruleTester.run(RULE_NAME, rule, {
           await view.findByRole('button');
         });
       `,
-      options: [
-        {
-          renderFunctions: ['customRender'],
-        },
-      ],
+      settings: { 'testing-library/custom-renders': ['customRender'] },
     },
     {
       code: `
@@ -123,11 +115,7 @@ ruleTester.run(RULE_NAME, rule, {
           await utils.findByRole('button');
         });
       `,
-      options: [
-        {
-          renderFunctions: ['customRender'],
-        },
-      ],
+      settings: { 'testing-library/custom-renders': ['customRender'] },
     },
     {
       code: `
@@ -203,7 +191,7 @@ ruleTester.run(RULE_NAME, rule, {
         {
           messageId: 'renderResultNamingConvention',
           data: {
-            varName: 'wrapper',
+            renderResultName: 'wrapper',
           },
           line: 5,
           column: 17,
@@ -223,7 +211,7 @@ ruleTester.run(RULE_NAME, rule, {
         {
           messageId: 'renderResultNamingConvention',
           data: {
-            varName: 'wrapper',
+            renderResultName: 'wrapper',
           },
           line: 5,
           column: 17,
@@ -243,7 +231,7 @@ ruleTester.run(RULE_NAME, rule, {
         {
           messageId: 'renderResultNamingConvention',
           data: {
-            varName: 'component',
+            renderResultName: 'component',
           },
           line: 5,
           column: 17,
@@ -280,7 +268,7 @@ ruleTester.run(RULE_NAME, rule, {
         {
           messageId: 'renderResultNamingConvention',
           data: {
-            varName: 'wrapper',
+            renderResultName: 'wrapper',
           },
           line: 5,
           column: 17,
@@ -307,7 +295,7 @@ ruleTester.run(RULE_NAME, rule, {
         {
           messageId: 'renderResultNamingConvention',
           data: {
-            varName: 'wrapper',
+            renderResultName: 'wrapper',
           },
           line: 6,
           column: 17,
@@ -323,16 +311,12 @@ ruleTester.run(RULE_NAME, rule, {
           const button = wrapper.getByText('some button');
         });
       `,
-      options: [
-        {
-          renderFunctions: ['customRender'],
-        },
-      ],
+      settings: { 'testing-library/custom-renders': ['customRender'] },
       errors: [
         {
           messageId: 'renderResultNamingConvention',
           data: {
-            varName: 'wrapper',
+            renderResultName: 'wrapper',
           },
           line: 5,
           column: 17,

--- a/tests/lib/rules/render-result-naming-convention.test.ts
+++ b/tests/lib/rules/render-result-naming-convention.test.ts
@@ -119,48 +119,6 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { render } from '@foo/bar';
-        
-        test('should not report from render not related to testing library', () => {
-          const wrapper = render(<SomeComponent />);
-          const button = wrapper.getByText('some button');
-        });
-      `,
-    },
-    {
-      code: `
-        import { render } from '@foo/bar';
-        
-        test('should not report from render not imported from testing library', () => {
-          const wrapper = render(<SomeComponent />);
-          const button = wrapper.getByText('some button');
-        });
-      `,
-    },
-    {
-      code: `
-        import * as RTL from '@foo/bar';
-        
-        test('should not report from wildcard render not imported from testing library', () => {
-          const wrapper = RTL.render(<SomeComponent />);
-          const button = wrapper.getByText('some button');
-        });
-      `,
-    },
-    {
-      code: `
-        function render() {
-          return 'whatever';
-        }
-        
-        test('should not report from custom render not related to testing library', () => {
-          const wrapper = render(<SomeComponent />);
-          const button = wrapper.getByText('some button');
-        });
-      `,
-    },
-    {
-      code: `
         import { render } from '@testing-library/react';
         
         const setup = () => {
@@ -319,6 +277,68 @@ ruleTester.run(RULE_NAME, rule, {
             renderResultName: 'wrapper',
           },
           line: 5,
+          column: 17,
+        },
+      ],
+    },
+    {
+      code: `
+        import { render } from '@foo/bar';
+
+        test('aggressive reporting - should report from render not related to testing library', () => {
+          const wrapper = render(<SomeComponent />);
+          const button = wrapper.getByText('some button');
+        });
+      `,
+      errors: [
+        {
+          messageId: 'renderResultNamingConvention',
+          data: {
+            renderResultName: 'wrapper',
+          },
+          line: 5,
+          column: 17,
+        },
+      ],
+    },
+    {
+      code: `
+        import * as RTL from '@foo/bar';
+
+        test('aggressive reporting - should report from wildcard render not imported from testing library', () => {
+          const wrapper = RTL.render(<SomeComponent />);
+          const button = wrapper.getByText('some button');
+        });
+      `,
+      errors: [
+        {
+          messageId: 'renderResultNamingConvention',
+          data: {
+            renderResultName: 'wrapper',
+          },
+          line: 5,
+          column: 17,
+        },
+      ],
+    },
+    {
+      code: `
+        function render() {
+          return 'whatever';
+        }
+
+        test('aggressive reporting - should report from custom render not related to testing library', () => {
+          const wrapper = render(<SomeComponent />);
+          const button = wrapper.getByText('some button');
+        });
+      `,
+      errors: [
+        {
+          messageId: 'renderResultNamingConvention',
+          data: {
+            renderResultName: 'wrapper',
+          },
+          line: 7,
           column: 17,
         },
       ],


### PR DESCRIPTION
I'm back 😎 Let's get v4 finished!

Relates to #198 

This PR includes:
- new `testing-library/custom-renders` shared setting to config custom render methods
- new `isRenderUtil` helper to detect `render` methods related to Testing Library + Aggressive Render Reporting
- tests for `render` detection within fake rule
- refactor `render-result-naming-convention` to use custom rule creator + detection helper
- fix some rule tests (some valid cases are invalid now due to Aggressive Render Reporting)
- remove `renderFunctions` rule option in favor of the new shared setting included