### PR TITLE
refactor: several tweaks

### DIFF
--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -265,11 +265,11 @@ export function detectTestingLibraryUtils<
      * the name matches with some Testing Library async util, and the node is
      * coming from Testing Library module.
      *
-     * The latter depends on Aggressive
-     * module reporting: if enabled, then it doesn't matter from
-     * where the given node was imported from as it will be considered part of
-     * Testing Library. Otherwise, it means `custom-module` has been set up, so
-     * only those nodes coming from Testing Library will be considered as valid.
+     * The latter depends on Aggressive module reporting:
+     * if enabled, then it doesn't matter from where the given node was imported
+     * from as it will be considered part of Testing Library.
+     * Otherwise, it means `custom-module` has been set up, so only those nodes
+     * coming from Testing Library will be considered as valid.
      */
     const isAsyncUtil: IsAsyncUtilFn = (node) => {
       return isTestingLibraryUtil(node, (identifierNode) =>

--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -447,11 +447,7 @@ export function detectTestingLibraryUtils<
       node
     ) => {
       const identifierName: string | undefined = getPropertyIdentifierNode(node)
-        ?.name;
-
-      if (!identifierName) {
-        return false;
-      }
+        .name;
 
       return !!findImportedUtilSpecifier(identifierName);
     };

--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -331,9 +331,20 @@ export function detectTestingLibraryUtils<
         return false;
       }
 
+      const referenceNode = (function () {
+        if (isMemberExpression(node)) {
+          return node;
+        }
+
+        if (node.parent && isMemberExpression(node.parent)) {
+          return node.parent;
+        }
+        return identifier;
+      })();
+
       return (
         isAggressiveModuleReportingEnabled() ||
-        isNodeComingFromTestingLibrary(identifier)
+        isNodeComingFromTestingLibrary(referenceNode)
       );
     };
 

--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -446,13 +446,8 @@ export function detectTestingLibraryUtils<
     const isNodeComingFromTestingLibrary: IsNodeComingFromTestingLibraryFn = (
       node
     ) => {
-      let identifierName: string | undefined;
-
-      if (ASTUtils.isIdentifier(node)) {
-        identifierName = node.name;
-      } else if (ASTUtils.isIdentifier(node.object)) {
-        identifierName = node.object.name;
-      }
+      const identifierName: string | undefined = getPropertyIdentifierNode(node)
+        ?.name;
 
       if (!identifierName) {
         return false;

--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -23,7 +23,7 @@ import {
 } from './utils';
 
 export type TestingLibrarySettings = {
-  'testing-library/module'?: string;
+  'testing-library/utils-module'?: string;
   'testing-library/filename-pattern'?: string;
   'testing-library/custom-renders'?: string[];
 };
@@ -95,7 +95,7 @@ export function detectTestingLibraryUtils<
     let importedCustomModuleNode: ImportModuleNode | null = null;
 
     // Init options based on shared ESLint settings
-    const customModule = context.settings['testing-library/module'];
+    const customModule = context.settings['testing-library/utils-module'];
     const filenamePattern =
       context.settings['testing-library/filename-pattern'] ??
       DEFAULT_FILENAME_PATTERN;
@@ -150,7 +150,7 @@ export function detectTestingLibraryUtils<
      * custom modules.
      *
      * However, there is a setting to customize the module where TL utils can
-     * be imported from: "testing-library/module". If this setting is enabled,
+     * be imported from: "testing-library/utils-module". If this setting is enabled,
      * then this method will return `true` ONLY IF a testing-library package
      * or custom module are imported.
      */

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -363,6 +363,45 @@ export function getFunctionReturnStatementNode(
   return null;
 }
 
+/**
+ * Gets the property identifier node of a given property node.
+ *
+ * Not to be confused with {@link getIdentifierNode}
+ *
+ * An example:
+ * Having `const a = rtl.within('foo').getByRole('button')`:
+ *  if we call `getPropertyIdentifierNode` with `rtl` property node,
+ *  it will return `rtl` identifier node
+ */
+export function getPropertyIdentifierNode(
+  node: TSESTree.Node
+): TSESTree.Identifier | null {
+  if (ASTUtils.isIdentifier(node)) {
+    return node;
+  }
+
+  if (isMemberExpression(node)) {
+    return getPropertyIdentifierNode(node.object);
+  }
+
+  if (isCallExpression(node)) {
+    return getPropertyIdentifierNode(node.callee);
+  }
+
+  return null;
+}
+
+/**
+ * Gets the deepest identifier node from a given node.
+ *
+ * Opposite of {@link getReferenceNode}
+ *
+ * An example:
+ * Having `const a = rtl.within('foo').getByRole('button')`:
+ *  if we call `getIdentifierNode` with `rtl` node,
+ *  it will return `getByRole` identifier
+ */
+// TODO: rename to getDeepestIdentifierNode
 export function getIdentifierNode(
   node: TSESTree.Node
 ): TSESTree.Identifier | null {
@@ -379,6 +418,29 @@ export function getIdentifierNode(
   }
 
   return null;
+}
+
+/**
+ * Gets the farthest node from a given node.
+ *
+ * Opposite of {@link getIdentifierNode}
+
+ * An example:
+ * Having `const a = rtl.within('foo').getByRole('button')`:
+ *  if we call `getReferenceNode` with `getByRole` identifier,
+ *  it will return `rtl` node
+ */
+export function getReferenceNode(
+  node:
+    | TSESTree.CallExpression
+    | TSESTree.MemberExpression
+    | TSESTree.Identifier
+): TSESTree.CallExpression | TSESTree.MemberExpression | TSESTree.Identifier {
+  if (isMemberExpression(node.parent) || isCallExpression(node.parent)) {
+    return getReferenceNode(node.parent);
+  }
+
+  return node;
 }
 
 export function getFunctionName(

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -151,7 +151,7 @@ export function isCallExpressionCallee(
   node: TSESTree.CallExpression,
   identifier: TSESTree.Identifier
 ): boolean {
-  const nodeInnerIdentifier = getIdentifierNode(node);
+  const nodeInnerIdentifier = getDeepestIdentifierNode(node);
 
   if (nodeInnerIdentifier) {
     return nodeInnerIdentifier.name === identifier.name;
@@ -366,7 +366,7 @@ export function getFunctionReturnStatementNode(
 /**
  * Gets the property identifier node of a given property node.
  *
- * Not to be confused with {@link getIdentifierNode}
+ * Not to be confused with {@link getDeepestIdentifierNode}
  *
  * An example:
  * Having `const a = rtl.within('foo').getByRole('button')`:
@@ -398,11 +398,10 @@ export function getPropertyIdentifierNode(
  *
  * An example:
  * Having `const a = rtl.within('foo').getByRole('button')`:
- *  if we call `getIdentifierNode` with `rtl` node,
+ *  if we call `getDeepestIdentifierNode` with `rtl` node,
  *  it will return `getByRole` identifier
  */
-// TODO: rename to getDeepestIdentifierNode
-export function getIdentifierNode(
+export function getDeepestIdentifierNode(
   node: TSESTree.Node
 ): TSESTree.Identifier | null {
   if (ASTUtils.isIdentifier(node)) {
@@ -414,7 +413,7 @@ export function getIdentifierNode(
   }
 
   if (isCallExpression(node)) {
-    return getIdentifierNode(node.callee);
+    return getDeepestIdentifierNode(node.callee);
   }
 
   return null;
@@ -423,7 +422,7 @@ export function getIdentifierNode(
 /**
  * Gets the farthest node from a given node.
  *
- * Opposite of {@link getIdentifierNode}
+ * Opposite of {@link getDeepestIdentifierNode}
 
  * An example:
  * Having `const a = rtl.within('foo').getByRole('button')`:
@@ -611,7 +610,9 @@ export function getInnermostReturningFunction(
     return;
   }
 
-  const returnStatementIdentifier = getIdentifierNode(returnStatementNode);
+  const returnStatementIdentifier = getDeepestIdentifierNode(
+    returnStatementNode
+  );
 
   if (returnStatementIdentifier?.name !== node.name) {
     return;

--- a/lib/rules/await-async-utils.ts
+++ b/lib/rules/await-async-utils.ts
@@ -4,7 +4,6 @@ import {
   getFunctionName,
   getInnermostReturningFunction,
   getVariableReferences,
-  isMemberExpression,
   isPromiseHandled,
 } from '../node-utils';
 import { createTestingLibraryRule } from '../create-testing-library-rule';
@@ -46,16 +45,6 @@ export default createTestingLibraryRule<Options, MessageIds>({
     return {
       'CallExpression Identifier'(node: TSESTree.Identifier) {
         if (helpers.isAsyncUtil(node)) {
-          if (
-            !helpers.isNodeComingFromTestingLibrary(node) &&
-            !(
-              isMemberExpression(node.parent) &&
-              helpers.isNodeComingFromTestingLibrary(node.parent)
-            )
-          ) {
-            return;
-          }
-
           // detect async query used within wrapper function for later analysis
           detectAsyncUtilWrapper(node);
 

--- a/lib/rules/no-promise-in-fire-event.ts
+++ b/lib/rules/no-promise-in-fire-event.ts
@@ -2,7 +2,7 @@ import { ASTUtils, TSESTree } from '@typescript-eslint/experimental-utils';
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {
   findClosestCallExpressionNode,
-  getIdentifierNode,
+  getDeepestIdentifierNode,
   isCallExpression,
   isNewExpression,
   isPromiseIdentifier,
@@ -50,7 +50,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
       }
 
       if (isCallExpression(node)) {
-        const domElementIdentifier = getIdentifierNode(node);
+        const domElementIdentifier = getDeepestIdentifierNode(node);
 
         if (
           helpers.isAsyncQuery(domElementIdentifier) ||

--- a/lib/rules/no-wait-for-snapshot.ts
+++ b/lib/rules/no-wait-for-snapshot.ts
@@ -37,7 +37,6 @@ export default createTestingLibraryRule<Options, MessageIds>({
         const callExpression = findClosestCallExpressionNode(n);
         if (
           ASTUtils.isIdentifier(callExpression.callee) &&
-          helpers.isNodeComingFromTestingLibrary(callExpression.callee) &&
           helpers.isAsyncUtil(callExpression.callee)
         ) {
           return callExpression.callee;
@@ -45,7 +44,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
         if (
           isMemberExpression(callExpression.callee) &&
           ASTUtils.isIdentifier(callExpression.callee.property) &&
-          helpers.isNodeComingFromTestingLibrary(callExpression.callee)
+          helpers.isAsyncUtil(callExpression.callee.property)
         ) {
           return callExpression.callee.property;
         }

--- a/lib/rules/render-result-naming-convention.ts
+++ b/lib/rules/render-result-naming-convention.ts
@@ -1,5 +1,5 @@
 import { createTestingLibraryRule } from '../create-testing-library-rule';
-import { isObjectPattern } from '../node-utils';
+import { getIdentifierNode, isObjectPattern } from '../node-utils';
 import { ASTUtils } from '@typescript-eslint/experimental-utils';
 
 export const RULE_NAME = 'render-result-naming-convention';
@@ -32,7 +32,13 @@ export default createTestingLibraryRule<Options, MessageIds>({
   create(context, _, helpers) {
     return {
       VariableDeclarator(node) {
-        if (!helpers.isRenderUtil(node.init)) {
+        const initIdentifierNode = getIdentifierNode(node.init);
+
+        if (!initIdentifierNode) {
+          return;
+        }
+
+        if (!helpers.isRenderUtil(initIdentifierNode)) {
           return;
         }
 

--- a/lib/rules/render-result-naming-convention.ts
+++ b/lib/rules/render-result-naming-convention.ts
@@ -1,5 +1,5 @@
 import { createTestingLibraryRule } from '../create-testing-library-rule';
-import { getIdentifierNode, isObjectPattern } from '../node-utils';
+import { getDeepestIdentifierNode, isObjectPattern } from '../node-utils';
 import { ASTUtils } from '@typescript-eslint/experimental-utils';
 
 export const RULE_NAME = 'render-result-naming-convention';
@@ -32,7 +32,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
   create(context, _, helpers) {
     return {
       VariableDeclarator(node) {
-        const initIdentifierNode = getIdentifierNode(node.init);
+        const initIdentifierNode = getDeepestIdentifierNode(node.init);
 
         if (!initIdentifierNode) {
           return;

--- a/tests/create-testing-library-rule.test.ts
+++ b/tests/create-testing-library-rule.test.ts
@@ -30,7 +30,7 @@ ruleTester.run(RULE_NAME, rule, {
       const utils = render();
       `,
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
     },
     {
@@ -41,7 +41,7 @@ ruleTester.run(RULE_NAME, rule, {
       const utils = render();
       `,
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
     },
     {
@@ -51,7 +51,7 @@ ruleTester.run(RULE_NAME, rule, {
       import { foo } from 'report-me'
       `,
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
     },
     {
@@ -61,7 +61,7 @@ ruleTester.run(RULE_NAME, rule, {
       const { foo } = require('report-me')
       `,
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
     },
     {
@@ -112,7 +112,7 @@ ruleTester.run(RULE_NAME, rule, {
     // Test Cases for all settings mixed
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
         'testing-library/filename-pattern': 'testing-library\\.js',
       },
       code: `
@@ -126,7 +126,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
         'testing-library/filename-pattern': 'testing-library\\.js',
       },
       filename: 'MyComponent.testing-library.js',
@@ -174,7 +174,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       // case: built-in "getBy*" query not reported because custom module not imported
@@ -184,7 +184,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       // case: built-in "queryBy*" query not reported because custom module not imported
@@ -194,7 +194,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       // case: built-in "findBy*" query not reported because custom module not imported
@@ -231,7 +231,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
         import * as tl from 'test-utils'
@@ -240,7 +240,7 @@ ruleTester.run(RULE_NAME, rule, {
       `,
     },
     {
-      settings: { 'testing-library/module': 'test-utils' },
+      settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
       // case: aggressive render enabled, but module disabled - not coming from TL
       import { render } from 'somewhere-else'
@@ -346,7 +346,7 @@ ruleTester.run(RULE_NAME, rule, {
       const utils = render();
       `,
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       errors: [
         {
@@ -366,7 +366,7 @@ ruleTester.run(RULE_NAME, rule, {
       const utils = render();
       `,
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       errors: [
         {
@@ -387,7 +387,7 @@ ruleTester.run(RULE_NAME, rule, {
       const utils = render();
       `,
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       errors: [
         {
@@ -408,7 +408,7 @@ ruleTester.run(RULE_NAME, rule, {
       const utils = render();
       `,
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       errors: [
         {
@@ -420,7 +420,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'custom-module-forced-report',
+        'testing-library/utils-module': 'custom-module-forced-report',
       },
       code: `
       // case: import custom module forced to be reported with custom module setting
@@ -432,7 +432,7 @@ ruleTester.run(RULE_NAME, rule, {
     // Test Cases for all settings mixed
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
         'testing-library/filename-pattern': 'testing-library\\.js',
       },
       filename: 'MyComponent.testing-library.js',
@@ -589,7 +589,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       // case: built-in "getBy*" query reported with custom module + Testing Library package import
@@ -601,7 +601,7 @@ ruleTester.run(RULE_NAME, rule, {
     {
       filename: 'MyComponent.spec.js',
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       // case: built-in "queryBy*" query reported with custom module + Testing Library package import
@@ -613,7 +613,7 @@ ruleTester.run(RULE_NAME, rule, {
     {
       filename: 'MyComponent.spec.js',
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       // case: built-in "findBy*" query reported with custom module + Testing Library package import
@@ -624,7 +624,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       // case: built-in "getBy*" query reported with custom module + custom module import
@@ -636,7 +636,7 @@ ruleTester.run(RULE_NAME, rule, {
     {
       filename: 'MyComponent.spec.js',
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       // case: built-in "queryBy*" query reported with custom module + custom module import
@@ -648,7 +648,7 @@ ruleTester.run(RULE_NAME, rule, {
     {
       filename: 'MyComponent.spec.js',
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       // case: built-in "queryBy*" query reported with custom module + custom module import
@@ -660,7 +660,7 @@ ruleTester.run(RULE_NAME, rule, {
 
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       // case: custom "getBy*" query reported with custom module + Testing Library package import
@@ -672,7 +672,7 @@ ruleTester.run(RULE_NAME, rule, {
     {
       filename: 'MyComponent.spec.js',
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       // case: custom "queryBy*" query reported with custom module + Testing Library package import
@@ -684,7 +684,7 @@ ruleTester.run(RULE_NAME, rule, {
     {
       filename: 'MyComponent.spec.js',
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       // case: custom "findBy*" query reported with custom module + Testing Library package import
@@ -695,7 +695,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       // case: custom "getBy*" query reported with custom module + custom module import
@@ -707,7 +707,7 @@ ruleTester.run(RULE_NAME, rule, {
     {
       filename: 'MyComponent.spec.js',
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       // case: custom "queryBy*" query reported with custom module + custom module import
@@ -719,7 +719,7 @@ ruleTester.run(RULE_NAME, rule, {
     {
       filename: 'MyComponent.spec.js',
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       // case: custom "findBy*" query reported with custom module + custom module import
@@ -730,7 +730,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
         import * as tl from 'test-utils'
@@ -744,7 +744,7 @@ ruleTester.run(RULE_NAME, rule, {
       filename: 'MyComponent.custom-suffix.js',
       settings: {
         'testing-library/custom-renders': ['customRender', 'renderWithRedux'],
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
         'testing-library/filename-pattern': 'custom-suffix\\.js',
       },
       code: `

--- a/tests/create-testing-library-rule.test.ts
+++ b/tests/create-testing-library-rule.test.ts
@@ -108,6 +108,174 @@ ruleTester.run(RULE_NAME, rule, {
       const utils = customRender()
       `,
     },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+      // case: aggressive render enabled, but module disabled - not coming from TL
+      import { render } from 'somewhere-else'
+      
+      const utils = render()
+      `,
+    },
+    {
+      filename: 'file.not.matching.js',
+      code: `
+      // case: aggressive render and module enabled, but file name not matching
+      import { render } from '@testing-library/react'
+      
+      const utils = render()
+      `,
+    },
+
+    // Test Cases for presence/absence assertions
+    // cases: asserts not related to presence/absence
+    'expect(element).toBeDisabled()',
+    'expect(element).toBeEnabled()',
+
+    // cases: presence/absence matcher not related to assert
+    'element.toBeInTheDocument()',
+    'element.not.toBeInTheDocument()',
+
+    // cases: weird scenarios to check guard against parent nodes
+    'expect(element).not()',
+    'expect(element).not()',
+
+    // Test Cases for Queries and Aggressive Queries Reporting
+    {
+      code: `
+      // case: custom method not matching "getBy*" variant pattern
+      getSomeElement('button')
+    `,
+    },
+    {
+      code: `
+      // case: custom method not matching "getBy*" variant pattern using within
+      within(container).getSomeElement('button')
+    `,
+    },
+    {
+      code: `
+      // case: custom method not matching "queryBy*" variant pattern
+      querySomeElement('button')
+    `,
+    },
+    {
+      code: `
+      // case: custom method not matching "queryBy*" variant pattern using within
+      within(container).querySomeElement('button')
+    `,
+    },
+    {
+      code: `
+      // case: custom method not matching "findBy*" variant pattern
+      findSomeElement('button')
+    `,
+    },
+    {
+      code: `
+      // case: custom method not matching "findBy*" variant pattern using within
+      within(container).findSomeElement('button')
+    `,
+    },
+    {
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+      },
+      code: `
+      // case: built-in "getBy*" query not reported because custom module not imported
+      import { render } from 'other-module'
+      getByRole('button')
+    `,
+    },
+    {
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+      },
+      code: `
+      // case: built-in "getBy*" query not reported because custom module not imported  using within
+      import { render } from 'other-module'
+      within(container).getByRole('button')
+    `,
+    },
+    {
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+      },
+      code: `
+      // case: built-in "queryBy*" query not reported because custom module not imported
+      import { render } from 'other-module'
+      queryByRole('button')
+    `,
+    },
+    {
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+      },
+      code: `
+      // case: built-in "queryBy*" query not reported because custom module not imported using within
+      import { render } from 'other-module'
+      within(container).queryByRole('button')
+    `,
+    },
+    {
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+      },
+      code: `
+      // case: built-in "findBy*" query not reported because custom module not imported
+      import { render } from 'other-module'
+      findByRole('button')
+    `,
+    },
+    {
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+      },
+      code: `
+      // case: built-in "findBy*" query not reported because custom module not imported using within
+      import { render } from 'other-module'
+      within(container).findByRole('button')
+    `,
+    },
+    {
+      settings: {
+        'testing-library/filename-pattern': 'testing-library\\.js',
+      },
+      code: `
+      // case: built-in "getBy*" query not reported because custom filename doesn't match
+      getByRole('button')
+    `,
+    },
+    {
+      settings: {
+        'testing-library/filename-pattern': 'testing-library\\.js',
+      },
+      code: `
+      // case: built-in "queryBy*" query not reported because custom filename doesn't match
+      queryByRole('button')
+    `,
+    },
+    {
+      settings: {
+        'testing-library/filename-pattern': 'testing-library\\.js',
+      },
+      code: `
+      // case: built-in "findBy*" query not reported because custom filename doesn't match
+      findByRole('button')
+    `,
+    },
+
+    // Test Cases for async utils
+    {
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+      },
+      code: `
+        import * as tl from 'test-utils'
+        const obj = { tl }
+        obj.tl.waitFor(() => {})
+      `,
+    },
 
     // Test Cases for all settings mixed
     {
@@ -139,126 +307,6 @@ ruleTester.run(RULE_NAME, rule, {
       const utils = render();
       `,
     },
-
-    // Test Cases for presence/absence assertions
-    // cases: asserts not related to presence/absence
-    'expect(element).toBeDisabled()',
-    'expect(element).toBeEnabled()',
-
-    // cases: presence/absence matcher not related to assert
-    'element.toBeInTheDocument()',
-    'element.not.toBeInTheDocument()',
-
-    // cases: weird scenarios to check guard against parent nodes
-    'expect(element).not()',
-    'expect(element).not()',
-
-    // Test Cases for Queries and Aggressive Queries Reporting
-    {
-      code: `
-      // case: custom method not matching "getBy*" variant pattern
-      getSomeElement('button')
-    `,
-    },
-    {
-      code: `
-      // case: custom method not matching "queryBy*" variant pattern
-      querySomeElement('button')
-    `,
-    },
-    {
-      code: `
-      // case: custom method not matching "findBy*" variant pattern
-      findSomeElement('button')
-    `,
-    },
-    {
-      settings: {
-        'testing-library/utils-module': 'test-utils',
-      },
-      code: `
-      // case: built-in "getBy*" query not reported because custom module not imported
-      import { render } from 'other-module'
-      getByRole('button')
-    `,
-    },
-    {
-      settings: {
-        'testing-library/utils-module': 'test-utils',
-      },
-      code: `
-      // case: built-in "queryBy*" query not reported because custom module not imported
-      import { render } from 'other-module'
-      queryByRole('button')
-    `,
-    },
-    {
-      settings: {
-        'testing-library/utils-module': 'test-utils',
-      },
-      code: `
-      // case: built-in "findBy*" query not reported because custom module not imported
-      import { render } from 'other-module'
-      findByRole('button')
-    `,
-    },
-    {
-      settings: {
-        'testing-library/filename-pattern': 'testing-library\\.js',
-      },
-      code: `
-      // case: built-in "getBy*" query not reported because custom filename doesn't match
-      getByRole('button')
-    `,
-    },
-    {
-      settings: {
-        'testing-library/filename-pattern': 'testing-library\\.js',
-      },
-      code: `
-      // case: built-in "queryBy*" query not reported because custom filename doesn't match
-      queryByRole('button')
-    `,
-    },
-    {
-      settings: {
-        'testing-library/filename-pattern': 'testing-library\\.js',
-      },
-      code: `
-      // case: built-in "findBy*" query not reported because custom filename doesn't match
-      findByRole('button')
-    `,
-    },
-    {
-      settings: {
-        'testing-library/utils-module': 'test-utils',
-      },
-      code: `
-        import * as tl from 'test-utils'
-        const obj = { tl }
-        obj.tl.waitFor(() => {})
-      `,
-    },
-    {
-      settings: { 'testing-library/utils-module': 'test-utils' },
-      code: `
-      // case: aggressive render enabled, but module disabled - not coming from TL
-      import { render } from 'somewhere-else'
-      
-      const utils = render()
-      `,
-    },
-    {
-      filename: 'file.not.matching.js',
-      code: `
-      // case: aggressive render and module enabled, but file name not matching
-      import { render } from '@testing-library/react'
-      
-      const utils = render()
-      `,
-    },
-
-    // Test Cases for all settings mixed
     {
       settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
@@ -442,24 +490,6 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [{ line: 3, column: 7, messageId: 'fakeError' }],
     },
 
-    // Test Cases for all settings mixed
-    {
-      settings: {
-        'testing-library/utils-module': 'test-utils',
-        'testing-library/filename-pattern': 'testing-library\\.js',
-      },
-      filename: 'MyComponent.testing-library.js',
-      code: `
-      // case: matching all custom settings
-      import { render } from 'test-utils'
-      import { somethingElse } from 'another-module'
-      const foo = require('bar')
-      
-      const utils = render();
-      `,
-      errors: [{ line: 7, column: 21, messageId: 'renderError' }],
-    },
-
     // Test Cases for renders
     {
       code: `
@@ -579,6 +609,13 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
+      // case: built-in "getBy*" query reported without import using within (aggressive reporting)
+      within(container).getByRole('button')
+    `,
+      errors: [{ line: 3, column: 25, messageId: 'getByError' }],
+    },
+    {
+      code: `
       // case: built-in "queryBy*" query reported without import (aggressive reporting)
       queryByRole('button')
     `,
@@ -586,10 +623,24 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
+      // case: built-in "queryBy*" query reported without import using within (aggressive reporting)
+      within(container).queryByRole('button')
+    `,
+      errors: [{ line: 3, column: 25, messageId: 'queryByError' }],
+    },
+    {
+      code: `
       // case: built-in "findBy*" query reported without import (aggressive reporting)
       findByRole('button')
     `,
       errors: [{ line: 3, column: 7, messageId: 'findByError' }],
+    },
+    {
+      code: `
+      // case: built-in "findBy*" query reported without import using within (aggressive reporting)
+      within(container).findByRole('button')
+    `,
+      errors: [{ line: 3, column: 25, messageId: 'findByError' }],
     },
     {
       filename: 'MyComponent.spec.js',
@@ -600,6 +651,14 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [{ line: 3, column: 7, messageId: 'customQueryError' }],
     },
     {
+      filename: 'MyComponent.spec.js',
+      code: `
+      // case: custom "getBy*" query reported without import using within (aggressive reporting)
+      within(container).getByIcon('search')
+    `,
+      errors: [{ line: 3, column: 25, messageId: 'customQueryError' }],
+    },
+    {
       code: `
       // case: custom "queryBy*" query reported without import (aggressive reporting)
       queryByIcon('search')
@@ -608,10 +667,24 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
+      // case: custom "queryBy*" query reported without import using within (aggressive reporting)
+      within(container).queryByIcon('search')
+    `,
+      errors: [{ line: 3, column: 25, messageId: 'customQueryError' }],
+    },
+    {
+      code: `
       // case: custom "findBy*" query reported without import (aggressive reporting)
       findByIcon('search')
     `,
       errors: [{ line: 3, column: 7, messageId: 'customQueryError' }],
+    },
+    {
+      code: `
+      // case: custom "findBy*" query reported without import using within (aggressive reporting)
+      within(container).findByIcon('search')
+    `,
+      errors: [{ line: 3, column: 25, messageId: 'customQueryError' }],
     },
     {
       settings: {
@@ -766,7 +839,6 @@ ruleTester.run(RULE_NAME, rule, {
     },
 
     // Test Cases for all settings mixed
-
     {
       filename: 'MyComponent.custom-suffix.js',
       settings: {
@@ -785,6 +857,22 @@ ruleTester.run(RULE_NAME, rule, {
         { line: 5, column: 29, messageId: 'renderError' },
         { line: 6, column: 18, messageId: 'getByError' },
       ],
+    },
+    {
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+        'testing-library/filename-pattern': 'testing-library\\.js',
+      },
+      filename: 'MyComponent.testing-library.js',
+      code: `
+      // case: matching all custom settings
+      import { render } from 'test-utils'
+      import { somethingElse } from 'another-module'
+      const foo = require('bar')
+      
+      const utils = render();
+      `,
+      errors: [{ line: 7, column: 21, messageId: 'renderError' }],
     },
   ],
 });

--- a/tests/create-testing-library-rule.test.ts
+++ b/tests/create-testing-library-rule.test.ts
@@ -265,17 +265,7 @@ ruleTester.run(RULE_NAME, rule, {
     `,
     },
 
-    // Test Cases for async utils
-    {
-      settings: {
-        'testing-library/utils-module': 'test-utils',
-      },
-      code: `
-        import * as tl from 'test-utils'
-        const obj = { tl }
-        obj.tl.waitFor(() => {})
-      `,
-    },
+    // TODO: Test Cases for async utils
 
     // Test Cases for all settings mixed
     {
@@ -597,6 +587,22 @@ ruleTester.run(RULE_NAME, rule, {
       expect(element).toBeNull()
       `,
       errors: [{ line: 3, column: 7, messageId: 'absenceAssertError' }],
+    },
+
+    // Test Cases for async utils
+    {
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+      },
+      code: `
+        // case: object property shadowed name is checked correctly
+        import * as tl from 'test-utils'
+        const obj = { tl }
+        
+        obj.module.waitFor(() => {})
+      `,
+      // TODO: column will be different when async utils errors are implemented properly
+      errors: [{ line: 6, column: 9, messageId: 'fakeError' }],
     },
 
     // Test Cases for Queries and Aggressive Queries Reporting

--- a/tests/create-testing-library-rule.test.ts
+++ b/tests/create-testing-library-rule.test.ts
@@ -257,6 +257,19 @@ ruleTester.run(RULE_NAME, rule, {
       const utils = render()
       `,
     },
+
+    // Test Cases for all settings mixed
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+      // case: aggressive module disabled and render coming from non-related module
+      import * as somethingElse from '@somewhere/else'
+      import { render } from '@testing-library/react'
+      
+      // somethingElse.render is not coming from any module related to TL
+      const utils = somethingElse.render()
+      `,
+    },
   ],
   invalid: [
     // Test Cases for Imports & Filename
@@ -512,6 +525,19 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [{ line: 5, column: 21, messageId: 'renderError' }],
     },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+      // case: aggressive module disabled and render wildcard-imported from related module
+      import * as rtl from '@testing-library/react'
+      
+      const utils = rtl.render()
+      `,
+      errors: [
+        { line: 5, column: 21, messageId: 'fakeError' },
+        { line: 5, column: 25, messageId: 'renderError' },
+      ],
+    },
 
     // Test Cases for presence/absence assertions
     {
@@ -740,6 +766,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
 
     // Test Cases for all settings mixed
+
     {
       filename: 'MyComponent.custom-suffix.js',
       settings: {

--- a/tests/lib/rules/await-async-query.test.ts
+++ b/tests/lib/rules/await-async-query.test.ts
@@ -207,7 +207,7 @@ ruleTester.run(RULE_NAME, rule, {
 
     // unresolved async queries with aggressive reporting opted-out are valid
     ...ALL_ASYNC_COMBINATIONS_TO_TEST.map((query) => ({
-      settings: { 'testing-library/module': 'test-utils' },
+      settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
         import { render } from "another-library"
 

--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -103,18 +103,28 @@ ruleTester.run(RULE_NAME, rule, {
       `,
     })),
     ...ASYNC_UTILS.map((asyncUtil) => ({
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+      },
       code: `
         import { ${asyncUtil} } from 'some-other-library';
-        test('util "${asyncUtil}" which is not related to testing library is valid', async () => {
+        test(
+        'aggressive reporting disabled - util "${asyncUtil}" which is not related to testing library is valid',
+        async () => {
           doSomethingElse();
           ${asyncUtil}();
         });
       `,
     })),
     ...ASYNC_UTILS.map((asyncUtil) => ({
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+      },
       code: `
         import * as asyncUtils from 'some-other-library';
-        test('util "asyncUtils.${asyncUtil}" which is not related to testing library is valid', async () => {
+        test(
+        'aggressive reporting disabled - util "asyncUtils.${asyncUtil}" which is not related to testing library is valid',
+        async () => {
           doSomethingElse();
           asyncUtils.${asyncUtil}();
         });
@@ -174,16 +184,6 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
     },
-    ...ASYNC_UTILS.map((asyncUtil) => ({
-      code: `
-        import { ${asyncUtil} } from '@somewhere/else';
-        test('util unhandled but not related to testing library is valid', async () => {
-          doSomethingElse();
-          ${asyncUtil}('not related to testing library')
-          waitForNotRelatedToTestingLibrary()
-        });
-      `,
-    })),
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
         import { ${asyncUtil} } from '@testing-library/dom';
@@ -300,6 +300,30 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
       errors: [{ messageId: 'asyncUtilWrapper', line: 10, column: 11 }],
+    })),
+    ...ASYNC_UTILS.map((asyncUtil) => ({
+      code: `
+        import { ${asyncUtil} } from 'some-other-library';
+        test(
+        'aggressive reporting - util "${asyncUtil}" which is not related to testing library is invalid',
+        async () => {
+          doSomethingElse();
+          ${asyncUtil}();
+        });
+      `,
+      errors: [{ line: 7, column: 11, messageId: 'awaitAsyncUtil' }],
+    })),
+    ...ASYNC_UTILS.map((asyncUtil) => ({
+      code: `
+        import * as asyncUtils from 'some-other-library';
+        test(
+        'aggressive reporting - util "asyncUtils.${asyncUtil}" which is not related to testing library is invalid',
+        async () => {
+          doSomethingElse();
+          asyncUtils.${asyncUtil}();
+        });
+      `,
+      errors: [{ line: 7, column: 22, messageId: 'awaitAsyncUtil' }],
     })),
   ],
 });

--- a/tests/lib/rules/await-fire-event.test.ts
+++ b/tests/lib/rules/await-fire-event.test.ts
@@ -101,7 +101,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...COMMON_FIRE_EVENT_METHODS.map((fireEventMethod) => ({
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       import { fireEvent } from 'somewhere-else'
@@ -112,7 +112,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...COMMON_FIRE_EVENT_METHODS.map((fireEventMethod) => ({
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       import { fireEvent } from 'test-utils'
@@ -215,7 +215,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...COMMON_FIRE_EVENT_METHODS.map((fireEventMethod) => ({
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       import { fireEvent } from '@testing-library/vue'
@@ -234,7 +234,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...COMMON_FIRE_EVENT_METHODS.map((fireEventMethod) => ({
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       import { fireEvent } from 'test-utils'
@@ -255,7 +255,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...COMMON_FIRE_EVENT_METHODS.map((fireEventMethod) => ({
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       import { fireEvent } from '@testing-library/vue'

--- a/tests/lib/rules/no-await-sync-query.test.ts
+++ b/tests/lib/rules/no-await-sync-query.test.ts
@@ -69,7 +69,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     // sync query awaited but not matching filename pattern is invalid but not reported
     {
-      settings: { 'testing-library/filename-pattern': '^.*\\.(nope)\\.js$' },
+      settings: { 'testing-library/filename-pattern': 'nope\\.js' },
       code: `
       () => {
         const element = await getByRole('button')

--- a/tests/lib/rules/no-await-sync-query.test.ts
+++ b/tests/lib/rules/no-await-sync-query.test.ts
@@ -59,7 +59,7 @@ ruleTester.run(RULE_NAME, rule, {
 
     // sync query awaited but not related to custom module is invalid but not reported
     {
-      settings: { 'testing-library/module': 'test-utils' },
+      settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
       import { screen } from 'somewhere-else'
       () => {
@@ -194,7 +194,7 @@ ruleTester.run(RULE_NAME, rule, {
     // sync query awaited and related to testing library module
     // with custom module setting is not valid
     {
-      settings: { 'testing-library/module': 'test-utils' },
+      settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
       import { screen } from '@testing-library/react'
       () => {
@@ -205,7 +205,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     // sync query awaited and related to custom module is not valid
     {
-      settings: { 'testing-library/module': 'test-utils' },
+      settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
       import { screen } from 'test-utils'
       () => {

--- a/tests/lib/rules/no-dom-import.test.ts
+++ b/tests/lib/rules/no-dom-import.test.ts
@@ -23,7 +23,7 @@ ruleTester.run(RULE_NAME, rule, {
     'require("@testing-library/react")',
     {
       code: 'import { fireEvent } from "test-utils"',
-      settings: { 'testing-library/module': 'test-utils' },
+      settings: { 'testing-library/utils-module': 'test-utils' },
     },
     {
       code: 'import { fireEvent } from "dom-testing-library"',
@@ -70,7 +70,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       // case: dom-testing-library imported with custom module setting
@@ -122,7 +122,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       // case: dom-testing-library wildcard imported with custom module setting
@@ -144,7 +144,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       // case: @testing-library/dom imported with custom module setting
@@ -190,7 +190,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       // case: dom-testing-library required with custom module setting
@@ -225,7 +225,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       // case: @testing-library/dom required with custom module setting

--- a/tests/lib/rules/no-dom-import.test.ts
+++ b/tests/lib/rules/no-dom-import.test.ts
@@ -31,7 +31,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: 'import { fireEvent } from "dom-testing-library"',
-      settings: { 'testing-library/filename-pattern': '^.*\\.(nope)\\.js$' },
+      settings: { 'testing-library/filename-pattern': 'nope\\.js' },
     },
     {
       code: 'const { fireEvent } = require("dom-testing-library")',
@@ -39,7 +39,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: 'const { fireEvent } = require("dom-testing-library")',
-      settings: { 'testing-library/filename-pattern': '^.*\\.(nope)\\.js$' },
+      settings: { 'testing-library/filename-pattern': 'nope\\.js' },
     },
     {
       code: 'import { fireEvent } from "@testing-library/dom"',
@@ -47,7 +47,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: 'import { fireEvent } from "@testing-library/dom"',
-      settings: { 'testing-library/filename-pattern': '^.*\\.(nope)\\.js$' },
+      settings: { 'testing-library/filename-pattern': 'nope\\.js' },
     },
     {
       code: 'const { fireEvent } = require("@testing-library/dom")',
@@ -55,7 +55,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: 'const { fireEvent } = require("@testing-library/dom")',
-      settings: { 'testing-library/filename-pattern': '^.*\\.(nope)\\.js$' },
+      settings: { 'testing-library/filename-pattern': 'nope\\.js' },
     },
   ],
   invalid: [

--- a/tests/lib/rules/no-manual-cleanup.test.ts
+++ b/tests/lib/rules/no-manual-cleanup.test.ts
@@ -77,7 +77,7 @@ ruleTester.run(RULE_NAME, rule, {
     ...ALL_TESTING_LIBRARIES_WITH_CLEANUP.map((lib) => ({
       // official testing-library packages should be reported with custom module setting
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `import { cleanup, render } from "${lib}"`,
       errors: [
@@ -90,7 +90,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
         import { render, cleanup } from 'test-utils'
@@ -109,7 +109,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
         import { cleanup as myCustomCleanup } from 'test-utils'
@@ -128,7 +128,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
         import utils, { cleanup } from 'test-utils'
@@ -150,7 +150,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
         import utils from 'test-utils'
@@ -183,7 +183,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
         const { render, cleanup } = require('test-utils')

--- a/tests/lib/rules/no-node-access.test.ts
+++ b/tests/lib/rules/no-node-access.test.ts
@@ -64,7 +64,7 @@ ruleTester.run(RULE_NAME, rule, {
       expect(closestButton).toBeInTheDocument();
       `,
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
     },
   ],

--- a/tests/lib/rules/no-promise-in-fire-event.test.ts
+++ b/tests/lib/rules/no-promise-in-fire-event.test.ts
@@ -41,7 +41,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `// invalid usage but aggressive reporting opted-out
         import { fireEvent } from 'somewhere-else'

--- a/tests/lib/rules/no-wait-for-snapshot.test.ts
+++ b/tests/lib/rules/no-wait-for-snapshot.test.ts
@@ -51,73 +51,101 @@ ruleTester.run(RULE_NAME, rule, {
       `,
     })),
     ...ASYNC_UTILS.map((asyncUtil) => ({
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+      },
       code: `
         import { ${asyncUtil} } from 'some-other-library';
-        test('snapshot calls within ${asyncUtil} are not valid', async () => {
+        test('aggressive reporting disabled - snapshot calls within ${asyncUtil} not related to Testing Library are valid', async () => {
           await ${asyncUtil}(() => expect(foo).toMatchSnapshot());
         });
       `,
     })),
     ...ASYNC_UTILS.map((asyncUtil) => ({
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+      },
       code: `
         import { ${asyncUtil} } from 'some-other-library';
-        test('snapshot calls within ${asyncUtil} are not valid', async () => {
+        test('(alt) aggressive reporting disabled - snapshot calls within ${asyncUtil} not related to Testing Library are valid', async () => {
           await ${asyncUtil}(() => {
-              expect(foo).toMatchSnapshot()
+            // this alt version doesn't return from callback passed to async util
+            expect(foo).toMatchSnapshot()
           });
         });
       `,
     })),
     ...ASYNC_UTILS.map((asyncUtil) => ({
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+      },
       code: `
         import * as asyncUtils from 'some-other-library';
-        test('snapshot calls within ${asyncUtil} are not valid', async () => {
+        test('aggressive reporting disabled - snapshot calls within ${asyncUtil} from wildcard import not related to Testing Library are valid', async () => {
           await asyncUtils.${asyncUtil}(() => expect(foo).toMatchSnapshot());
         });
       `,
     })),
     ...ASYNC_UTILS.map((asyncUtil) => ({
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+      },
       code: `
         import * as asyncUtils from 'some-other-library';
-        test('snapshot calls within ${asyncUtil} are not valid', async () => {
+        test('(alt) aggressive reporting disabled - snapshot calls within ${asyncUtil} from wildcard import not related to Testing Library are valid', async () => {
           await asyncUtils.${asyncUtil}(() => {
-              expect(foo).toMatchSnapshot()
+            // this alt version doesn't return from callback passed to async util
+            expect(foo).toMatchSnapshot()
           });
         });
       `,
     })),
     ...ASYNC_UTILS.map((asyncUtil) => ({
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+      },
       code: `
         import { ${asyncUtil} } from 'some-other-library';
-        test('snapshot calls within ${asyncUtil} are not valid', async () => {
+        test('aggressive reporting disabled - inline snapshot calls within ${asyncUtil} import not related to Testing Library are valid', async () => {
           await ${asyncUtil}(() => expect(foo).toMatchInlineSnapshot());
         });
       `,
     })),
     ...ASYNC_UTILS.map((asyncUtil) => ({
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+      },
       code: `
         import { ${asyncUtil} } from 'some-other-library';
-        test('snapshot calls within ${asyncUtil} are not valid', async () => {
+        test('(alt) aggressive reporting disabled - inline snapshot calls within ${asyncUtil} import not related to Testing Library are valid', async () => {
           await ${asyncUtil}(() => {
-              expect(foo).toMatchInlineSnapshot()
+            // this alt version doesn't return from callback passed to async util
+            expect(foo).toMatchInlineSnapshot()
           });
         });
       `,
     })),
     ...ASYNC_UTILS.map((asyncUtil) => ({
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+      },
       code: `
         import * as asyncUtils from 'some-other-library';
-        test('snapshot calls within ${asyncUtil} are not valid', async () => {
+        test('aggressive reporting disabled - inline snapshot calls within ${asyncUtil} from wildcard import not related to Testing Library are valid', async () => {
           await asyncUtils.${asyncUtil}(() => expect(foo).toMatchInlineSnapshot());
         });
       `,
     })),
     ...ASYNC_UTILS.map((asyncUtil) => ({
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+      },
       code: `
         import * as asyncUtils from 'some-other-library';
-        test('snapshot calls within ${asyncUtil} are not valid', async () => {
+        test('(alt) aggressive reporting disabled - inline snapshot calls within ${asyncUtil} from wildcard import not related to Testing Library are valid', async () => {
           await asyncUtils.${asyncUtil}(() => {
-              expect(foo).toMatchInlineSnapshot()
+            // this alt version doesn't return from callback passed to async util
+            expect(foo).toMatchInlineSnapshot()
           });
         });
       `,

--- a/tests/lib/rules/prefer-explicit-assert.test.ts
+++ b/tests/lib/rules/prefer-explicit-assert.test.ts
@@ -11,7 +11,7 @@ ruleTester.run(RULE_NAME, rule, {
     ...COMBINED_QUERIES_METHODS.map((queryMethod) => ({
       code: `get${queryMethod}('Hello')`,
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
     })),
     ...COMBINED_QUERIES_METHODS.map((queryMethod) => ({
@@ -153,7 +153,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...COMBINED_QUERIES_METHODS.map((queryMethod) => ({
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
         import "test-utils"

--- a/tests/lib/rules/prefer-presence-queries.test.ts
+++ b/tests/lib/rules/prefer-presence-queries.test.ts
@@ -52,7 +52,7 @@ ruleTester.run(RULE_NAME, rule, {
     `expect(getElement('foo')).not.toBeInTheDocument()`,
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
         // case: invalid presence assert but not reported because custom module is not imported
@@ -61,7 +61,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
         // case: invalid absence assert but not reported because custom module is not imported
@@ -664,7 +664,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       // case: asserting presence incorrectly importing custom module
@@ -675,7 +675,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       // case: asserting absence incorrectly importing custom module

--- a/tests/lib/rules/prefer-user-event.test.ts
+++ b/tests/lib/rules/prefer-user-event.test.ts
@@ -105,7 +105,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
         import { screen } from 'test-utils'
@@ -114,7 +114,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
         import { render } from 'test-utils'
@@ -124,7 +124,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     ...UserEventMethods.map((userEventMethod) => ({
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
         import userEvent from 'test-utils'
@@ -134,7 +134,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...Object.keys(MappingToUserEvent).map((fireEventMethod: string) => ({
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
         // fireEvent method used but not imported from TL related module
@@ -145,7 +145,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...Object.keys(MappingToUserEvent).map((fireEventMethod: string) => ({
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       import { fireEvent } from 'test-utils'
@@ -156,7 +156,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...Object.keys(MappingToUserEvent).map((fireEventMethod: string) => ({
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       import { fireEvent as fireEventAliased } from 'test-utils'
@@ -167,7 +167,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...Object.keys(MappingToUserEvent).map((fireEventMethod: string) => ({
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
       import * as dom from 'test-utils'
@@ -231,7 +231,7 @@ ruleTester.run(RULE_NAME, rule, {
     ),
     ...Object.keys(MappingToUserEvent).map((fireEventMethod: string) => ({
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
         import * as dom from 'test-utils'
@@ -241,7 +241,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...Object.keys(MappingToUserEvent).map((fireEventMethod: string) => ({
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
         import { fireEvent } from 'test-utils'
@@ -260,7 +260,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...Object.keys(MappingToUserEvent).map((fireEventMethod: string) => ({
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `
         import { fireEvent as fireEventAliased } from 'test-utils'

--- a/tests/lib/rules/prefer-wait-for.test.ts
+++ b/tests/lib/rules/prefer-wait-for.test.ts
@@ -22,7 +22,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `import { waitFor, render } from 'test-utils';
       
@@ -32,7 +32,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `const { waitFor, render } = require('test-utils');
       
@@ -56,7 +56,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `import { waitForElementToBeRemoved, render } from 'test-utils';
       
@@ -66,7 +66,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `const { waitForElementToBeRemoved, render } = require('test-utils');
       
@@ -90,7 +90,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `import * as testingLibrary from 'test-utils';
       
@@ -100,7 +100,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `const testingLibrary = require('test-utils');
       
@@ -126,7 +126,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `import { render } from 'test-utils';
       import { waitForSomethingElse } from 'other-module';
@@ -137,7 +137,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `const { render } = require('test-utils');
       const { waitForSomethingElse } = require('other-module');
@@ -162,7 +162,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `import * as testingLibrary from 'test-utils';
   
@@ -172,7 +172,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `const testingLibrary = require('test-utils');
   
@@ -295,7 +295,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `import { wait, render } from 'test-utils';
   
@@ -322,7 +322,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `const { wait, render } = require('test-utils');
   
@@ -389,7 +389,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `import * as testingLibrary from 'test-utils';
   
@@ -411,7 +411,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `const testingLibrary = require('test-utils');
   
@@ -473,7 +473,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `import * as testingLibrary from 'test-utils';
   
@@ -495,7 +495,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `const testingLibrary = require('test-utils');
   
@@ -565,7 +565,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `import { render, wait } from 'test-utils'
   
@@ -592,7 +592,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `const { render, wait } = require('test-utils');
   
@@ -677,7 +677,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `import { render, wait, screen } from "test-utils";
   
@@ -708,7 +708,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `const { render, wait, screen } = require('test-utils');
   
@@ -787,7 +787,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `import { render, waitForElement, screen } from 'test-utils'
   
@@ -814,7 +814,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `const { render, waitForElement, screen } = require('test-utils');
   
@@ -897,7 +897,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `import { waitForElement } from 'test-utils';
 
@@ -928,7 +928,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `const { waitForElement } = require('test-utils');
 
@@ -1007,7 +1007,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `import { waitForDomChange } from 'test-utils';
 
@@ -1034,7 +1034,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `const { waitForDomChange } = require('test-utils');
 
@@ -1109,7 +1109,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `import { waitForDomChange } from 'test-utils';
 
@@ -1136,7 +1136,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `const { waitForDomChange } = require('test-utils');
 
@@ -1211,7 +1211,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `import { waitForDomChange } from 'test-utils';
 
@@ -1238,7 +1238,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `const { waitForDomChange } = require('test-utils');
 
@@ -1359,7 +1359,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `import { waitForDomChange, wait, waitForElement } from 'test-utils';
       import userEvent from '@testing-library/user-event';
@@ -1409,7 +1409,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `const { waitForDomChange, wait, waitForElement } = require('test-utils');
       const userEvent = require('@testing-library/user-event');
@@ -1549,7 +1549,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `import { render, waitForDomChange, wait, waitForElement } from 'test-utils';
 
@@ -1597,7 +1597,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `const { render, waitForDomChange, wait, waitForElement } = require('test-utils');
 
@@ -1735,7 +1735,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `import { waitForDomChange, wait, render, waitForElement } from 'test-utils';
 
@@ -1783,7 +1783,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `const { waitForDomChange, wait, render, waitForElement } = require('test-utils');
 
@@ -1931,7 +1931,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `import {
         waitForDomChange,
@@ -1984,7 +1984,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       code: `const {
         waitForDomChange,
@@ -2091,7 +2091,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       // if already importing waitFor then it's not imported twice
       code: `import { wait, waitFor, render } from 'test-utils';
@@ -2121,7 +2121,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: {
-        'testing-library/module': 'test-utils',
+        'testing-library/utils-module': 'test-utils',
       },
       // if already importing waitFor then it's not imported twice
       code: `const { wait, waitFor, render } = require('test-utils');


### PR DESCRIPTION
Relates to #198

Pull Request not related to any particular rule. The purpose of this PR is to fix some checks, extract some commons patterns and general improvements:

- Rename `testing-library/module` setting to `testing-library/utils-module`
- Move detection helpers types to simplify their definitions
- Add new `getReferenceNode` and `getPropertyIdentifierNode` node util methods
- Rename `getIdentifierNode` to `getDeepestIdentifierNode` to avoid any misunderstanding with its behavior
- Add `isTestingLibraryUtil` method to extract common logic from `isAsyncUtil` and `isRenderUtil`
- Check inside `isAsyncUtil` if coming from Testing Library or not
- Improve how `isNodeComingFromTestingLibrary` obtained node identifier so it detects chained properties correctly
- Refactor rules using `isAsyncUtil` to avoid checking if coming from Testing Library manually
- Add several tests to fake rule to cover new detection helpers better

I mentioned I wanted to use glob pattern for `testing-library/filename-pattern` setting instead of regexp, but it doesn't make sense since it's just the name of the file, not its path. It's still using a string regexp then, but I'll need to clarify in the docs that it needs double backslash to scape special chars.