### PR TITLE
refactor(render-result-naming-convention): refine checks to decide if coming from Testing Library

### DIFF
--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -139,10 +139,25 @@ export function detectTestingLibraryUtils<
       const referenceNode = getReferenceNode(node);
       const referenceNodeIdentifier = getPropertyIdentifierNode(referenceNode);
 
-      return (
-        isAggressiveModuleReportingEnabled() ||
-        isNodeComingFromTestingLibrary(referenceNodeIdentifier)
+      if (isAggressiveModuleReportingEnabled()) {
+        return true;
+      }
+
+      // TODO: extract this into function, combined with logic from isFireEventMethod
+      // TODO: include some tests create-testing-library-rule
+      const importNode = findImportedUtilSpecifier(
+        referenceNodeIdentifier.name
       );
+
+      if (!importNode) {
+        return false;
+      }
+
+      if (ASTUtils.isIdentifier(importNode)) {
+        return importNode.name === referenceNodeIdentifier.name;
+      }
+
+      return importNode.local.name === referenceNodeIdentifier.name;
     }
 
     /**

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -620,3 +620,14 @@ export function getInnermostReturningFunction(
 
   return functionScope.block;
 }
+
+export function hasImportMatch(
+  importNode: TSESTree.ImportClause | TSESTree.Identifier,
+  identifierName: string
+): boolean {
+  if (ASTUtils.isIdentifier(importNode)) {
+    return importNode.name === identifierName;
+  }
+
+  return importNode.local.name === identifierName;
+}

--- a/tests/create-testing-library-rule.test.ts
+++ b/tests/create-testing-library-rule.test.ts
@@ -647,26 +647,6 @@ ruleTester.run(RULE_NAME, rule, {
         'testing-library/utils-module': 'test-utils',
       },
       code: `
-        // case: waitFor from object property shadowed name is checked correctly
-        import * as tl from 'test-utils'
-        const obj = { tl }
-        
-        obj.module.waitFor(() => {})
-      `,
-      errors: [
-        {
-          line: 6,
-          column: 20,
-          messageId: 'asyncUtilError',
-          data: { utilName: 'waitFor' },
-        },
-      ],
-    },
-    {
-      settings: {
-        'testing-library/utils-module': 'test-utils',
-      },
-      code: `
         // case: aggressive reporting disabled - waitFor from wildcard import related to TL 
         import * as tl from 'test-utils'
         tl.waitFor(() => {})

--- a/tests/create-testing-library-rule.test.ts
+++ b/tests/create-testing-library-rule.test.ts
@@ -126,6 +126,19 @@ ruleTester.run(RULE_NAME, rule, {
       const utils = render()
       `,
     },
+    {
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+      },
+      code: `
+      // case (render util): aggressive reporting disabled - method with same name
+      // as TL method but not coming from TL module is valid
+      import { render as testingLibraryRender } from 'test-utils'
+      import { render } from 'somewhere-else'
+
+      const utils = render()
+      `,
+    },
 
     // Test Cases for presence/absence assertions
     // cases: asserts not related to presence/absence
@@ -285,6 +298,21 @@ ruleTester.run(RULE_NAME, rule, {
       import { waitFor } from '@testing-library/react'
       
       waitFor()
+      `,
+    },
+    {
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+      },
+      code: `
+      // case (async util): aggressive reporting disabled - method with same name
+      // as TL method but not coming from TL module is valid
+      import { waitFor as testingLibraryWaitFor } from 'test-utils'
+      import { waitFor } from 'somewhere-else'
+
+        test('this should not be reported', () => {
+        waitFor()
+      });
       `,
     },
 

--- a/tests/lib/rules/prefer-wait-for.test.ts
+++ b/tests/lib/rules/prefer-wait-for.test.ts
@@ -219,6 +219,21 @@ ruleTester.run(RULE_NAME, rule, {
       `,
     },
     {
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+      },
+      code: `
+      // case: aggressive reporting disabled - method named same as invalid method
+      // but not coming from Testing Library is valid
+      import { wait as testingLibraryWait } from 'test-utils'
+      import { wait } from 'somewhere-else'
+      
+      async () => {
+        await wait();
+      }
+      `,
+    },
+    {
       // https://github.com/testing-library/eslint-plugin-testing-library/issues/145
       code: `import * as foo from 'imNoTestingLibrary';
         async function wait(): Promise<any> {

--- a/tests/lib/rules/render-result-naming-convention.test.ts
+++ b/tests/lib/rules/render-result-naming-convention.test.ts
@@ -148,6 +148,27 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
     },
+    {
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+        'testing-library/custom-renders': ['customRender'],
+      },
+      code: `
+        import { customRender as myRender } from 'test-utils';
+        import { customRender } from 'non-related'
+        
+        const setup = () => {
+          return customRender(<SomeComponent />);
+        };
+
+        test(
+        'both render and module aggressive reporting disabled - should not report render result called "wrapper" from nont-related renamed custom render wrapped in a function',
+        async () => {
+          const wrapper = setup();
+          await wrapper.findByRole('button');
+        });
+      `,
+    },
   ],
   invalid: [
     {
@@ -426,6 +447,63 @@ ruleTester.run(RULE_NAME, rule, {
             renderResultName: 'wrapper',
           },
           line: 9,
+          column: 17,
+        },
+      ],
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+        import { render as testingLibraryRender } from '@testing-library/react';
+        
+        const setup = () => {
+          return testingLibraryRender(<SomeComponent />);
+        };
+
+        test(
+        'aggressive reporting disabled - should report render result called "wrapper" from renamed render wrapped in a function',
+        async () => {
+          const wrapper = setup();
+          await wrapper.findByRole('button');
+        });
+      `,
+      errors: [
+        {
+          messageId: 'renderResultNamingConvention',
+          data: {
+            renderResultName: 'wrapper',
+          },
+          line: 11,
+          column: 17,
+        },
+      ],
+    },
+    {
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+        'testing-library/custom-renders': ['customRender'],
+      },
+      code: `
+        import { customRender as myRender } from 'test-utils';
+        
+        const setup = () => {
+          return myRender(<SomeComponent />);
+        };
+
+        test(
+        'both render and module aggressive reporting disabled - should report render result called "wrapper" from renamed custom render wrapped in a function',
+        async () => {
+          const wrapper = setup();
+          await wrapper.findByRole('button');
+        });
+      `,
+      errors: [
+        {
+          messageId: 'renderResultNamingConvention',
+          data: {
+            renderResultName: 'wrapper',
+          },
+          line: 11,
           column: 17,
         },
       ],

--- a/tests/lib/rules/render-result-naming-convention.test.ts
+++ b/tests/lib/rules/render-result-naming-convention.test.ts
@@ -261,6 +261,55 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+        import { render } from '@testing-library/react';
+        
+        const setup = () => render(<SomeComponent />);
+
+        test('aggressive reporting disabled - should report nested render from TL package', () => {
+          const wrapper = setup();
+          const button = wrapper.getByText('some button');
+        });
+      `,
+      errors: [
+        {
+          messageId: 'renderResultNamingConvention',
+          data: {
+            renderResultName: 'wrapper',
+          },
+          line: 7,
+          column: 17,
+        },
+      ],
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+        import { render } from 'test-utils';
+        
+        function setup() {
+          doSomethingElse();
+          return render(<SomeComponent />)
+        }
+
+        test('aggressive reporting disabled - should report nested render from custom utils module', () => {
+          const wrapper = setup();
+          const button = wrapper.getByText('some button');
+        });
+      `,
+      errors: [
+        {
+          messageId: 'renderResultNamingConvention',
+          data: {
+            renderResultName: 'wrapper',
+          },
+          line: 10,
+          column: 17,
+        },
+      ],
+    },
+    {
       code: `
         import { customRender } from 'test-utils';
 

--- a/tests/lib/rules/render-result-naming-convention.test.ts
+++ b/tests/lib/rules/render-result-naming-convention.test.ts
@@ -134,6 +134,20 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
     },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+        import { render as testingLibraryRender } from '@testing-library/react';
+        import { render } from '@somewhere/else'
+        
+        const setup = () => render(<SomeComponent />);
+
+        test('aggressive reporting disabled - should not report nested render not related to TL', () => {
+          const wrapper = setup();
+          const button = wrapper.getByText('some button');
+        });
+      `,
+    },
   ],
   invalid: [
     {

--- a/tests/lib/rules/render-result-naming-convention.test.ts
+++ b/tests/lib/rules/render-result-naming-convention.test.ts
@@ -406,5 +406,29 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     },
+    {
+      code: `
+        import { render as testingLibraryRender } from '@testing-library/react';
+        
+        const setup = () => {
+          return testingLibraryRender(<SomeComponent />);
+        };
+
+        test('should report render result called "wrapper" from renamed render wrapped in a function', async () => {
+          const wrapper = setup();
+          await wrapper.findByRole('button');
+        });
+      `,
+      errors: [
+        {
+          messageId: 'renderResultNamingConvention',
+          data: {
+            renderResultName: 'wrapper',
+          },
+          line: 9,
+          column: 17,
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
Relates to #198

As mentioned in [the PR for migrating `render-result-naming-convention` rule to the new mechanism](https://github.com/testing-library/eslint-plugin-testing-library/pull/280#discussion_r585942050), this new PR aims to check nested/wrapped render calls.

After doing so, I came up with checking misleading renamed imports like:
```javascript
import { render as testingLibrary } from '@testing-library/react'
import { render } from 'somewhere-else'

// ...

// this render must not be reported when aggressive reporting is disabled
render()
```

It turned out we were reporting this case, so I've refined the "is coming from Testing Library" check to make sure the renamed import is what we are looking for. It was based on @gndelia's check for `fireEvent` but extracted into few utils and made more generic, without changing `isFireEventMethod` since it needs the actual import clause to do more checks.

After this refinement, I'm really confident about the whole detection mechanism. I don't expect to find major issues migrating the remaining rules, so I hope I can create several PRs in the coming days migrating most of them 💪 