### PR TITLE
fix: add no-await-sync-events exception for userEvent.keyboard

### DIFF
--- a/lib/rules/no-await-sync-events.ts
+++ b/lib/rules/no-await-sync-events.ts
@@ -44,7 +44,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
               property.key.name === 'delay'
           );
 
-        if (!(node.name === 'userEvent' && methodNode.name === 'type' && withDelay)) {
+        if (!(node.name === 'userEvent' && (methodNode.name === 'type' || methodNode.name === 'keyboard') && withDelay)) {
           context.report({
             node: methodNode,
             messageId: 'noAwaitSyncEvents',

--- a/lib/rules/no-await-sync-events.ts
+++ b/lib/rules/no-await-sync-events.ts
@@ -44,7 +44,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
               property.key.name === 'delay'
           );
 
-        if (!(node.name === 'userEvent' && (methodNode.name === 'type' || methodNode.name === 'keyboard') && withDelay)) {
+        if (!(node.name === 'userEvent' && ['type', 'keyboard'].includes(methodNode.name) && withDelay)) {
           context.report({
             node: methodNode,
             messageId: 'noAwaitSyncEvents',

--- a/lib/rules/no-await-sync-events.ts
+++ b/lib/rules/no-await-sync-events.ts
@@ -35,9 +35,9 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
         const memberExpression = node.parent as TSESTree.MemberExpression;
         const methodNode = memberExpression.property as TSESTree.Identifier;
         const callExpression = memberExpression.parent as TSESTree.CallExpression;
-        const withDelay = callExpression.arguments.length >= 3 &&
-          isObjectExpression(callExpression.arguments[2]) &&
-          callExpression.arguments[2].properties.some(
+        const lastArg = callExpression.arguments[callExpression.arguments.length - 1]
+        const withDelay = isObjectExpression(lastArg) &&
+          lastArg.properties.some(
             property =>
               isProperty(property) &&
               isIdentifier(property.key) &&

--- a/tests/lib/rules/no-await-sync-events.test.ts
+++ b/tests/lib/rules/no-await-sync-events.test.ts
@@ -138,6 +138,12 @@ ruleTester.run(RULE_NAME, rule, {
       }
       `,
     },
+    {
+      code: `() => {
+        await userEvent.keyboard('foo', {delay: 1234})
+      }
+      `,
+    },
   ],
 
   invalid: [
@@ -157,9 +163,13 @@ ruleTester.run(RULE_NAME, rule, {
         import userEvent from '@testing-library/user-event';
         test('should report sync event awaited', async() => {
           await userEvent.type('foo', 'bar', {hello: 1234});
+          await userEvent.keyboard('foo', {hello: 1234});
         });
       `,
-      errors: [{ line: 4, messageId: 'noAwaitSyncEvents' },],
+      errors: [
+        { line: 4, messageId: 'noAwaitSyncEvents' },
+        { line: 5, messageId: 'noAwaitSyncEvents' },
+      ],
     }
   ],
 });


### PR DESCRIPTION
Added exception for the new API proposed in https://github.com/testing-library/user-event/pull/581

Note that with the change `userEvent.type` (and `userEvent.keyboard`) will actually return no Promise if the `delay` is not `>0` so that the typing and the actual return value will match.

Further it might be worth discussing if this rule should be disabled for `.ts` and `.tsx` files as `ts(80007)` and `@typescript-eslint/await-thenable` already warn here and curating a manual list has no benefits when there already are warnings based on the type.