### PR TITLE
Move rules settings to ESLint shared config: refactor prefer-screen-queries rule

### DIFF
--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -61,6 +61,7 @@ type IsQueryQueryVariantFn = (node: TSESTree.Identifier) => boolean;
 type IsFindQueryVariantFn = (node: TSESTree.Identifier) => boolean;
 type IsSyncQueryFn = (node: TSESTree.Identifier) => boolean;
 type IsAsyncQueryFn = (node: TSESTree.Identifier) => boolean;
+type IsQueryFn = (node: TSESTree.Identifier) => boolean;
 type IsCustomQueryFn = (node: TSESTree.Identifier) => boolean;
 type IsAsyncUtilFn = (node: TSESTree.Identifier) => boolean;
 type IsFireEventMethodFn = (node: TSESTree.Identifier) => boolean;
@@ -87,6 +88,7 @@ export interface DetectionHelpers {
   isFindQueryVariant: IsFindQueryVariantFn;
   isSyncQuery: IsSyncQueryFn;
   isAsyncQuery: IsAsyncQueryFn;
+  isQuery: IsQueryFn;
   isCustomQuery: IsCustomQueryFn;
   isAsyncUtil: IsAsyncUtilFn;
   isFireEventMethod: IsFireEventMethodFn;
@@ -271,11 +273,16 @@ export function detectTestingLibraryUtils<
       return isFindQueryVariant(node);
     };
 
+    /**
+     * Determines whether a given node is a valid query,
+     * either built-in or custom
+     */
+    const isQuery: IsQueryFn = (node) => {
+      return isSyncQuery(node) || isAsyncQuery(node);
+    };
+
     const isCustomQuery: IsCustomQueryFn = (node) => {
-      return (
-        (isSyncQuery(node) || isAsyncQuery(node)) &&
-        !ALL_QUERIES_COMBINATIONS.includes(node.name)
-      );
+      return isQuery(node) && !ALL_QUERIES_COMBINATIONS.includes(node.name);
     };
 
     /**
@@ -528,6 +535,7 @@ export function detectTestingLibraryUtils<
       isFindQueryVariant,
       isSyncQuery,
       isAsyncQuery,
+      isQuery,
       isCustomQuery,
       isAsyncUtil,
       isFireEventMethod,

--- a/lib/rules/prefer-screen-queries.ts
+++ b/lib/rules/prefer-screen-queries.ts
@@ -1,16 +1,13 @@
+import { ASTUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { ALL_QUERIES_COMBINATIONS } from '../utils';
 import {
-  ESLintUtils,
-  TSESTree,
-  ASTUtils,
-} from '@typescript-eslint/experimental-utils';
-import { getDocsUrl, ALL_QUERIES_COMBINATIONS } from '../utils';
-import {
-  isMemberExpression,
-  isObjectPattern,
   isCallExpression,
-  isProperty,
+  isMemberExpression,
   isObjectExpression,
+  isObjectPattern,
+  isProperty,
 } from '../node-utils';
+import { createTestingLibraryRule } from '../create-testing-library-rule';
 
 export const RULE_NAME = 'prefer-screen-queries';
 export type MessageIds = 'preferScreenQueries';
@@ -35,7 +32,7 @@ function usesContainerOrBaseElement(node: TSESTree.CallExpression) {
   );
 }
 
-export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
+export default createTestingLibraryRule<Options, MessageIds>({
   name: RULE_NAME,
   meta: {
     type: 'suggestion',

--- a/lib/rules/prefer-screen-queries.ts
+++ b/lib/rules/prefer-screen-queries.ts
@@ -50,7 +50,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
   },
   defaultOptions: [],
 
-  create(context) {
+  create(context, _, helpers) {
     function reportInvalidUsage(node: TSESTree.Identifier) {
       context.report({
         node,
@@ -75,9 +75,8 @@ export default createTestingLibraryRule<Options, MessageIds>({
           return;
         }
         const isWithinFunction = node.init.callee.name === 'within';
-        // TODO add the custom render option #198
         const usesRenderOptions =
-          node.init.callee.name === 'render' &&
+          helpers.isRenderUtil(node.init.callee) &&
           usesContainerOrBaseElement(node.init);
 
         if (!isWithinFunction && !usesRenderOptions) {
@@ -130,7 +129,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
           isCallExpression(node.parent.object) &&
           ASTUtils.isIdentifier(node.parent.object.callee) &&
           node.parent.object.callee.name !== 'within' &&
-          node.parent.object.callee.name === 'render' &&
+          helpers.isRenderUtil(node.parent.object.callee) &&
           !usesContainerOrBaseElement(node.parent.object)
         ) {
           reportInvalidUsage(node);

--- a/tests/lib/rules/prefer-screen-queries.test.ts
+++ b/tests/lib/rules/prefer-screen-queries.test.ts
@@ -4,6 +4,8 @@ import { ALL_QUERIES_COMBINATIONS } from '../../../lib/utils';
 
 const ruleTester = createRuleTester();
 
+// TODO: include custom queries in test cases
+
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     {

--- a/tests/lib/rules/prefer-screen-queries.test.ts
+++ b/tests/lib/rules/prefer-screen-queries.test.ts
@@ -127,6 +127,15 @@ ruleTester.run(RULE_NAME, rule, {
         render(foo, { baseElement: treeA }).${queryMethod}()
       `,
     })),
+    // ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+    //   settings: {
+    //     'testing-library/custom-renders': ['customRender'],
+    //   },
+    //   code: `
+    //     import { anotherRender } from 'whatever'
+    //     const { ${queryMethod} } = anotherRender(foo)
+    //     ${queryMethod}()`,
+    // })),
   ],
 
   invalid: [
@@ -136,6 +145,77 @@ ruleTester.run(RULE_NAME, rule, {
         ${queryMethod}()`,
       errors: [
         {
+          messageId: 'preferScreenQueries',
+          data: {
+            name: queryMethod,
+          },
+        },
+      ],
+    })),
+    ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+        import { render } from 'test-utils'
+        const { ${queryMethod} } = render(foo)
+        ${queryMethod}()`,
+      errors: [
+        {
+          line: 4,
+          column: 9,
+          messageId: 'preferScreenQueries',
+          data: {
+            name: queryMethod,
+          },
+        },
+      ],
+    })),
+
+    ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+      settings: {
+        'testing-library/custom-renders': ['customRender'],
+      },
+      code: `
+        import { customRender } from 'whatever'
+        const { ${queryMethod} } = customRender(foo)
+        ${queryMethod}()`,
+      errors: [
+        {
+          line: 4,
+          column: 9,
+          messageId: 'preferScreenQueries',
+          data: {
+            name: queryMethod,
+          },
+        },
+      ],
+    })),
+    ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+        import { render as testingLibraryRender} from '@testing-library/react'
+        const { ${queryMethod} } = testingLibraryRender(foo)
+        ${queryMethod}()`,
+      errors: [
+        {
+          line: 4,
+          column: 9,
+          messageId: 'preferScreenQueries',
+          data: {
+            name: queryMethod,
+          },
+        },
+      ],
+    })),
+    ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+        import { render } from 'test-utils'
+        const { ${queryMethod} } = render(foo)
+        ${queryMethod}()`,
+      errors: [
+        {
+          line: 4,
+          column: 9,
           messageId: 'preferScreenQueries',
           data: {
             name: queryMethod,

--- a/tests/lib/rules/prefer-screen-queries.test.ts
+++ b/tests/lib/rules/prefer-screen-queries.test.ts
@@ -151,15 +151,23 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       })
     ),
-    // ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map((queryMethod) => ({
-    //   settings: {
-    //     'testing-library/custom-renders': ['customRender'],
-    //   },
-    //   code: `
-    //     import { anotherRender } from 'whatever'
-    //     const { ${queryMethod} } = anotherRender(foo)
-    //     ${queryMethod}()`,
-    // })),
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map((queryMethod) => ({
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+        import { render as testUtilRender } from 'test-utils'
+        import { render } from 'somewhere-else'
+        const { ${queryMethod} } = render(foo)
+        ${queryMethod}()`,
+    })),
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map((queryMethod) => ({
+      settings: {
+        'testing-library/custom-renders': ['customRender'],
+      },
+      code: `
+        import { anotherRender } from 'whatever'
+        const { ${queryMethod} } = anotherRender(foo)
+        ${queryMethod}()`,
+    })),
   ],
 
   invalid: [

--- a/tests/lib/rules/prefer-screen-queries.test.ts
+++ b/tests/lib/rules/prefer-screen-queries.test.ts
@@ -1,17 +1,27 @@
 import { createRuleTester } from '../test-utils';
 import rule, { RULE_NAME } from '../../../lib/rules/prefer-screen-queries';
-import { ALL_QUERIES_COMBINATIONS } from '../../../lib/utils';
+import {
+  ALL_QUERIES_COMBINATIONS,
+  ALL_QUERIES_VARIANTS,
+  combineQueries,
+} from '../../../lib/utils';
 
 const ruleTester = createRuleTester();
 
-// TODO: include custom queries in test cases
+const CUSTOM_QUERY_COMBINATIONS = combineQueries(ALL_QUERIES_VARIANTS, [
+  'ByIcon',
+]);
+const ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS = [
+  ...ALL_QUERIES_COMBINATIONS,
+  ...CUSTOM_QUERY_COMBINATIONS,
+];
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     {
       code: `const baz = () => 'foo'`,
     },
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `screen.${queryMethod}()`,
     })),
     {
@@ -20,19 +30,19 @@ ruleTester.run(RULE_NAME, rule, {
     {
       code: `component.otherFunctionShouldNotThrow()`,
     },
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `within(component).${queryMethod}()`,
     })),
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `within(screen.${queryMethod}()).${queryMethod}()`,
     })),
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `
         const { ${queryMethod} } = within(screen.getByText('foo'))
         ${queryMethod}(baz)
       `,
     })),
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `
         const myWithinVariable = within(foo)
         myWithinVariable.${queryMethod}('baz')
@@ -86,48 +96,62 @@ ruleTester.run(RULE_NAME, rule, {
         utils.unmount();
       `,
     },
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod: string) => ({
-      code: `
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map(
+      (queryMethod: string) => ({
+        code: `
         const { ${queryMethod} } = render(baz, { baseElement: treeA })
         expect(${queryMethod}(baz)).toBeDefined()
       `,
-    })),
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod: string) => ({
-      code: `
+      })
+    ),
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map(
+      (queryMethod: string) => ({
+        code: `
         const { ${queryMethod}: aliasMethod } = render(baz, { baseElement: treeA })
         expect(aliasMethod(baz)).toBeDefined()
       `,
-    })),
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod: string) => ({
-      code: `
+      })
+    ),
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map(
+      (queryMethod: string) => ({
+        code: `
         const { ${queryMethod} } = render(baz, { container: treeA })
         expect(${queryMethod}(baz)).toBeDefined()
       `,
-    })),
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod: string) => ({
-      code: `
+      })
+    ),
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map(
+      (queryMethod: string) => ({
+        code: `
         const { ${queryMethod}: aliasMethod } = render(baz, { container: treeA })
         expect(aliasMethod(baz)).toBeDefined()
       `,
-    })),
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod: string) => ({
-      code: `
+      })
+    ),
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map(
+      (queryMethod: string) => ({
+        code: `
         const { ${queryMethod} } = render(baz, { baseElement: treeB, container: treeA })
         expect(${queryMethod}(baz)).toBeDefined()
       `,
-    })),
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod: string) => ({
-      code: `
+      })
+    ),
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map(
+      (queryMethod: string) => ({
+        code: `
         const { ${queryMethod}: aliasMethod } = render(baz, { baseElement: treeB, container: treeA })
         expect(aliasMethod(baz)).toBeDefined()
       `,
-    })),
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod: string) => ({
-      code: `
+      })
+    ),
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map(
+      (queryMethod: string) => ({
+        code: `
         render(foo, { baseElement: treeA }).${queryMethod}()
       `,
-    })),
-    // ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+      })
+    ),
+    // ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map((queryMethod) => ({
     //   settings: {
     //     'testing-library/custom-renders': ['customRender'],
     //   },
@@ -139,7 +163,7 @@ ruleTester.run(RULE_NAME, rule, {
   ],
 
   invalid: [
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `
         const { ${queryMethod} } = render(foo)
         ${queryMethod}()`,
@@ -152,7 +176,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     })),
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map((queryMethod) => ({
       settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
         import { render } from 'test-utils'
@@ -170,7 +194,7 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     })),
 
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map((queryMethod) => ({
       settings: {
         'testing-library/custom-renders': ['customRender'],
       },
@@ -189,7 +213,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     })),
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map((queryMethod) => ({
       settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
         import { render as testingLibraryRender} from '@testing-library/react'
@@ -206,7 +230,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     })),
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map((queryMethod) => ({
       settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
         import { render } from 'test-utils'
@@ -223,7 +247,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     })),
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `render().${queryMethod}()`,
       errors: [
         {
@@ -234,7 +258,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     })),
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `render(foo, { hydrate: true }).${queryMethod}()`,
       errors: [
         {
@@ -245,7 +269,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     })),
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `component.${queryMethod}()`,
       errors: [
         {
@@ -256,7 +280,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     })),
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `
         const { ${queryMethod} } = render()
         ${queryMethod}(baz)
@@ -270,7 +294,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     })),
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `
         const myRenderVariable = render()
         myRenderVariable.${queryMethod}(baz)
@@ -284,7 +308,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     })),
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `
         const [myVariable] = render()
         myVariable.${queryMethod}(baz)
@@ -298,7 +322,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     })),
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `
         const { ${queryMethod} } = render(baz, { hydrate: true })
         ${queryMethod}(baz)
@@ -312,7 +336,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     })),
-    ...ALL_QUERIES_COMBINATIONS.map((queryMethod) => ({
+    ...ALL_BUILTIN_AND_CUSTOM_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `
         const [myVariable] = within()
         myVariable.${queryMethod}(baz)


### PR DESCRIPTION
Relates to #198

This refactor for `prefer-screen-queries` includes:
- using custom rule creator + detection helpers
- detect only queries coming from valid renders
- minor tweaks and fixes

I had an idea to simplify the whole rule implementation. However, since this one works fine, I'll leave it for now as I don't have that amount of time to spend on this.