### PR TITLE
Move rules settings to ESLint shared config: refactor no-debug rule 

### DIFF
--- a/docs/rules/no-debug.md
+++ b/docs/rules/no-debug.md
@@ -1,6 +1,6 @@
 # Disallow the use of `debug` (no-debug)
 
-Just like `console.log` statements pollutes the browser's output, debug statements also pollutes the tests if one of your team mates forgot to remove it. `debug` statements should be used when you actually want to debug your tests but should not be pushed to the codebase.
+Just like `console.log` statements pollutes the browser's output, debug statements also pollutes the tests if one of your teammates forgot to remove it. `debug` statements should be used when you actually want to debug your tests but should not be pushed to the codebase.
 
 ## Rule Details
 
@@ -26,12 +26,6 @@ screen.debug();
 ```js
 const { screen } = require('@testing-library/react');
 screen.debug();
-```
-
-If you use [custom render functions](https://testing-library.com/docs/example-react-redux) then you can set a config option in your `.eslintrc` to look for these.
-
-```
-   "testing-library/no-debug": ["error", {"renderFunctions":["renderWithRedux", "renderWithRouter"]}],
 ```
 
 ## Further Reading

--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -69,6 +69,7 @@ type IsAsyncUtilFn = (
 ) => boolean;
 type IsFireEventMethodFn = (node: TSESTree.Identifier) => boolean;
 type IsRenderUtilFn = (node: TSESTree.Identifier) => boolean;
+type IsDebugUtilFn = (node: TSESTree.Identifier) => boolean;
 type IsPresenceAssertFn = (node: TSESTree.MemberExpression) => boolean;
 type IsAbsenceAssertFn = (node: TSESTree.MemberExpression) => boolean;
 type CanReportErrorsFn = () => boolean;
@@ -96,6 +97,7 @@ export interface DetectionHelpers {
   isAsyncUtil: IsAsyncUtilFn;
   isFireEventMethod: IsFireEventMethodFn;
   isRenderUtil: IsRenderUtilFn;
+  isDebugUtil: IsDebugUtilFn;
   isPresenceAssert: IsPresenceAssertFn;
   isAbsenceAssert: IsAbsenceAssertFn;
   canReportErrors: CanReportErrorsFn;
@@ -406,6 +408,17 @@ export function detectTestingLibraryUtils<
       );
     };
 
+    const isDebugUtil: IsDebugUtilFn = (node) => {
+      return isTestingLibraryUtil(
+        node,
+        (identifierNodeName, originalNodeName) => {
+          return [identifierNodeName, originalNodeName]
+            .filter(Boolean)
+            .includes('debug');
+        }
+      );
+    };
+
     /**
      * Determines whether a given MemberExpression node is a presence assert
      *
@@ -549,6 +562,7 @@ export function detectTestingLibraryUtils<
       isAsyncUtil,
       isFireEventMethod,
       isRenderUtil,
+      isDebugUtil,
       isPresenceAssert,
       isAbsenceAssert,
       canReportErrors,

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -392,7 +392,7 @@ export function getPropertyIdentifierNode(
 }
 
 /**
- * Gets the deepest identifier node from a given node.
+ * Gets the deepest identifier node in the expression from a given node.
  *
  * Opposite of {@link getReferenceNode}
  *
@@ -416,11 +416,15 @@ export function getDeepestIdentifierNode(
     return getDeepestIdentifierNode(node.callee);
   }
 
+  if (ASTUtils.isAwaitExpression(node)) {
+    return getDeepestIdentifierNode(node.argument);
+  }
+
   return null;
 }
 
 /**
- * Gets the farthest node from a given node.
+ * Gets the farthest node in the expression from a given node.
  *
  * Opposite of {@link getDeepestIdentifierNode}
 

--- a/lib/rules/no-debug.ts
+++ b/lib/rules/no-debug.ts
@@ -1,28 +1,21 @@
+import { ASTUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { hasTestingLibraryImportModule, LIBRARY_MODULES } from '../utils';
 import {
-  ESLintUtils,
-  TSESTree,
-  ASTUtils,
-} from '@typescript-eslint/experimental-utils';
-import {
-  getDocsUrl,
-  LIBRARY_MODULES,
-  hasTestingLibraryImportModule,
-} from '../utils';
-import {
-  isObjectPattern,
-  isProperty,
   isCallExpression,
+  isImportSpecifier,
   isLiteral,
   isMemberExpression,
-  isImportSpecifier,
+  isObjectPattern,
+  isProperty,
   isRenderVariableDeclarator,
 } from '../node-utils';
+import { createTestingLibraryRule } from '../create-testing-library-rule';
 
 export const RULE_NAME = 'no-debug';
 export type MessageIds = 'noDebug';
 type Options = [{ renderFunctions?: string[] }];
 
-export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
+export default createTestingLibraryRule<Options, MessageIds>({
   name: RULE_NAME,
   meta: {
     type: 'problem',

--- a/lib/rules/no-debug.ts
+++ b/lib/rules/no-debug.ts
@@ -46,10 +46,6 @@ export default createTestingLibraryRule<Options, MessageIds>({
       VariableDeclarator(node) {
         const initIdentifierNode = getDeepestIdentifierNode(node.init);
 
-        if (!initIdentifierNode) {
-          return;
-        }
-
         if (!helpers.isRenderUtil(initIdentifierNode)) {
           return;
         }
@@ -68,12 +64,12 @@ export default createTestingLibraryRule<Options, MessageIds>({
               );
             }
           }
-        } else {
-          // find utils kept from render and save their node, like:
-          // const utils = render();
-          if (ASTUtils.isIdentifier(node.id)) {
-            suspiciousReferenceNodes.push(node.id);
-          }
+        }
+
+        // find utils kept from render and save their node, like:
+        // const utils = render();
+        if (ASTUtils.isIdentifier(node.id)) {
+          suspiciousReferenceNodes.push(node.id);
         }
       },
       CallExpression(node) {

--- a/tests/lib/rules/no-debug.test.ts
+++ b/tests/lib/rules/no-debug.test.ts
@@ -101,6 +101,8 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [
         {
+          line: 3,
+          column: 9,
           messageId: 'noDebug',
         },
       ],
@@ -117,6 +119,8 @@ ruleTester.run(RULE_NAME, rule, {
       ],
       errors: [
         {
+          line: 3,
+          column: 9,
           messageId: 'noDebug',
         },
       ],
@@ -128,6 +132,8 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [
         {
+          line: 3,
+          column: 15,
           messageId: 'noDebug',
         },
       ],
@@ -141,9 +147,13 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [
         {
+          line: 3,
+          column: 15,
           messageId: 'noDebug',
         },
         {
+          line: 5,
+          column: 15,
           messageId: 'noDebug',
         },
       ],
@@ -158,6 +168,8 @@ ruleTester.run(RULE_NAME, rule, {
       })`,
       errors: [
         {
+          line: 5,
+          column: 11,
           messageId: 'noDebug',
         },
       ],
@@ -172,6 +184,8 @@ ruleTester.run(RULE_NAME, rule, {
       })`,
       errors: [
         {
+          line: 5,
+          column: 17,
           messageId: 'noDebug',
         },
       ],
@@ -183,6 +197,8 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [
         {
+          line: 3,
+          column: 16,
           messageId: 'noDebug',
         },
       ],
@@ -194,6 +210,8 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [
         {
+          line: 3,
+          column: 16,
           messageId: 'noDebug',
         },
       ],
@@ -206,6 +224,8 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [
         {
+          line: 3,
+          column: 16,
           messageId: 'noDebug',
         },
       ],

--- a/tests/lib/rules/no-debug.test.ts
+++ b/tests/lib/rules/no-debug.test.ts
@@ -6,9 +6,18 @@ const ruleTester = createRuleTester();
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     {
+      settings: { 'testing-library/utils-module': 'test-utils' },
       code: `debug()`,
     },
     {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+      import { screen } from 'somewhere-else'
+      screen.debug()
+      `,
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
       code: `() => {
         const somethingElse = {}
         const { debug } = foo()
@@ -16,6 +25,7 @@ ruleTester.run(RULE_NAME, rule, {
       }`,
     },
     {
+      settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
         let foo
         const debug = require('debug')
@@ -41,6 +51,7 @@ ruleTester.run(RULE_NAME, rule, {
       `,
     },
     {
+      settings: { 'testing-library/utils-module': 'test-utils' },
       code: `screen.debug()`,
     },
     {
@@ -64,6 +75,7 @@ ruleTester.run(RULE_NAME, rule, {
       `,
     },
     {
+      settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
         import * as foo from '@somewhere/else';
         foo.debug();
@@ -73,12 +85,14 @@ ruleTester.run(RULE_NAME, rule, {
       code: `import { queries } from '@testing-library/dom'`,
     },
     {
+      settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
         const { screen } = require('something-else')
         screen.debug()
       `,
     },
     {
+      settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
         import { screen } from 'something-else'
         screen.debug()
@@ -95,6 +109,25 @@ ruleTester.run(RULE_NAME, rule, {
 
   invalid: [
     {
+      code: `debug()`,
+      errors: [{ line: 1, column: 1, messageId: 'noDebug' }],
+    },
+    {
+      code: `
+      import { screen } from 'aggressive-reporting'
+      screen.debug()
+      `,
+      errors: [{ line: 3, column: 14, messageId: 'noDebug' }],
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+      import { screen } from 'test-utils'
+      screen.debug()
+      `,
+      errors: [{ line: 3, column: 14, messageId: 'noDebug' }],
+    },
+    {
       code: `
         const { debug } = render(<Component/>)
         debug()
@@ -108,15 +141,13 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
+      settings: {
+        'testing-library/custom-renders': ['customRender', 'renderWithRedux'],
+      },
       code: `
         const { debug } = renderWithRedux(<Component/>)
         debug()
       `,
-      options: [
-        {
-          renderFunctions: ['renderWithRedux'],
-        },
-      ],
       errors: [
         {
           line: 3,

--- a/tests/lib/rules/no-debug.test.ts
+++ b/tests/lib/rules/no-debug.test.ts
@@ -105,6 +105,40 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
     },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+      import { debug as testingDebug } from 'test-utils'
+      import { debug } from 'somewhere-else'
+
+      debug()
+      `,
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+      import { render as testingRender } from '@testing-library/react'
+      import { render } from 'somewhere-else'
+      
+      const { debug } = render(element)
+      
+      somethingElse()
+      debug()
+      `,
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+      import { render as testingRender } from '@testing-library/react'
+      import { render } from 'somewhere-else'
+      
+      const { debug } = render(element)
+      const { debug: testingDebug } = testingRender(element)
+      
+      somethingElse()
+      debug()
+      `,
+    },
   ],
 
   invalid: [
@@ -126,6 +160,14 @@ ruleTester.run(RULE_NAME, rule, {
       screen.debug()
       `,
       errors: [{ line: 3, column: 14, messageId: 'noDebug' }],
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+      import { debug as testingDebug } from 'test-utils'
+      testingDebug()
+      `,
+      errors: [{ line: 3, column: 7, messageId: 'noDebug' }],
     },
     {
       code: `
@@ -170,6 +212,21 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `// aggressive reporting disabled
+        import { render } from 'test-utils'
+        const utils = render(<Component/>)
+        utils.debug()
+      `,
+      errors: [
+        {
+          line: 4,
+          column: 15,
+          messageId: 'noDebug',
+        },
+      ],
+    },
+    {
       code: `
         const utils = render(<Component/>)
         utils.debug()
@@ -184,6 +241,28 @@ ruleTester.run(RULE_NAME, rule, {
         },
         {
           line: 5,
+          column: 15,
+          messageId: 'noDebug',
+        },
+      ],
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `// aggressive reporting disabled
+        import { render } from 'test-utils'
+        const utils = render(<Component/>)
+        utils.debug()
+        utils.foo()
+        utils.debug()
+      `,
+      errors: [
+        {
+          line: 4,
+          column: 15,
+          messageId: 'noDebug',
+        },
+        {
+          line: 6,
           column: 15,
           messageId: 'noDebug',
         },
@@ -206,6 +285,24 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `// aggressive reporting disabled
+      import { render } from 'test-utils'
+      describe(() => {
+        test(async () => {
+          const { debug } = await render("foo")
+          debug()
+        })
+      })`,
+      errors: [
+        {
+          line: 6,
+          column: 11,
+          messageId: 'noDebug',
+        },
+      ],
+    },
+    {
       code: `
       describe(() => {
         test(async () => {
@@ -216,6 +313,24 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [
         {
           line: 5,
+          column: 17,
+          messageId: 'noDebug',
+        },
+      ],
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `// aggressive reporting disabled
+      import { render } from 'test-utils'
+      describe(() => {
+        test(async () => {
+          const utils = await render("foo")
+          utils.debug()
+        })
+      })`,
+      errors: [
+        {
+          line: 6,
           column: 17,
           messageId: 'noDebug',
         },
@@ -235,7 +350,35 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `// aggressive reporting disabled
+        const { screen } = require('@testing-library/dom')
+        screen.debug()
+      `,
+      errors: [
+        {
+          line: 3,
+          column: 16,
+          messageId: 'noDebug',
+        },
+      ],
+    },
+    {
       code: `
+        import { screen } from '@testing-library/dom'
+        screen.debug()
+      `,
+      errors: [
+        {
+          line: 3,
+          column: 16,
+          messageId: 'noDebug',
+        },
+      ],
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `// aggressive reporting disabled
         import { screen } from '@testing-library/dom'
         screen.debug()
       `,
@@ -262,6 +405,21 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `// aggressive reporting disabled
+        import { screen, render } from '@testing-library/dom'
+        screen.debug()
+      `,
+      errors: [
+        {
+          line: 3,
+          column: 16,
+          messageId: 'noDebug',
+        },
+      ],
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
         import * as dtl from '@testing-library/dom';
         dtl.debug();
@@ -273,6 +431,68 @@ ruleTester.run(RULE_NAME, rule, {
           column: 13,
         },
       ],
+    },
+    {
+      code: `
+      import { render } from 'aggressive-reporting'
+      
+      const { debug } = render(element)
+      
+      somethingElse()
+      debug()
+      `,
+      errors: [{ line: 7, column: 7, messageId: 'noDebug' }],
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+      import { render } from '@testing-library/react'
+      
+      const { debug } = render(element)
+      
+      somethingElse()
+      debug()
+      `,
+      errors: [{ line: 7, column: 7, messageId: 'noDebug' }],
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+      import { render } from 'test-utils'
+      
+      const { debug: renamed } = render(element)
+      
+      somethingElse()
+      renamed()
+      `,
+      errors: [{ line: 7, column: 7, messageId: 'noDebug' }],
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+      import { render } from '@testing-library/react'
+      
+      const utils = render(element)
+      
+      somethingElse()
+      utils.debug()
+      `,
+      errors: [{ line: 7, column: 13, messageId: 'noDebug' }],
+    },
+    {
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+        'testing-library/custom-renders': ['testingRender'],
+      },
+      code: `// aggressive reporting disabled, custom render set
+      import { testingRender } from 'test-utils'
+      
+      const { debug: renamedDebug } = testingRender(element)
+      
+      somethingElse()
+      renamedDebug()
+      `,
+      errors: [{ line: 7, column: 7, messageId: 'noDebug' }],
     },
   ],
 });


### PR DESCRIPTION
Relates to #198 

This refactor for `no-debug` includes:

- using custom rule creator + detection helpers
- improve test coverage and errors assertions