### PR TITLE
Move rules settings to ESLint shared config: refactor no-container rule 

### DIFF
--- a/docs/rules/no-container.md
+++ b/docs/rules/no-container.md
@@ -32,12 +32,6 @@ render(<Example />);
 screen.getByRole('button', { name: /click me/i });
 ```
 
-If you use [custom render functions](https://testing-library.com/docs/example-react-redux) then you can set a config option in your `.eslintrc` to look for these.
-
-```
-"testing-library/no-container": ["error", {"renderFunctions":["renderWithRedux", "renderWithRouter"]}],
-```
-
 ## Further Reading
 
 - [about the `container` element](https://testing-library.com/docs/react-testing-library/api#container-1)

--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -154,6 +154,10 @@ export function detectTestingLibraryUtils<
         originalNodeName?: string
       ) => boolean
     ): boolean {
+      if (!node) {
+        return false;
+      }
+
       const referenceNode = getReferenceNode(node);
       const referenceNodeIdentifier = getPropertyIdentifierNode(referenceNode);
       const importedUtilSpecifier = getImportedUtilSpecifier(

--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -5,6 +5,7 @@ import {
 } from '@typescript-eslint/experimental-utils';
 import {
   getAssertNodeInfo,
+  getDeepestIdentifierNode,
   getImportModuleName,
   getPropertyIdentifierNode,
   getReferenceNode,
@@ -69,6 +70,9 @@ type IsAsyncUtilFn = (
 ) => boolean;
 type IsFireEventMethodFn = (node: TSESTree.Identifier) => boolean;
 type IsRenderUtilFn = (node: TSESTree.Identifier) => boolean;
+type IsRenderVariableDeclaratorFn = (
+  node: TSESTree.VariableDeclarator
+) => boolean;
 type IsDebugUtilFn = (node: TSESTree.Identifier) => boolean;
 type IsPresenceAssertFn = (node: TSESTree.MemberExpression) => boolean;
 type IsAbsenceAssertFn = (node: TSESTree.MemberExpression) => boolean;
@@ -97,6 +101,7 @@ export interface DetectionHelpers {
   isAsyncUtil: IsAsyncUtilFn;
   isFireEventMethod: IsFireEventMethodFn;
   isRenderUtil: IsRenderUtilFn;
+  isRenderVariableDeclarator: IsRenderVariableDeclaratorFn;
   isDebugUtil: IsDebugUtilFn;
   isPresenceAssert: IsPresenceAssertFn;
   isAbsenceAssert: IsAbsenceAssertFn;
@@ -408,6 +413,12 @@ export function detectTestingLibraryUtils<
       );
     };
 
+    const isRenderVariableDeclarator: IsRenderVariableDeclaratorFn = (node) => {
+      const initIdentifierNode = getDeepestIdentifierNode(node.init);
+
+      return isRenderUtil(initIdentifierNode);
+    };
+
     const isDebugUtil: IsDebugUtilFn = (node) => {
       return isTestingLibraryUtil(
         node,
@@ -562,6 +573,7 @@ export function detectTestingLibraryUtils<
       isAsyncUtil,
       isFireEventMethod,
       isRenderUtil,
+      isRenderVariableDeclarator,
       isDebugUtil,
       isPresenceAssert,
       isAbsenceAssert,

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -477,31 +477,6 @@ export function isRenderFunction(
   });
 }
 
-// TODO: should be removed after v4 is finished
-export function isRenderVariableDeclarator(
-  node: TSESTree.VariableDeclarator,
-  renderFunctions: string[]
-): boolean {
-  if (node.init) {
-    if (ASTUtils.isAwaitExpression(node.init)) {
-      return (
-        node.init.argument &&
-        isRenderFunction(
-          node.init.argument as TSESTree.CallExpression,
-          renderFunctions
-        )
-      );
-    } else {
-      return (
-        isCallExpression(node.init) &&
-        isRenderFunction(node.init, renderFunctions)
-      );
-    }
-  }
-
-  return false;
-}
-
 // TODO: extract into types file?
 export type ImportModuleNode =
   | TSESTree.ImportDeclaration

--- a/lib/rules/no-container.ts
+++ b/lib/rules/no-container.ts
@@ -1,10 +1,5 @@
 import { ASTUtils, TSESTree } from '@typescript-eslint/experimental-utils';
-import {
-  getDeepestIdentifierNode,
-  isMemberExpression,
-  isObjectPattern,
-  isProperty,
-} from '../node-utils';
+import { isMemberExpression, isObjectPattern, isProperty } from '../node-utils';
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 
 export const RULE_NAME = 'no-container';
@@ -63,9 +58,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 
     return {
       VariableDeclarator(node) {
-        const initIdentifierNode = getDeepestIdentifierNode(node.init);
-
-        if (!helpers.isRenderUtil(initIdentifierNode)) {
+        if (!helpers.isRenderVariableDeclarator(node)) {
           return;
         }
 
@@ -76,8 +69,10 @@ export default createTestingLibraryRule<Options, MessageIds>({
               ASTUtils.isIdentifier(property.key) &&
               property.key.name === 'container'
           );
+
           const nodeValue =
             containerIndex !== -1 && node.id.properties[containerIndex].value;
+
           if (ASTUtils.isIdentifier(nodeValue)) {
             containerName = nodeValue.name;
           } else {

--- a/lib/rules/no-container.ts
+++ b/lib/rules/no-container.ts
@@ -36,18 +36,27 @@ export default createTestingLibraryRule<Options, MessageIds>({
       if (isMemberExpression(innerNode)) {
         if (ASTUtils.isIdentifier(innerNode.object)) {
           const isContainerName = innerNode.object.name === containerName;
-          const isRenderWrapper = innerNode.object.name === renderWrapperName;
 
+          if (isContainerName) {
+            context.report({
+              node: innerNode,
+              messageId: 'noContainer',
+            });
+            return;
+          }
+
+          const isRenderWrapper = innerNode.object.name === renderWrapperName;
           containerCallsMethod =
             ASTUtils.isIdentifier(innerNode.property) &&
             innerNode.property.name === 'container' &&
             isRenderWrapper;
 
-          if (isContainerName || containerCallsMethod) {
+          if (containerCallsMethod) {
             context.report({
-              node: innerNode,
+              node: innerNode.property,
               messageId: 'noContainer',
             });
+            return;
           }
         }
         showErrorIfChainedContainerMethod(

--- a/lib/rules/no-debug.ts
+++ b/lib/rules/no-debug.ts
@@ -44,9 +44,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 
     return {
       VariableDeclarator(node) {
-        const initIdentifierNode = getDeepestIdentifierNode(node.init);
-
-        if (!helpers.isRenderUtil(initIdentifierNode)) {
+        if (!helpers.isRenderVariableDeclarator(node)) {
           return;
         }
 

--- a/lib/rules/render-result-naming-convention.ts
+++ b/lib/rules/render-result-naming-convention.ts
@@ -59,7 +59,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
         }
 
         if (
-          !helpers.isRenderUtil(initIdentifierNode) &&
+          !helpers.isRenderVariableDeclarator(node) &&
           !renderWrapperNames.includes(initIdentifierNode.name)
         ) {
           return;

--- a/tests/lib/rules/no-container.test.ts
+++ b/tests/lib/rules/no-container.test.ts
@@ -116,15 +116,13 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     },
     {
+      settings: {
+        'testing-library/custom-renders': ['customRender', 'renderWithRedux'],
+      },
       code: `
         const { container } = renderWithRedux(<Example />);
         container.querySelector();
       `,
-      options: [
-        {
-          renderFunctions: ['renderWithRedux'],
-        },
-      ],
       errors: [
         {
           line: 3,

--- a/tests/lib/rules/no-container.test.ts
+++ b/tests/lib/rules/no-container.test.ts
@@ -48,6 +48,25 @@ ruleTester.run(RULE_NAME, rule, {
         expect(firstChild).toBeDefined();
       `,
     },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+        import { render as renamed } from '@testing-library/react'
+        import { render } from 'somewhere-else'
+        const { container } = render(<Example />);
+        const button = container.querySelector('.btn-primary');
+      `,
+    },
+    {
+      settings: {
+        'testing-library/custom-renders': ['customRender', 'renderWithRedux'],
+      },
+      code: `
+        import { otherRender } from 'somewhere-else'
+        const { container } = otherRender(<Example />);
+        const button = container.querySelector('.btn-primary');
+      `,
+    },
   ],
   invalid: [
     {
@@ -58,6 +77,54 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [
         {
           line: 3,
+          column: 24,
+          messageId: 'noContainer',
+        },
+      ],
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+        import { render } from 'test-utils'
+        const { container } = render(<Example />);
+        const button = container.querySelector('.btn-primary');
+      `,
+      errors: [
+        {
+          line: 4,
+          column: 24,
+          messageId: 'noContainer',
+        },
+      ],
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+        import { render as testingRender } from '@testing-library/react'
+        const { container: renamed } = testingRender(<Example />);
+        const button = renamed.querySelector('.btn-primary');
+      `,
+      errors: [
+        {
+          line: 4,
+          column: 24,
+          messageId: 'noContainer',
+        },
+      ],
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+        import { render } from '@testing-library/react'
+        
+        const setup = () => render(<Example />)
+
+        const { container } = setup()
+        const button = container.querySelector('.btn-primary');
+      `,
+      errors: [
+        {
+          line: 7,
           column: 24,
           messageId: 'noContainer',
         },
@@ -110,6 +177,21 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [
         {
           line: 3,
+          column: 9,
+          messageId: 'noContainer',
+        },
+      ],
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+        import { render } from '@testing-library/react'
+        const { container: { querySelector } } = render(<Example />);
+        querySelector('foo');
+      `,
+      errors: [
+        {
+          line: 4,
           column: 9,
           messageId: 'noContainer',
         },

--- a/tests/lib/rules/no-container.test.ts
+++ b/tests/lib/rules/no-container.test.ts
@@ -57,6 +57,8 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [
         {
+          line: 3,
+          column: 24,
           messageId: 'noContainer',
         },
       ],
@@ -68,6 +70,8 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [
         {
+          line: 3,
+          column: 9,
           messageId: 'noContainer',
         },
       ],
@@ -79,6 +83,8 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [
         {
+          line: 3,
+          column: 9,
           messageId: 'noContainer',
         },
       ],
@@ -90,6 +96,8 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [
         {
+          line: 3,
+          column: 24,
           messageId: 'noContainer',
         },
       ],
@@ -101,6 +109,8 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [
         {
+          line: 3,
+          column: 9,
           messageId: 'noContainer',
         },
       ],
@@ -117,6 +127,8 @@ ruleTester.run(RULE_NAME, rule, {
       ],
       errors: [
         {
+          line: 3,
+          column: 9,
           messageId: 'noContainer',
         },
       ],

--- a/tests/lib/rules/no-container.test.ts
+++ b/tests/lib/rules/no-container.test.ts
@@ -97,7 +97,7 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [
         {
           line: 3,
-          column: 24,
+          column: 29,
           messageId: 'noContainer',
         },
       ],

--- a/tests/lib/rules/no-debug.test.ts
+++ b/tests/lib/rules/no-debug.test.ts
@@ -213,6 +213,24 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+        import { render } from 'test-utils'
+
+        const setup = () => render(<Component/>)
+
+        const utils = setup()
+        utils.debug()
+      `,
+      errors: [
+        {
+          line: 7,
+          column: 15,
+          messageId: 'noDebug',
+        },
+      ],
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
       code: `// aggressive reporting disabled
         import { render } from 'test-utils'
         const utils = render(<Component/>)


### PR DESCRIPTION
Relates to #198

This refactor for `no-container` includes:

- using custom rule creator + detection helpers
- improve location of the node reported
- improve test coverage and errors assertions
- add ability to detect `container` usage coming from functions wrapping `render`
- `no-debug`: add ability to detect `debug` usage coming from functions wrapping `render`

Ideally, the ability to detect functions wrapping a _reportable_ `render` should be part of `isRenderUtil`, or extracted into some helper. However, I'm gonna replicate the same behavior I applied in this PR (and others previously) to detect wrappers around `render` for remaining rules. After v4 I'll spend more time trying to make that check generic.