### PR TITLE
refactor: remove mechanism to match files to be reported

### DIFF
--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -27,7 +27,6 @@ import {
 
 export type TestingLibrarySettings = {
   'testing-library/utils-module'?: string;
-  'testing-library/filename-pattern'?: string;
   'testing-library/custom-renders'?: string[];
 };
 
@@ -56,7 +55,6 @@ type GetCustomModuleImportNodeFn = () => ImportModuleNode | null;
 type GetTestingLibraryImportNameFn = () => string | undefined;
 type GetCustomModuleImportNameFn = () => string | undefined;
 type IsTestingLibraryImportedFn = () => boolean;
-type IsValidFilenameFn = () => boolean;
 type IsGetQueryVariantFn = (node: TSESTree.Identifier) => boolean;
 type IsQueryQueryVariantFn = (node: TSESTree.Identifier) => boolean;
 type IsFindQueryVariantFn = (node: TSESTree.Identifier) => boolean;
@@ -90,7 +88,6 @@ export interface DetectionHelpers {
   getTestingLibraryImportName: GetTestingLibraryImportNameFn;
   getCustomModuleImportName: GetCustomModuleImportNameFn;
   isTestingLibraryImported: IsTestingLibraryImportedFn;
-  isValidFilename: IsValidFilenameFn;
   isGetQueryVariant: IsGetQueryVariantFn;
   isQueryQueryVariant: IsQueryQueryVariantFn;
   isFindQueryVariant: IsFindQueryVariantFn;
@@ -109,8 +106,6 @@ export interface DetectionHelpers {
   findImportedUtilSpecifier: FindImportedUtilSpecifierFn;
   isNodeComingFromTestingLibrary: IsNodeComingFromTestingLibraryFn;
 }
-
-const DEFAULT_FILENAME_PATTERN = '^.*\\.(test|spec)\\.[jt]sx?$';
 
 const FIRE_EVENT_NAME = 'fireEvent';
 const RENDER_NAME = 'render';
@@ -132,9 +127,6 @@ export function detectTestingLibraryUtils<
 
     // Init options based on shared ESLint settings
     const customModule = context.settings['testing-library/utils-module'];
-    const filenamePattern =
-      context.settings['testing-library/filename-pattern'] ??
-      DEFAULT_FILENAME_PATTERN;
     const customRenders = context.settings['testing-library/custom-renders'];
 
     /**
@@ -241,15 +233,6 @@ export function detectTestingLibraryUtils<
         !!importedTestingLibraryNode ||
         !!importedCustomModuleNode
       );
-    };
-
-    /**
-     * Determines whether filename is valid or not for current file
-     * being analyzed based on "testing-library/filename-pattern" setting.
-     */
-    const isValidFilename: IsValidFilenameFn = () => {
-      const fileName = context.getFilename();
-      return !!fileName.match(filenamePattern);
     };
 
     /**
@@ -536,7 +519,7 @@ export function detectTestingLibraryUtils<
      * Determines if file inspected meets all conditions to be reported by rules or not.
      */
     const canReportErrors: CanReportErrorsFn = () => {
-      return isTestingLibraryImported() && isValidFilename();
+      return isTestingLibraryImported();
     };
 
     /**
@@ -566,7 +549,6 @@ export function detectTestingLibraryUtils<
       getTestingLibraryImportName,
       getCustomModuleImportName,
       isTestingLibraryImported,
-      isValidFilename,
       isGetQueryVariant,
       isQueryQueryVariant,
       isFindQueryVariant,

--- a/tests/create-testing-library-rule.test.ts
+++ b/tests/create-testing-library-rule.test.ts
@@ -5,7 +5,7 @@ const ruleTester = createRuleTester();
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
-    // Test Cases for Imports & Filename
+    // Test Cases for Imports
     {
       code: `
       // case: nothing related to Testing Library at all
@@ -66,25 +66,6 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-      // case: import module forced to be reported but not matching settings filename
-      import { foo } from 'report-me'
-    `,
-      settings: {
-        'testing-library/filename-pattern': 'testing-library\\.js',
-      },
-    },
-    {
-      code: `
-      // case: import module forced to be reported but not matching settings filename
-      // (require version)
-      const { foo } = require('report-me')
-    `,
-      settings: {
-        'testing-library/filename-pattern': 'testing-library\\.js',
-      },
-    },
-    {
-      code: `
       // case: import custom module forced to be reported without custom module setting
       import { foo } from 'custom-module-forced-report'
     `,
@@ -113,15 +94,6 @@ ruleTester.run(RULE_NAME, rule, {
       code: `
       // case: aggressive render enabled, but module disabled - not coming from TL
       import { render } from 'somewhere-else'
-      
-      const utils = render()
-      `,
-    },
-    {
-      filename: 'file.not.matching.js',
-      code: `
-      // case: aggressive render and module enabled, but file name not matching
-      import { render } from '@testing-library/react'
       
       const utils = render()
       `,
@@ -250,33 +222,6 @@ ruleTester.run(RULE_NAME, rule, {
       within(container).findByRole('button')
     `,
     },
-    {
-      settings: {
-        'testing-library/filename-pattern': 'testing-library\\.js',
-      },
-      code: `
-      // case: built-in "getBy*" query not reported because custom filename doesn't match
-      getByRole('button')
-    `,
-    },
-    {
-      settings: {
-        'testing-library/filename-pattern': 'testing-library\\.js',
-      },
-      code: `
-      // case: built-in "queryBy*" query not reported because custom filename doesn't match
-      queryByRole('button')
-    `,
-    },
-    {
-      settings: {
-        'testing-library/filename-pattern': 'testing-library\\.js',
-      },
-      code: `
-      // case: built-in "findBy*" query not reported because custom filename doesn't match
-      findByRole('button')
-    `,
-    },
 
     // Test Cases for async utils
     {
@@ -289,15 +234,6 @@ ruleTester.run(RULE_NAME, rule, {
           'aggressive reporting disabled - util waitFor not related to testing library is valid',
           () => { waitFor() }
         );
-      `,
-    },
-    {
-      filename: 'file.not.matching.js',
-      code: `
-      // case: waitFor util found, but file name not matching
-      import { waitFor } from '@testing-library/react'
-      
-      waitFor()
       `,
     },
     {
@@ -320,25 +256,9 @@ ruleTester.run(RULE_NAME, rule, {
     {
       settings: {
         'testing-library/utils-module': 'test-utils',
-        'testing-library/filename-pattern': 'testing-library\\.js',
       },
       code: `
-      // case: matching custom settings partially - module but not filename
-      import { render } from 'test-utils'
-      import { somethingElse } from 'another-module'
-      const foo = require('bar')
-      
-      const utils = render();
-      `,
-    },
-    {
-      settings: {
-        'testing-library/utils-module': 'test-utils',
-        'testing-library/filename-pattern': 'testing-library\\.js',
-      },
-      filename: 'MyComponent.testing-library.js',
-      code: `
-      // case: matching custom settings partially - filename but not module
+      // case: matching custom settings
       import { render } from 'other-utils'
       import { somethingElse } from 'another-module'
       const foo = require('bar')
@@ -359,31 +279,12 @@ ruleTester.run(RULE_NAME, rule, {
     },
   ],
   invalid: [
-    // Test Cases for Imports & Filename
+    // Test Cases for Imports
     {
       code: `
       // case: import module forced to be reported
       import { foo } from 'report-me'
     `,
-      errors: [{ line: 3, column: 7, messageId: 'fakeError' }],
-    },
-    {
-      filename: 'MyComponent.spec.js',
-      code: `
-      // case: import module forced to be reported but from .spec.js named file
-      import { foo } from 'report-me'
-    `,
-      errors: [{ line: 3, column: 7, messageId: 'fakeError' }],
-    },
-    {
-      filename: 'MyComponent.testing-library.js',
-      code: `
-      // case: import module forced to be reported with custom file name
-      import { foo } from 'report-me'
-    `,
-      settings: {
-        'testing-library/filename-pattern': 'testing-library\\.js',
-      },
       errors: [{ line: 3, column: 7, messageId: 'fakeError' }],
     },
     {
@@ -733,22 +634,6 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [{ line: 3, column: 25, messageId: 'findByError' }],
     },
     {
-      filename: 'MyComponent.spec.js',
-      code: `
-      // case: custom "getBy*" query reported without import (aggressive reporting)
-      getByIcon('search')
-    `,
-      errors: [{ line: 3, column: 7, messageId: 'customQueryError' }],
-    },
-    {
-      filename: 'MyComponent.spec.js',
-      code: `
-      // case: custom "getBy*" query reported without import using within (aggressive reporting)
-      within(container).getByIcon('search')
-    `,
-      errors: [{ line: 3, column: 25, messageId: 'customQueryError' }],
-    },
-    {
       code: `
       // case: custom "queryBy*" query reported without import (aggressive reporting)
       queryByIcon('search')
@@ -788,30 +673,6 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [{ line: 4, column: 7, messageId: 'getByError' }],
     },
     {
-      filename: 'MyComponent.spec.js',
-      settings: {
-        'testing-library/utils-module': 'test-utils',
-      },
-      code: `
-      // case: built-in "queryBy*" query reported with custom module + Testing Library package import
-      import { render } from '@testing-library/react'
-      queryByRole('button')
-    `,
-      errors: [{ line: 4, column: 7, messageId: 'queryByError' }],
-    },
-    {
-      filename: 'MyComponent.spec.js',
-      settings: {
-        'testing-library/utils-module': 'test-utils',
-      },
-      code: `
-      // case: built-in "findBy*" query reported with custom module + Testing Library package import
-      import { render } from '@testing-library/react'
-      findByRole('button')
-    `,
-      errors: [{ line: 4, column: 7, messageId: 'findByError' }],
-    },
-    {
       settings: {
         'testing-library/utils-module': 'test-utils',
       },
@@ -821,30 +682,6 @@ ruleTester.run(RULE_NAME, rule, {
       getByRole('button')
     `,
       errors: [{ line: 4, column: 7, messageId: 'getByError' }],
-    },
-    {
-      filename: 'MyComponent.spec.js',
-      settings: {
-        'testing-library/utils-module': 'test-utils',
-      },
-      code: `
-      // case: built-in "queryBy*" query reported with custom module + custom module import
-      import { render } from 'test-utils'
-      queryByRole('button')
-    `,
-      errors: [{ line: 4, column: 7, messageId: 'queryByError' }],
-    },
-    {
-      filename: 'MyComponent.spec.js',
-      settings: {
-        'testing-library/utils-module': 'test-utils',
-      },
-      code: `
-      // case: built-in "queryBy*" query reported with custom module + custom module import
-      import { render } from 'test-utils'
-      findByRole('button')
-    `,
-      errors: [{ line: 4, column: 7, messageId: 'findByError' }],
     },
 
     {
@@ -859,30 +696,6 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [{ line: 4, column: 7, messageId: 'customQueryError' }],
     },
     {
-      filename: 'MyComponent.spec.js',
-      settings: {
-        'testing-library/utils-module': 'test-utils',
-      },
-      code: `
-      // case: custom "queryBy*" query reported with custom module + Testing Library package import
-      import { render } from '@testing-library/framework'
-      queryByIcon('search')
-    `,
-      errors: [{ line: 4, column: 7, messageId: 'customQueryError' }],
-    },
-    {
-      filename: 'MyComponent.spec.js',
-      settings: {
-        'testing-library/utils-module': 'test-utils',
-      },
-      code: `
-      // case: custom "findBy*" query reported with custom module + Testing Library package import
-      import { render } from '@testing-library/framework'
-      findByIcon('search')
-    `,
-      errors: [{ line: 4, column: 7, messageId: 'customQueryError' }],
-    },
-    {
       settings: {
         'testing-library/utils-module': 'test-utils',
       },
@@ -893,41 +706,15 @@ ruleTester.run(RULE_NAME, rule, {
     `,
       errors: [{ line: 4, column: 7, messageId: 'customQueryError' }],
     },
-    {
-      filename: 'MyComponent.spec.js',
-      settings: {
-        'testing-library/utils-module': 'test-utils',
-      },
-      code: `
-      // case: custom "queryBy*" query reported with custom module + custom module import
-      import { render } from 'test-utils'
-      queryByIcon('search')
-    `,
-      errors: [{ line: 4, column: 7, messageId: 'customQueryError' }],
-    },
-    {
-      filename: 'MyComponent.spec.js',
-      settings: {
-        'testing-library/utils-module': 'test-utils',
-      },
-      code: `
-      // case: custom "findBy*" query reported with custom module + custom module import
-      import { render } from 'test-utils'
-      findByIcon('search')
-    `,
-      errors: [{ line: 4, column: 7, messageId: 'customQueryError' }],
-    },
 
     // Test Cases for all settings mixed
     {
-      filename: 'MyComponent.custom-suffix.js',
       settings: {
         'testing-library/custom-renders': ['customRender', 'renderWithRedux'],
         'testing-library/utils-module': 'test-utils',
-        'testing-library/filename-pattern': 'custom-suffix\\.js',
       },
       code: `
-      // case: all aggressive reporting disabled and filename setup - matching all custom settings
+      // case: aggressive reporting disabled - matching all custom settings
       import { renderWithRedux, waitFor, screen } from 'test-utils'
       
       const { getByRole } = renderWithRedux()
@@ -948,9 +735,7 @@ ruleTester.run(RULE_NAME, rule, {
     {
       settings: {
         'testing-library/utils-module': 'test-utils',
-        'testing-library/filename-pattern': 'testing-library\\.js',
       },
-      filename: 'MyComponent.testing-library.js',
       code: `
       // case: matching all custom settings
       import { render } from 'test-utils'

--- a/tests/lib/rules/no-await-sync-query.test.ts
+++ b/tests/lib/rules/no-await-sync-query.test.ts
@@ -67,15 +67,6 @@ ruleTester.run(RULE_NAME, rule, {
       }
       `,
     },
-    // sync query awaited but not matching filename pattern is invalid but not reported
-    {
-      settings: { 'testing-library/filename-pattern': 'nope\\.js' },
-      code: `
-      () => {
-        const element = await getByRole('button')
-      }
-      `,
-    },
 
     // https://github.com/testing-library/eslint-plugin-testing-library/issues/276
     `

--- a/tests/lib/rules/no-dom-import.test.ts
+++ b/tests/lib/rules/no-dom-import.test.ts
@@ -25,38 +25,6 @@ ruleTester.run(RULE_NAME, rule, {
       code: 'import { fireEvent } from "test-utils"',
       settings: { 'testing-library/utils-module': 'test-utils' },
     },
-    {
-      code: 'import { fireEvent } from "dom-testing-library"',
-      filename: 'filename.not-matching.js',
-    },
-    {
-      code: 'import { fireEvent } from "dom-testing-library"',
-      settings: { 'testing-library/filename-pattern': 'nope\\.js' },
-    },
-    {
-      code: 'const { fireEvent } = require("dom-testing-library")',
-      filename: 'filename.not-matching.js',
-    },
-    {
-      code: 'const { fireEvent } = require("dom-testing-library")',
-      settings: { 'testing-library/filename-pattern': 'nope\\.js' },
-    },
-    {
-      code: 'import { fireEvent } from "@testing-library/dom"',
-      filename: 'filename.not-matching.js',
-    },
-    {
-      code: 'import { fireEvent } from "@testing-library/dom"',
-      settings: { 'testing-library/filename-pattern': 'nope\\.js' },
-    },
-    {
-      code: 'const { fireEvent } = require("@testing-library/dom")',
-      filename: 'filename.not-matching.js',
-    },
-    {
-      code: 'const { fireEvent } = require("@testing-library/dom")',
-      settings: { 'testing-library/filename-pattern': 'nope\\.js' },
-    },
   ],
   invalid: [
     {

--- a/tests/lib/rules/no-manual-cleanup.test.ts
+++ b/tests/lib/rules/no-manual-cleanup.test.ts
@@ -54,14 +54,6 @@ ruleTester.run(RULE_NAME, rule, {
     {
       code: `const utils = require(moduleName)`,
     },
-    {
-      settings: {
-        'testing-library/filename-pattern': 'testing-library\\.js',
-      },
-      code: `
-      import { render, cleanup } from "${ALL_TESTING_LIBRARIES_WITH_CLEANUP[0]}"
-      `,
-    },
   ],
   invalid: [
     ...ALL_TESTING_LIBRARIES_WITH_CLEANUP.map((lib) => ({

--- a/tests/lib/rules/no-node-access.test.ts
+++ b/tests/lib/rules/no-node-access.test.ts
@@ -49,16 +49,6 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        const Component = props => {
-          return <div>{props.children}</div>
-        }
-      `,
-      settings: {
-        'testing-library/filename-pattern': 'testing-library\\.js',
-      },
-    },
-    {
-      code: `
       // case: importing custom module
       const closestButton = document.getElementById('submit-btn').closest('button');
       expect(closestButton).toBeInTheDocument();


### PR DESCRIPTION
Relates to #198 

Remove everything related to mechanism for matching files to be reported, as discussed in #296 

@MichaelDeBoey adding you here in case you want to double-check it too!