### PR TITLE
Move rules settings to ESLint shared config: refactor no-render-in-setup rule

### DIFF
--- a/docs/rules/no-render-in-setup.md
+++ b/docs/rules/no-render-in-setup.md
@@ -21,6 +21,22 @@ it('Should have bar', () => {
 ```
 
 ```js
+const setup = () => render(<MyComponent />);
+
+beforeEach(() => {
+  setup();
+});
+
+it('Should have foo', () => {
+  expect(screen.getByText('foo')).toBeInTheDocument();
+});
+
+it('Should have bar', () => {
+  expect(screen.getByText('bar')).toBeInTheDocument();
+});
+```
+
+```js
 beforeAll(() => {
   render(<MyComponent />);
 });
@@ -44,10 +60,18 @@ it('Should have foo and bar', () => {
 });
 ```
 
-If you use [custom render functions](https://testing-library.com/docs/example-react-redux) then you can set a config option in your `.eslintrc` to look for these.
+```js
+const setup = () => render(<MyComponent />);
 
-```
-   "testing-library/no-render-in-setup": ["error", {"renderFunctions": ["renderWithRedux", "renderWithRouter"]}],
+beforeEach(() => {
+  // other stuff...
+});
+
+it('Should have foo and bar', () => {
+  setup();
+  expect(screen.getByText('foo')).toBeInTheDocument();
+  expect(screen.getByText('bar')).toBeInTheDocument();
+});
 ```
 
 If you would like to allow the use of `render` (or a custom render function) in _either_ `beforeAll` or `beforeEach`, this can be configured using the option `allowTestingFrameworkSetupHook`. This may be useful if you have configured your tests to [skip auto cleanup](https://testing-library.com/docs/react-testing-library/setup#skipping-auto-cleanup). `allowTestingFrameworkSetupHook` is an enum that accepts either `"beforeAll"` or `"beforeEach"`.

--- a/docs/rules/no-render-in-setup.md
+++ b/docs/rules/no-render-in-setup.md
@@ -2,7 +2,7 @@
 
 ## Rule Details
 
-This rule disallows the usage of `render` (or a custom render function) in setup functions (`beforeEach` and `beforeAll`) in favor of moving `render` closer to test assertions.
+This rule disallows the usage of `render` (or a custom render function) in testing framework setup functions (`beforeEach` and `beforeAll`) in favor of moving `render` closer to test assertions.
 
 Examples of **incorrect** code for this rule:
 

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -321,7 +321,7 @@ interface InnermostFunctionScope extends TSESLintScope.FunctionScope {
 }
 
 export function getInnermostFunctionScope(
-  context: RuleContext<string, []>,
+  context: RuleContext<string, unknown[]>,
   asyncQueryNode: TSESTree.Identifier
 ): InnermostFunctionScope | null {
   const innermostScope = ASTUtils.getInnermostScope(
@@ -568,7 +568,7 @@ export function hasClosestExpectResolvesRejects(node: TSESTree.Node): boolean {
  * Gets the Function node which returns the given Identifier.
  */
 export function getInnermostReturningFunction(
-  context: RuleContext<string, []>,
+  context: RuleContext<string, unknown[]>,
   node: TSESTree.Identifier
 ):
   | TSESTree.FunctionDeclaration

--- a/lib/node-utils.ts
+++ b/lib/node-utils.ts
@@ -459,24 +459,6 @@ export function getFunctionName(
   );
 }
 
-// TODO: should be removed after v4 is finished
-export function isRenderFunction(
-  callNode: TSESTree.CallExpression,
-  renderFunctions: string[]
-): boolean {
-  // returns true for `render` and e.g. `customRenderFn`
-  // as well as `someLib.render` and `someUtils.customRenderFn`
-  return renderFunctions.some((name) => {
-    return (
-      (ASTUtils.isIdentifier(callNode.callee) &&
-        name === callNode.callee.name) ||
-      (isMemberExpression(callNode.callee) &&
-        ASTUtils.isIdentifier(callNode.callee.property) &&
-        name === callNode.callee.property.name)
-    );
-  });
-}
-
 // TODO: extract into types file?
 export type ImportModuleNode =
   | TSESTree.ImportDeclaration

--- a/lib/rules/no-debug.ts
+++ b/lib/rules/no-debug.ts
@@ -27,16 +27,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
       noDebug: 'Unexpected debug statement',
     },
     fixable: null,
-    schema: [
-      {
-        type: 'object',
-        properties: {
-          renderFunctions: {
-            type: 'array',
-          },
-        },
-      },
-    ],
+    schema: [],
   },
   defaultOptions: [],
 

--- a/lib/rules/no-render-in-setup.ts
+++ b/lib/rules/no-render-in-setup.ts
@@ -1,17 +1,14 @@
+import { ASTUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { TESTING_FRAMEWORK_SETUP_HOOKS } from '../utils';
 import {
-  ESLintUtils,
-  TSESTree,
-  ASTUtils,
-} from '@typescript-eslint/experimental-utils';
-import { getDocsUrl, TESTING_FRAMEWORK_SETUP_HOOKS } from '../utils';
-import {
-  isLiteral,
-  isProperty,
-  isObjectPattern,
   isCallExpression,
-  isRenderFunction,
   isImportSpecifier,
+  isLiteral,
+  isObjectPattern,
+  isProperty,
+  isRenderFunction,
 } from '../node-utils';
+import { createTestingLibraryRule } from '../create-testing-library-rule';
 
 export const RULE_NAME = 'no-render-in-setup';
 export type MessageIds = 'noRenderInSetup';
@@ -41,12 +38,13 @@ export function findClosestBeforeHook(
   return findClosestBeforeHook(node.parent, testingFrameworkSetupHooksToFilter);
 }
 
-export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
+export default createTestingLibraryRule<Options, MessageIds>({
   name: RULE_NAME,
   meta: {
     type: 'problem',
     docs: {
-      description: 'Disallow the use of `render` in setup functions',
+      description:
+        'Disallow the use of `render` in testing frameworks setup functions',
       category: 'Best Practices',
       recommended: false,
     },

--- a/lib/rules/no-render-in-setup.ts
+++ b/lib/rules/no-render-in-setup.ts
@@ -48,7 +48,6 @@ export default createTestingLibraryRule<Options, MessageIds>({
     schema: [
       {
         type: 'object',
-        default: {},
         properties: {
           allowTestingFrameworkSetupHook: {
             enum: TESTING_FRAMEWORK_SETUP_HOOKS,
@@ -66,12 +65,9 @@ export default createTestingLibraryRule<Options, MessageIds>({
   create(context, [{ allowTestingFrameworkSetupHook }], helpers) {
     return {
       CallExpression(node) {
-        let testingFrameworkSetupHooksToFilter = TESTING_FRAMEWORK_SETUP_HOOKS;
-        if (allowTestingFrameworkSetupHook.length !== 0) {
-          testingFrameworkSetupHooksToFilter = TESTING_FRAMEWORK_SETUP_HOOKS.filter(
-            (hook) => hook !== allowTestingFrameworkSetupHook
-          );
-        }
+        const testingFrameworkSetupHooksToFilter = TESTING_FRAMEWORK_SETUP_HOOKS.filter(
+          (hook) => hook !== allowTestingFrameworkSetupHook
+        );
         const callExpressionIdentifier = getDeepestIdentifierNode(node);
 
         if (!helpers.isRenderUtil(callExpressionIdentifier)) {
@@ -88,7 +84,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
         }
 
         context.report({
-          node,
+          node: callExpressionIdentifier,
           messageId: 'noRenderInSetup',
           data: {
             name: beforeHook.name,

--- a/lib/rules/no-render-in-setup.ts
+++ b/lib/rules/no-render-in-setup.ts
@@ -7,7 +7,6 @@ import {
   isCallExpression,
 } from '../node-utils';
 import { createTestingLibraryRule } from '../create-testing-library-rule';
-import { RuleContext } from '@typescript-eslint/experimental-utils/dist/ts-eslint';
 
 export const RULE_NAME = 'no-render-in-setup';
 export type MessageIds = 'noRenderInSetup';
@@ -72,10 +71,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
     const renderWrapperNames: string[] = [];
 
     function detectRenderWrapper(node: TSESTree.Identifier): void {
-      const innerFunction = getInnermostReturningFunction(
-        (context as unknown) as RuleContext<string, []>,
-        node
-      );
+      const innerFunction = getInnermostReturningFunction(context, node);
 
       if (innerFunction) {
         renderWrapperNames.push(getFunctionName(innerFunction));

--- a/lib/rules/no-render-in-setup.ts
+++ b/lib/rules/no-render-in-setup.ts
@@ -50,7 +50,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
     },
     messages: {
       noRenderInSetup:
-        'Move `render` out of `{{name}}` and into individual tests.',
+        'Forbidden usage of `render` within testing framework `{{ name }}` setup',
     },
     fixable: null,
     schema: [

--- a/lib/rules/render-result-naming-convention.ts
+++ b/lib/rules/render-result-naming-convention.ts
@@ -46,9 +46,10 @@ export default createTestingLibraryRule<Options, MessageIds>({
     }
 
     return {
-      'CallExpression Identifier'(node: TSESTree.Identifier) {
-        if (helpers.isRenderUtil(node)) {
-          detectRenderWrapper(node);
+      CallExpression(node) {
+        const callExpressionIdentifier = getDeepestIdentifierNode(node);
+        if (helpers.isRenderUtil(callExpressionIdentifier)) {
+          detectRenderWrapper(callExpressionIdentifier);
         }
       },
       VariableDeclarator(node) {

--- a/tests/lib/rules/no-render-in-setup.test.ts
+++ b/tests/lib/rules/no-render-in-setup.test.ts
@@ -9,6 +9,15 @@ ruleTester.run(RULE_NAME, rule, {
     {
       code: `
         import { render } from '@testing-library/foo';
+        
+        beforeAll(() => {
+          doOtherStuff();
+        });
+
+        beforeEach(() => {
+          doSomethingElse();
+        });
+        
         it('Test', () => {
           render(<Component/>)
         })
@@ -120,17 +129,18 @@ ruleTester.run(RULE_NAME, rule, {
     ...TESTING_FRAMEWORK_SETUP_HOOKS.map((setupHook) => ({
       settings: {
         'testing-library/utils-module': 'test-utils',
-        'testing-library/custom-renders': ['customRender', 'renderWithRedux'],
+        'testing-library/custom-renders': ['show', 'renderWithRedux'],
       },
       code: `
-        import { renderWithRedux } from '../test-utils';
+        import { show } from '../test-utils';
+  
         ${setupHook}(() => {
-          renderWithRedux(<Component/>)
+          show(<Component/>)
         })
       `,
       errors: [
         {
-          line: 4,
+          line: 5,
           column: 11,
           messageId: 'noRenderInSetup',
         },

--- a/tests/lib/rules/no-render-in-setup.test.ts
+++ b/tests/lib/rules/no-render-in-setup.test.ts
@@ -136,24 +136,20 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     })),
-    // call render within a wrapper function
-    // TODO: update this test so:
-    //  - the wrapper is outside the hook
-    //  - the error is located in `wrapper()` call
     ...TESTING_FRAMEWORK_SETUP_HOOKS.map((setupHook) => ({
-      code: `
+      code: `// call render within a wrapper function
       import { render } from '@testing-library/foo';
-        ${setupHook}(() => {
-          const wrapper = () => {
-            render(<Component/>)
-          }
-          wrapper()
-        })
+
+      const wrapper = () => render(<Component/>)
+
+      ${setupHook}(() => {
+        wrapper()
+      })
       `,
       errors: [
         {
-          line: 5,
-          column: 13,
+          line: 7,
+          column: 9,
           messageId: 'noRenderInSetup',
         },
       ],

--- a/tests/lib/rules/no-render-in-setup.test.ts
+++ b/tests/lib/rules/no-render-in-setup.test.ts
@@ -15,22 +15,26 @@ ruleTester.run(RULE_NAME, rule, {
       `,
     },
     // test config options
-    ...TESTING_FRAMEWORK_SETUP_HOOKS.map((setupHook) => ({
+    {
       code: `
-        import { renderWithRedux } from '../test-utils';
-        ${setupHook}(() => {
-          renderWithRedux(<Component/>)
-        })
-      `,
-      options: [
-        {
-          allowTestingFrameworkSetupHook: setupHook,
-          renderFunctions: ['renderWithRedux'],
-        },
-      ],
-    })),
-    // test usage of a non-Testing Library render fn
+      import { render } from '@testing-library/foo';
+      beforeAll(() => {
+        render(<Component />);
+      });
+    `,
+      options: [{ allowTestingFrameworkSetupHook: 'beforeAll' }],
+    },
+    {
+      code: `
+      import { render } from '@testing-library/foo';
+      beforeEach(() => {
+        render(<Component />);
+      });
+    `,
+      options: [{ allowTestingFrameworkSetupHook: 'beforeEach' }],
+    },
     ...TESTING_FRAMEWORK_SETUP_HOOKS.map((setupHook) => ({
+      settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
         import { render } from 'imNoTestingLibrary';
         ${setupHook}(() => {
@@ -43,11 +47,15 @@ ruleTester.run(RULE_NAME, rule, {
         (setupHook) => setupHook !== allowedSetupHook
       );
       return {
+        settings: {
+          'testing-library/utils-module': 'test-utils',
+          'testing-library/custom-renders': ['show', 'renderWithRedux'],
+        },
         code: `
           import utils from 'imNoTestingLibrary';
-          import { renderWithRedux } from '../test-utils';
+          import { show } from '../test-utils';
           ${allowedSetupHook}(() => {
-            renderWithRedux(<Component/>)
+            show(<Component/>)
           })
           ${disallowedHook}(() => {
             utils.render(<Component/>)
@@ -56,12 +64,12 @@ ruleTester.run(RULE_NAME, rule, {
         options: [
           {
             allowTestingFrameworkSetupHook: allowedSetupHook,
-            renderFunctions: ['renderWithRedux'],
           },
         ],
       };
     }),
     ...TESTING_FRAMEWORK_SETUP_HOOKS.map((setupHook) => ({
+      settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
         const { render } = require('imNoTestingLibrary')
 
@@ -110,17 +118,16 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     // custom render function
     ...TESTING_FRAMEWORK_SETUP_HOOKS.map((setupHook) => ({
+      settings: {
+        'testing-library/utils-module': 'test-utils',
+        'testing-library/custom-renders': ['customRender', 'renderWithRedux'],
+      },
       code: `
         import { renderWithRedux } from '../test-utils';
         ${setupHook}(() => {
           renderWithRedux(<Component/>)
         })
       `,
-      options: [
-        {
-          renderFunctions: ['renderWithRedux'],
-        },
-      ],
       errors: [
         {
           line: 4,
@@ -192,6 +199,7 @@ ruleTester.run(RULE_NAME, rule, {
       ],
     })),
     ...TESTING_FRAMEWORK_SETUP_HOOKS.map((setupHook) => ({
+      settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
         import { render } from 'imNoTestingLibrary';
         import * as testUtils from '../test-utils';
@@ -202,11 +210,6 @@ ruleTester.run(RULE_NAME, rule, {
           render(<Component/>)
         })
       `,
-      options: [
-        {
-          renderFunctions: ['renderWithRedux'],
-        },
-      ],
       errors: [
         {
           line: 5,

--- a/tests/lib/rules/no-render-in-setup.test.ts
+++ b/tests/lib/rules/no-render-in-setup.test.ts
@@ -193,7 +193,7 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [
         {
           line: 4,
-          column: 11,
+          column: 26,
           messageId: 'noRenderInSetup',
         },
       ],
@@ -213,7 +213,7 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [
         {
           line: 5,
-          column: 11,
+          column: 21,
           messageId: 'noRenderInSetup',
         },
       ],

--- a/tests/lib/rules/no-render-in-setup.test.ts
+++ b/tests/lib/rules/no-render-in-setup.test.ts
@@ -87,6 +87,8 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [
         {
+          line: 4,
+          column: 11,
           messageId: 'noRenderInSetup',
         },
       ],
@@ -100,6 +102,8 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [
         {
+          line: 4,
+          column: 11,
           messageId: 'noRenderInSetup',
         },
       ],
@@ -119,11 +123,16 @@ ruleTester.run(RULE_NAME, rule, {
       ],
       errors: [
         {
+          line: 4,
+          column: 11,
           messageId: 'noRenderInSetup',
         },
       ],
     })),
     // call render within a wrapper function
+    // TODO: update this test so:
+    //  - the wrapper is outside the hook
+    //  - the error is located in `wrapper()` call
     ...TESTING_FRAMEWORK_SETUP_HOOKS.map((setupHook) => ({
       code: `
       import { render } from '@testing-library/foo';
@@ -136,6 +145,8 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [
         {
+          line: 5,
+          column: 13,
           messageId: 'noRenderInSetup',
         },
       ],
@@ -158,6 +169,8 @@ ruleTester.run(RULE_NAME, rule, {
         ],
         errors: [
           {
+            line: 4,
+            column: 13,
             messageId: 'noRenderInSetup',
           },
         ],
@@ -172,6 +185,8 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [
         {
+          line: 4,
+          column: 11,
           messageId: 'noRenderInSetup',
         },
       ],
@@ -194,6 +209,8 @@ ruleTester.run(RULE_NAME, rule, {
       ],
       errors: [
         {
+          line: 5,
+          column: 11,
           messageId: 'noRenderInSetup',
         },
       ],
@@ -208,6 +225,8 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [
         {
+          line: 5,
+          column: 11,
           messageId: 'noRenderInSetup',
         },
       ],


### PR DESCRIPTION
Relates to #198 

This refactor for `no-render-in-setup` includes:
- using custom rule creator + detection helpers
- updating rule doc and error message
- improving location of the node reported
- improving test coverage and errors assertions
- removing unused old AST util
- small fixes in other rules