### PR TITLE
refactor(node-utils): extract `isNodeOfType` functions

### DIFF
--- a/lib/node-utils/index.ts
+++ b/lib/node-utils/index.ts
@@ -7,6 +7,20 @@ import {
 } from '@typescript-eslint/experimental-utils';
 import { RuleContext } from '@typescript-eslint/experimental-utils/dist/ts-eslint';
 
+import {
+  isArrayExpression,
+  isArrowFunctionExpression,
+  isBlockStatement,
+  isCallExpression,
+  isExpressionStatement,
+  isImportDeclaration,
+  isLiteral,
+  isMemberExpression,
+  isReturnStatement,
+} from './is-node-of-type';
+
+export * from './is-node-of-type';
+
 const ValidLeftHandSideExpressions = [
   AST_NODE_TYPES.CallExpression,
   AST_NODE_TYPES.ClassExpression,
@@ -34,78 +48,6 @@ const ValidLeftHandSideExpressions = [
   AST_NODE_TYPES.TSAsExpression,
   AST_NODE_TYPES.ArrowFunctionExpression,
 ];
-
-export function isCallExpression(
-  node: TSESTree.Node | null | undefined
-): node is TSESTree.CallExpression {
-  return node?.type === AST_NODE_TYPES.CallExpression;
-}
-
-export function isNewExpression(
-  node: TSESTree.Node | null | undefined
-): node is TSESTree.NewExpression {
-  return node?.type === 'NewExpression';
-}
-
-export function isMemberExpression(
-  node: TSESTree.Node | null | undefined
-): node is TSESTree.MemberExpression {
-  return node?.type === AST_NODE_TYPES.MemberExpression;
-}
-
-export function isLiteral(
-  node: TSESTree.Node | null | undefined
-): node is TSESTree.Literal {
-  return node?.type === AST_NODE_TYPES.Literal;
-}
-
-export function isImportSpecifier(
-  node: TSESTree.Node | null | undefined
-): node is TSESTree.ImportSpecifier {
-  return node?.type === AST_NODE_TYPES.ImportSpecifier;
-}
-
-export function isImportNamespaceSpecifier(
-  node: TSESTree.Node | null | undefined
-): node is TSESTree.ImportNamespaceSpecifier {
-  return node?.type === AST_NODE_TYPES.ImportNamespaceSpecifier;
-}
-
-export function isImportDefaultSpecifier(
-  node: TSESTree.Node | null | undefined
-): node is TSESTree.ImportDefaultSpecifier {
-  return node?.type === AST_NODE_TYPES.ImportDefaultSpecifier;
-}
-
-export function isBlockStatement(
-  node: TSESTree.Node | null | undefined
-): node is TSESTree.BlockStatement {
-  return node?.type === AST_NODE_TYPES.BlockStatement;
-}
-
-export function isObjectPattern(
-  node: TSESTree.Node | null | undefined
-): node is TSESTree.ObjectPattern {
-  return node?.type === AST_NODE_TYPES.ObjectPattern;
-}
-
-export function isProperty(
-  node: TSESTree.Node | null | undefined
-): node is TSESTree.Property {
-  return node?.type === AST_NODE_TYPES.Property;
-}
-
-export function isJSXAttribute(
-  node: TSESTree.Node | null | undefined
-): node is TSESTree.JSXAttribute {
-  return node?.type === AST_NODE_TYPES.JSXAttribute;
-}
-
-export function isExpressionStatement(
-  node: TSESTree.Node | null | undefined
-): node is TSESTree.ExpressionStatement {
-  return node?.type === AST_NODE_TYPES.ExpressionStatement;
-}
 
 /**
  * Finds the closest CallExpression node for a given node.
@@ -153,42 +95,12 @@ export function findClosestCallNode(
   }
 }
 
-export function isObjectExpression(
-  node: TSESTree.Expression
-): node is TSESTree.ObjectExpression {
-  return node?.type === AST_NODE_TYPES.ObjectExpression;
-}
-
 export function hasThenProperty(node: TSESTree.Node): boolean {
   return (
     isMemberExpression(node) &&
     ASTUtils.isIdentifier(node.property) &&
     node.property.name === 'then'
   );
-}
-
-export function isArrowFunctionExpression(
-  node: TSESTree.Node
-): node is TSESTree.ArrowFunctionExpression {
-  return node?.type === AST_NODE_TYPES.ArrowFunctionExpression;
-}
-
-export function isReturnStatement(
-  node: TSESTree.Node
-): node is TSESTree.ReturnStatement {
-  return node?.type === AST_NODE_TYPES.ReturnStatement;
-}
-
-export function isArrayExpression(
-  node: TSESTree.Node
-): node is TSESTree.ArrayExpression {
-  return node?.type === AST_NODE_TYPES.ArrayExpression;
-}
-
-export function isImportDeclaration(
-  node: TSESTree.Node | null | undefined
-): node is TSESTree.ImportDeclaration {
-  return node?.type === AST_NODE_TYPES.ImportDeclaration;
 }
 
 export function hasChainedThen(node: TSESTree.Node): boolean {

--- a/lib/node-utils/is-node-of-type.ts
+++ b/lib/node-utils/is-node-of-type.ts
@@ -3,73 +3,34 @@ import {
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
 
-const isNodeOfType = <NodeOfType extends TSESTree.Node>(
-  nodeType: AST_NODE_TYPES
-) => (node: TSESTree.Node | null | undefined): node is NodeOfType =>
-  node?.type === nodeType;
+const isNodeOfType = <NodeType extends AST_NODE_TYPES>(nodeType: NodeType) => (
+  node: TSESTree.Node | null | undefined
+): node is TSESTree.Node & { type: NodeType } => node?.type === nodeType;
 
-export const isArrayExpression = isNodeOfType<TSESTree.ArrayExpression>(
-  AST_NODE_TYPES.ArrayExpression
-);
-
-export const isArrowFunctionExpression = isNodeOfType<TSESTree.ArrowFunctionExpression>(
+export const isArrayExpression = isNodeOfType(AST_NODE_TYPES.ArrayExpression);
+export const isArrowFunctionExpression = isNodeOfType(
   AST_NODE_TYPES.ArrowFunctionExpression
 );
-
-export const isBlockStatement = isNodeOfType<TSESTree.BlockStatement>(
-  AST_NODE_TYPES.BlockStatement
-);
-
-export const isCallExpression = isNodeOfType<TSESTree.CallExpression>(
-  AST_NODE_TYPES.CallExpression
-);
-
-export const isExpressionStatement = isNodeOfType<TSESTree.ExpressionStatement>(
+export const isBlockStatement = isNodeOfType(AST_NODE_TYPES.BlockStatement);
+export const isCallExpression = isNodeOfType(AST_NODE_TYPES.CallExpression);
+export const isExpressionStatement = isNodeOfType(
   AST_NODE_TYPES.ExpressionStatement
 );
-
-export const isImportDeclaration = isNodeOfType<TSESTree.ImportDeclaration>(
+export const isImportDeclaration = isNodeOfType(
   AST_NODE_TYPES.ImportDeclaration
 );
-
-export const isImportDefaultSpecifier = isNodeOfType<TSESTree.ImportDefaultSpecifier>(
+export const isImportDefaultSpecifier = isNodeOfType(
   AST_NODE_TYPES.ImportDefaultSpecifier
 );
-
-export const isImportNamespaceSpecifier = isNodeOfType<TSESTree.ImportNamespaceSpecifier>(
+export const isImportNamespaceSpecifier = isNodeOfType(
   AST_NODE_TYPES.ImportNamespaceSpecifier
 );
-
-export const isImportSpecifier = isNodeOfType<TSESTree.ImportSpecifier>(
-  AST_NODE_TYPES.ImportSpecifier
-);
-
-export const isJSXAttribute = isNodeOfType<TSESTree.JSXAttribute>(
-  AST_NODE_TYPES.JSXAttribute
-);
-
-export const isLiteral = isNodeOfType<TSESTree.Literal>(AST_NODE_TYPES.Literal);
-
-export const isMemberExpression = isNodeOfType<TSESTree.MemberExpression>(
-  AST_NODE_TYPES.MemberExpression
-);
-
-export const isNewExpression = isNodeOfType<TSESTree.NewExpression>(
-  AST_NODE_TYPES.NewExpression
-);
-
-export const isObjectExpression = isNodeOfType<TSESTree.ObjectExpression>(
-  AST_NODE_TYPES.ObjectExpression
-);
-
-export const isObjectPattern = isNodeOfType<TSESTree.ObjectPattern>(
-  AST_NODE_TYPES.ObjectPattern
-);
-
-export const isProperty = isNodeOfType<TSESTree.Property>(
-  AST_NODE_TYPES.Property
-);
-
-export const isReturnStatement = isNodeOfType<TSESTree.ReturnStatement>(
-  AST_NODE_TYPES.ReturnStatement
-);
+export const isImportSpecifier = isNodeOfType(AST_NODE_TYPES.ImportSpecifier);
+export const isJSXAttribute = isNodeOfType(AST_NODE_TYPES.JSXAttribute);
+export const isLiteral = isNodeOfType(AST_NODE_TYPES.Literal);
+export const isMemberExpression = isNodeOfType(AST_NODE_TYPES.MemberExpression);
+export const isNewExpression = isNodeOfType(AST_NODE_TYPES.NewExpression);
+export const isObjectExpression = isNodeOfType(AST_NODE_TYPES.ObjectExpression);
+export const isObjectPattern = isNodeOfType(AST_NODE_TYPES.ObjectPattern);
+export const isProperty = isNodeOfType(AST_NODE_TYPES.Property);
+export const isReturnStatement = isNodeOfType(AST_NODE_TYPES.ReturnStatement);

--- a/lib/node-utils/is-node-of-type.ts
+++ b/lib/node-utils/is-node-of-type.ts
@@ -1,0 +1,75 @@
+import {
+  AST_NODE_TYPES,
+  TSESTree,
+} from '@typescript-eslint/experimental-utils';
+
+const isNodeOfType = <NodeOfType extends TSESTree.Node>(
+  nodeType: AST_NODE_TYPES
+) => (node: TSESTree.Node | null | undefined): node is NodeOfType =>
+  node?.type === nodeType;
+
+export const isArrayExpression = isNodeOfType<TSESTree.ArrayExpression>(
+  AST_NODE_TYPES.ArrayExpression
+);
+
+export const isArrowFunctionExpression = isNodeOfType<TSESTree.ArrowFunctionExpression>(
+  AST_NODE_TYPES.ArrowFunctionExpression
+);
+
+export const isBlockStatement = isNodeOfType<TSESTree.BlockStatement>(
+  AST_NODE_TYPES.BlockStatement
+);
+
+export const isCallExpression = isNodeOfType<TSESTree.CallExpression>(
+  AST_NODE_TYPES.CallExpression
+);
+
+export const isExpressionStatement = isNodeOfType<TSESTree.ExpressionStatement>(
+  AST_NODE_TYPES.ExpressionStatement
+);
+
+export const isImportDeclaration = isNodeOfType<TSESTree.ImportDeclaration>(
+  AST_NODE_TYPES.ImportDeclaration
+);
+
+export const isImportDefaultSpecifier = isNodeOfType<TSESTree.ImportDefaultSpecifier>(
+  AST_NODE_TYPES.ImportDefaultSpecifier
+);
+
+export const isImportNamespaceSpecifier = isNodeOfType<TSESTree.ImportNamespaceSpecifier>(
+  AST_NODE_TYPES.ImportNamespaceSpecifier
+);
+
+export const isImportSpecifier = isNodeOfType<TSESTree.ImportSpecifier>(
+  AST_NODE_TYPES.ImportSpecifier
+);
+
+export const isJSXAttribute = isNodeOfType<TSESTree.JSXAttribute>(
+  AST_NODE_TYPES.JSXAttribute
+);
+
+export const isLiteral = isNodeOfType<TSESTree.Literal>(AST_NODE_TYPES.Literal);
+
+export const isMemberExpression = isNodeOfType<TSESTree.MemberExpression>(
+  AST_NODE_TYPES.MemberExpression
+);
+
+export const isNewExpression = isNodeOfType<TSESTree.NewExpression>(
+  AST_NODE_TYPES.NewExpression
+);
+
+export const isObjectExpression = isNodeOfType<TSESTree.ObjectExpression>(
+  AST_NODE_TYPES.ObjectExpression
+);
+
+export const isObjectPattern = isNodeOfType<TSESTree.ObjectPattern>(
+  AST_NODE_TYPES.ObjectPattern
+);
+
+export const isProperty = isNodeOfType<TSESTree.Property>(
+  AST_NODE_TYPES.Property
+);
+
+export const isReturnStatement = isNodeOfType<TSESTree.ReturnStatement>(
+  AST_NODE_TYPES.ReturnStatement
+);


### PR DESCRIPTION
Since all these functions are doing almost exactly the same, I extracted `isNodeOfType` and put all these kind of functions in a separate file.

@timdeschryver can probably help to make `isNodeOfType` more type-safe so we don't have to pass `NodeOfType` type anymore and we can do
```ts
export const isArrayExpression = isNodeOfType(AST_NODE_TYPES.ArrayExpression);
```
but I can't find it working atm.