### PR TITLE
test: add extra tests

### DIFF
--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -1,94 +1,87 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should export proper "angular" config 1`] = `
+exports[`should export configs that refer to actual rules 1`] = `
 Object {
-  "plugins": Array [
-    "testing-library",
-  ],
-  "rules": Object {
-    "testing-library/await-async-query": "error",
-    "testing-library/await-async-utils": "error",
-    "testing-library/no-await-sync-query": "error",
-    "testing-library/no-container": "error",
-    "testing-library/no-debug": "error",
-    "testing-library/no-dom-import": Array [
-      "error",
-      "angular",
+  "angular": Object {
+    "plugins": Array [
+      "testing-library",
     ],
-    "testing-library/no-node-access": "error",
-    "testing-library/no-promise-in-fire-event": "error",
-    "testing-library/no-wait-for-empty-callback": "error",
-    "testing-library/prefer-find-by": "error",
-    "testing-library/prefer-screen-queries": "error",
-    "testing-library/render-result-naming-convention": "error",
+    "rules": Object {
+      "testing-library/await-async-query": "error",
+      "testing-library/await-async-utils": "error",
+      "testing-library/no-await-sync-query": "error",
+      "testing-library/no-container": "error",
+      "testing-library/no-debug": "error",
+      "testing-library/no-dom-import": Array [
+        "error",
+        "angular",
+      ],
+      "testing-library/no-node-access": "error",
+      "testing-library/no-promise-in-fire-event": "error",
+      "testing-library/no-wait-for-empty-callback": "error",
+      "testing-library/prefer-find-by": "error",
+      "testing-library/prefer-screen-queries": "error",
+      "testing-library/render-result-naming-convention": "error",
+    },
   },
-}
-`;
-
-exports[`should export proper "dom" config 1`] = `
-Object {
-  "plugins": Array [
-    "testing-library",
-  ],
-  "rules": Object {
-    "testing-library/await-async-query": "error",
-    "testing-library/await-async-utils": "error",
-    "testing-library/no-await-sync-query": "error",
-    "testing-library/no-promise-in-fire-event": "error",
-    "testing-library/no-wait-for-empty-callback": "error",
-    "testing-library/prefer-find-by": "error",
-    "testing-library/prefer-screen-queries": "error",
-  },
-}
-`;
-
-exports[`should export proper "react" config 1`] = `
-Object {
-  "plugins": Array [
-    "testing-library",
-  ],
-  "rules": Object {
-    "testing-library/await-async-query": "error",
-    "testing-library/await-async-utils": "error",
-    "testing-library/no-await-sync-query": "error",
-    "testing-library/no-container": "error",
-    "testing-library/no-debug": "error",
-    "testing-library/no-dom-import": Array [
-      "error",
-      "react",
+  "dom": Object {
+    "plugins": Array [
+      "testing-library",
     ],
-    "testing-library/no-node-access": "error",
-    "testing-library/no-promise-in-fire-event": "error",
-    "testing-library/no-wait-for-empty-callback": "error",
-    "testing-library/prefer-find-by": "error",
-    "testing-library/prefer-screen-queries": "error",
-    "testing-library/render-result-naming-convention": "error",
+    "rules": Object {
+      "testing-library/await-async-query": "error",
+      "testing-library/await-async-utils": "error",
+      "testing-library/no-await-sync-query": "error",
+      "testing-library/no-promise-in-fire-event": "error",
+      "testing-library/no-wait-for-empty-callback": "error",
+      "testing-library/prefer-find-by": "error",
+      "testing-library/prefer-screen-queries": "error",
+    },
   },
-}
-`;
-
-exports[`should export proper "vue" config 1`] = `
-Object {
-  "plugins": Array [
-    "testing-library",
-  ],
-  "rules": Object {
-    "testing-library/await-async-query": "error",
-    "testing-library/await-async-utils": "error",
-    "testing-library/await-fire-event": "error",
-    "testing-library/no-await-sync-query": "error",
-    "testing-library/no-container": "error",
-    "testing-library/no-debug": "error",
-    "testing-library/no-dom-import": Array [
-      "error",
-      "vue",
+  "react": Object {
+    "plugins": Array [
+      "testing-library",
     ],
-    "testing-library/no-node-access": "error",
-    "testing-library/no-promise-in-fire-event": "error",
-    "testing-library/no-wait-for-empty-callback": "error",
-    "testing-library/prefer-find-by": "error",
-    "testing-library/prefer-screen-queries": "error",
-    "testing-library/render-result-naming-convention": "error",
+    "rules": Object {
+      "testing-library/await-async-query": "error",
+      "testing-library/await-async-utils": "error",
+      "testing-library/no-await-sync-query": "error",
+      "testing-library/no-container": "error",
+      "testing-library/no-debug": "error",
+      "testing-library/no-dom-import": Array [
+        "error",
+        "react",
+      ],
+      "testing-library/no-node-access": "error",
+      "testing-library/no-promise-in-fire-event": "error",
+      "testing-library/no-wait-for-empty-callback": "error",
+      "testing-library/prefer-find-by": "error",
+      "testing-library/prefer-screen-queries": "error",
+      "testing-library/render-result-naming-convention": "error",
+    },
+  },
+  "vue": Object {
+    "plugins": Array [
+      "testing-library",
+    ],
+    "rules": Object {
+      "testing-library/await-async-query": "error",
+      "testing-library/await-async-utils": "error",
+      "testing-library/await-fire-event": "error",
+      "testing-library/no-await-sync-query": "error",
+      "testing-library/no-container": "error",
+      "testing-library/no-debug": "error",
+      "testing-library/no-dom-import": Array [
+        "error",
+        "vue",
+      ],
+      "testing-library/no-node-access": "error",
+      "testing-library/no-promise-in-fire-event": "error",
+      "testing-library/no-wait-for-empty-callback": "error",
+      "testing-library/prefer-find-by": "error",
+      "testing-library/prefer-screen-queries": "error",
+      "testing-library/render-result-naming-convention": "error",
+    },
   },
 }
 `;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,25 +1,67 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { configs, rules } = require('../lib');
-import * as fs from 'fs';
-import * as path from 'path';
+import { existsSync } from 'fs';
+import { resolve } from 'path';
 
-const rulesModules = fs.readdirSync(path.join(__dirname, '../lib/rules'));
+import plugin from '../lib';
 
-it('should export all available rules', () => {
-  const availableRules = rulesModules.map((module) =>
-    module.replace('.ts', '')
-  );
-  expect(Object.keys(rules)).toEqual(availableRules);
+const numberOfRules = 24;
+const ruleNames = Object.keys(plugin.rules);
+
+// eslint-disable-next-line jest/expect-expect
+it('should have a corresponding doc for each rule', () => {
+  ruleNames.forEach((rule) => {
+    const docPath = resolve(__dirname, '../docs/rules', `${rule}.md`);
+
+    if (!existsSync(docPath)) {
+      throw new Error(
+        `Could not find documentation file for rule "${rule}" in path "${docPath}"`
+      );
+    }
+  });
 });
 
-it.each(['dom', 'angular', 'react', 'vue'])(
-  'should export proper "%s" config',
-  (configName) => {
-    expect(configs[configName]).toMatchSnapshot();
+// eslint-disable-next-line jest/expect-expect
+it('should have a corresponding test for each rule', () => {
+  ruleNames.forEach((rule) => {
+    const testPath = resolve(__dirname, './lib/rules/', `${rule}.test.ts`);
 
-    // make sure all enabled rules start by "testing-library/" prefix
-    Object.keys(configs[configName].rules).forEach((ruleEnabled) => {
-      expect(ruleEnabled).toMatch(/^testing-library\/.+$/);
-    });
+    if (!existsSync(testPath)) {
+      throw new Error(
+        `Could not find test file for rule "${rule}" in path "${testPath}"`
+      );
+    }
+  });
+});
+
+// eslint-disable-next-line jest/expect-expect
+it('should have the correct amount of rules', () => {
+  const { length } = ruleNames;
+
+  if (length !== numberOfRules) {
+    throw new Error(
+      `There should be exactly ${numberOfRules} rules, but there are ${length}. If you've added a new rule, please update this number.`
+    );
   }
-);
+});
+
+it('should export configs that refer to actual rules', () => {
+  const allConfigs = plugin.configs;
+
+  expect(allConfigs).toMatchSnapshot();
+  expect(Object.keys(allConfigs)).toEqual(['dom', 'angular', 'react', 'vue']);
+  const allConfigRules = Object.values(allConfigs)
+    .map((config) => Object.keys(config.rules))
+    .reduce((previousValue, currentValue) => [
+      ...previousValue,
+      ...currentValue,
+    ]);
+
+  allConfigRules.forEach((rule) => {
+    const ruleNamePrefix = 'testing-library/';
+    const ruleName = rule.slice(ruleNamePrefix.length);
+
+    expect(rule.startsWith(ruleNamePrefix)).toBe(true);
+    expect(ruleNames).toContain(ruleName);
+
+    expect(() => require(`../lib/rules/${ruleName}`)).not.toThrow();
+  });
+});


### PR DESCRIPTION
Took some inspiration from `eslint-plugin-jest` (see https://github.com/jest-community/eslint-plugin-jest/blob/main/src/__tests__/rules.test.ts).

With these tests, we ensure that
- all rules have docs
- all rules have tests
- all configs are referencing existing rules