### PR TITLE
fix: allow console.debug() in no-debug

### DIFF
--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -16,7 +16,6 @@ import {
   isImportNamespaceSpecifier,
   isImportSpecifier,
   isLiteral,
-  isCallExpression,
   isMemberExpression,
   isObjectPattern,
   isProperty,
@@ -584,11 +583,8 @@ export function detectTestingLibraryUtils<
     const isDebugUtil: IsDebugUtilFn = (identifierNode) => {
       const isBuiltInConsole =
         isMemberExpression(identifierNode.parent) &&
-        identifierNode.parent.parent &&
-        isCallExpression(identifierNode.parent.parent) &&
-        isMemberExpression(identifierNode.parent.parent.callee) &&
-        ASTUtils.isIdentifier(identifierNode.parent.parent.callee.object) &&
-        identifierNode.parent.parent.callee.object.name === 'console';
+        ASTUtils.isIdentifier(identifierNode.parent.object) &&
+        identifierNode.parent.object.name === 'console';
 
       return (
         !isBuiltInConsole &&

--- a/lib/detect-testing-library-utils.ts
+++ b/lib/detect-testing-library-utils.ts
@@ -16,6 +16,7 @@ import {
   isImportNamespaceSpecifier,
   isImportSpecifier,
   isLiteral,
+  isCallExpression,
   isMemberExpression,
   isObjectPattern,
   isProperty,
@@ -78,10 +79,7 @@ type IsRenderUtilFn = (node: TSESTree.Identifier) => boolean;
 type IsRenderVariableDeclaratorFn = (
   node: TSESTree.VariableDeclarator
 ) => boolean;
-type IsDebugUtilFn = (
-  identifierNode: TSESTree.Identifier,
-  callExpressionNode: TSESTree.CallExpression
-) => boolean;
+type IsDebugUtilFn = (identifierNode: TSESTree.Identifier) => boolean;
 type IsPresenceAssertFn = (node: TSESTree.MemberExpression) => boolean;
 type IsAbsenceAssertFn = (node: TSESTree.MemberExpression) => boolean;
 type CanReportErrorsFn = () => boolean;
@@ -583,11 +581,14 @@ export function detectTestingLibraryUtils<
       return isRenderUtil(initIdentifierNode);
     };
 
-    const isDebugUtil: IsDebugUtilFn = (identifierNode, callExpressionNode) => {
+    const isDebugUtil: IsDebugUtilFn = (identifierNode) => {
       const isBuiltInConsole =
-        isMemberExpression(callExpressionNode.callee) &&
-        ASTUtils.isIdentifier(callExpressionNode.callee.object) &&
-        callExpressionNode.callee.object.name === 'console';
+        isMemberExpression(identifierNode.parent) &&
+        identifierNode.parent.parent &&
+        isCallExpression(identifierNode.parent.parent) &&
+        isMemberExpression(identifierNode.parent.parent.callee) &&
+        ASTUtils.isIdentifier(identifierNode.parent.parent.callee.object) &&
+        identifierNode.parent.parent.callee.object.name === 'console';
 
       return (
         !isBuiltInConsole &&

--- a/lib/rules/no-debug.ts
+++ b/lib/rules/no-debug.ts
@@ -6,6 +6,7 @@ import {
   getReferenceNode,
   isObjectPattern,
   isProperty,
+  isMemberExpression,
 } from '../node-utils';
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import { ASTUtils, TSESTree } from '@typescript-eslint/experimental-utils';
@@ -50,7 +51,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
         }
         const initIdentifierNode = getDeepestIdentifierNode(node.init);
 
-        if (!initIdentifierNode) {
+        if (!initIdentifierNode || initIdentifierNode.name === 'console') {
           return;
         }
 
@@ -107,7 +108,11 @@ export default createTestingLibraryRule<Options, MessageIds>({
           return;
         }
 
-        const isDebugUtil = helpers.isDebugUtil(callExpressionIdentifier);
+        const isDebugUtil =
+          helpers.isDebugUtil(callExpressionIdentifier) &&
+          (!isMemberExpression(node.callee) ||
+            !ASTUtils.isIdentifier(node.callee.object) ||
+            node.callee.object.name !== 'console');
         const isDeclaredDebugVariable = suspiciousDebugVariableNames.includes(
           callExpressionIdentifier.name
         );

--- a/lib/rules/no-debug.ts
+++ b/lib/rules/no-debug.ts
@@ -4,6 +4,7 @@ import {
   getInnermostReturningFunction,
   getPropertyIdentifierNode,
   getReferenceNode,
+  isCallExpression,
   isObjectPattern,
   isProperty,
 } from '../node-utils';
@@ -113,7 +114,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
           return;
         }
 
-        const isDebugUtil = helpers.isDebugUtil(callExpressionIdentifier, node);
+        const isDebugUtil = helpers.isDebugUtil(callExpressionIdentifier);
         const isDeclaredDebugVariable = suspiciousDebugVariableNames.includes(
           callExpressionIdentifier.name
         );
@@ -130,7 +131,9 @@ export default createTestingLibraryRule<Options, MessageIds>({
           (variableDeclarator) => {
             const variables = context.getDeclaredVariables(variableDeclarator);
             return variables.some(
-              ({ name }) => name === callExpressionIdentifier.name
+              ({ name }) =>
+                name === callExpressionIdentifier.name &&
+                isCallExpression(callExpressionIdentifier.parent)
             );
           }
         );

--- a/lib/rules/no-debug.ts
+++ b/lib/rules/no-debug.ts
@@ -6,7 +6,6 @@ import {
   getReferenceNode,
   isObjectPattern,
   isProperty,
-  isMemberExpression,
 } from '../node-utils';
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import { ASTUtils, TSESTree } from '@typescript-eslint/experimental-utils';
@@ -108,11 +107,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
           return;
         }
 
-        const isDebugUtil =
-          helpers.isDebugUtil(callExpressionIdentifier) &&
-          (!isMemberExpression(node.callee) ||
-            !ASTUtils.isIdentifier(node.callee.object) ||
-            node.callee.object.name !== 'console');
+        const isDebugUtil = helpers.isDebugUtil(callExpressionIdentifier, node);
         const isDeclaredDebugVariable = suspiciousDebugVariableNames.includes(
           callExpressionIdentifier.name
         );

--- a/tests/lib/rules/no-debug.test.ts
+++ b/tests/lib/rules/no-debug.test.ts
@@ -537,5 +537,23 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [{ line: 7, column: 7, messageId: 'noDebug' }],
     },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+      import { render } from '@testing-library/react'
+      
+      const utils = render(element)
+      const { debug: renamedDestructuredDebug } = console
+      const { debug } = console
+      const assignedDebug = console.debug
+      console.debug('debugging')
+      debug('destructured')
+      assignedDebug('foo')
+      // the following line is the one that fails
+      utils.debug()
+      renamedDestructuredDebug('foo')
+      `,
+      errors: [{ line: 12, column: 13, messageId: 'noDebug' }],
+    },
   ],
 });

--- a/tests/lib/rules/no-debug.test.ts
+++ b/tests/lib/rules/no-debug.test.ts
@@ -55,6 +55,15 @@ ruleTester.run(RULE_NAME, rule, {
       code: `screen.debug()`,
     },
     {
+      code: `console.debug()`,
+    },
+    {
+      code: `
+        const consoleDebug = console.debug
+        consoleDebug()
+      `,
+    },
+    {
       code: `
         const { screen } = require('@testing-library/dom')
         screen.debug

--- a/tests/lib/rules/no-debug.test.ts
+++ b/tests/lib/rules/no-debug.test.ts
@@ -65,6 +65,18 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
+        const { debug } = console
+        debug()
+      `,
+    },
+    {
+      code: `
+        const { debug: consoleDebug } = console
+        consoleDebug()
+      `,
+    },
+    {
+      code: `
         const { screen } = require('@testing-library/dom')
         screen.debug
       `,


### PR DESCRIPTION
closes #327

I intentionally left out the following scenario

```js
const { debug } = console
debug()
```

because it goes against the first invalid tests that against any `debug()`, it raises a flag. 