### PR TITLE
feat(no-wait-for-side-effects): report render in waitFor

### DIFF
--- a/docs/rules/no-wait-for-side-effects.md
+++ b/docs/rules/no-wait-for-side-effects.md
@@ -2,7 +2,7 @@
 
 ## Rule Details
 
-This rule aims to avoid the usage of side effects actions (`fireEvent` or `userEvent`) inside `waitFor`.
+This rule aims to avoid the usage of side effects actions (`fireEvent`, `userEvent` or `render`) inside `waitFor`.
 Since `waitFor` is intended for things that have a non-deterministic amount of time between the action you performed and the assertion passing,
 the callback can be called (or checked for errors) a non-deterministic number of times and frequency.
 This will make your side-effect run multiple times.
@@ -32,6 +32,18 @@ Example of **incorrect** code for this rule:
     userEvent.click(button);
     expect(b).toEqual('b');
   });
+
+  // or
+  await waitFor(() => {
+    render(<App />)
+    expect(b).toEqual('b');
+  });
+
+  // or
+  await waitFor(function() {
+    render(<App />)
+    expect(b).toEqual('b');
+  });
 };
 ```
 
@@ -57,6 +69,18 @@ Examples of **correct** code for this rule:
 
   // or
   userEvent.click(button);
+  await waitFor(function() {
+    expect(b).toEqual('b');
+  });
+
+  // or
+  render(<App />)
+  await waitFor(() => {
+    expect(b).toEqual('b');
+  });
+
+  // or
+  render(<App />)
   await waitFor(function() {
     expect(b).toEqual('b');
   });

--- a/lib/create-testing-library-rule/detect-testing-library-utils.ts
+++ b/lib/create-testing-library-rule/detect-testing-library-utils.ts
@@ -173,7 +173,7 @@ export function detectTestingLibraryUtils<
      *    reporting)
      */
     function isTestingLibraryUtil(
-      node: TSESTree.Identifier,
+      node: TSESTree.Identifier | null,
       isUtilCallback: (
         identifierNodeName: string,
         originalNodeName?: string
@@ -430,8 +430,6 @@ export function detectTestingLibraryUtils<
      * Not to be confused with {@link isFireEventMethod}
      */
     const isFireEventUtil = (node: TSESTree.Identifier | null): boolean => {
-      if (!node) return false;
-
       return isTestingLibraryUtil(
         node,
         (identifierNodeName, originalNodeName) => {
@@ -573,25 +571,18 @@ export function detectTestingLibraryUtils<
      * Testing Library. Otherwise, it means `custom-module` has been set up, so
      * only those nodes coming from Testing Library will be considered as valid.
      */
-    const isRenderUtil: IsRenderUtilFn = (node) => {
-      if (!node) return false;
-
-      return isTestingLibraryUtil(
-        node,
-        (identifierNodeName, originalNodeName) => {
-          if (isAggressiveRenderReportingEnabled()) {
-            return identifierNodeName.toLowerCase().includes(RENDER_NAME);
-          }
-
-          return [RENDER_NAME, ...getCustomRenders()].some(
-            (validRenderName) =>
-              validRenderName === identifierNodeName ||
-              (Boolean(originalNodeName) &&
-                validRenderName === originalNodeName)
-          );
+    const isRenderUtil: IsRenderUtilFn = (node) =>
+      isTestingLibraryUtil(node, (identifierNodeName, originalNodeName) => {
+        if (isAggressiveRenderReportingEnabled()) {
+          return identifierNodeName.toLowerCase().includes(RENDER_NAME);
         }
-      );
-    };
+
+        return [RENDER_NAME, ...getCustomRenders()].some(
+          (validRenderName) =>
+            validRenderName === identifierNodeName ||
+            (Boolean(originalNodeName) && validRenderName === originalNodeName)
+        );
+      });
 
     const isRenderVariableDeclarator: IsRenderVariableDeclaratorFn = (node) => {
       if (!node.init) {

--- a/lib/create-testing-library-rule/detect-testing-library-utils.ts
+++ b/lib/create-testing-library-rule/detect-testing-library-utils.ts
@@ -444,7 +444,9 @@ export function detectTestingLibraryUtils<
      * Not to be confused with {@link isUserEventMethod}
      */
     const isUserEventUtil = (node: TSESTree.Identifier | null): boolean => {
-      if (!node) return false;
+      if (!node) {
+        return false;
+      }
 
       const userEvent = findImportedUserEventSpecifier();
       let userEventName: string | undefined;

--- a/lib/create-testing-library-rule/detect-testing-library-utils.ts
+++ b/lib/create-testing-library-rule/detect-testing-library-utils.ts
@@ -75,7 +75,7 @@ type IsAsyncUtilFn = (
 ) => boolean;
 type IsFireEventMethodFn = (node: TSESTree.Identifier) => boolean;
 type IsUserEventMethodFn = (node: TSESTree.Identifier) => boolean;
-type IsRenderUtilFn = (node: TSESTree.Identifier | null) => boolean;
+type IsRenderUtilFn = (node: TSESTree.Identifier) => boolean;
 type IsRenderVariableDeclaratorFn = (
   node: TSESTree.VariableDeclarator
 ) => boolean;
@@ -105,8 +105,8 @@ export interface DetectionHelpers {
   isCustomQuery: IsCustomQueryFn;
   isBuiltInQuery: IsBuiltInQueryFn;
   isAsyncUtil: IsAsyncUtilFn;
-  isFireEventUtil: (node: TSESTree.Identifier | null) => boolean;
-  isUserEventUtil: (node: TSESTree.Identifier | null) => boolean;
+  isFireEventUtil: (node: TSESTree.Identifier) => boolean;
+  isUserEventUtil: (node: TSESTree.Identifier) => boolean;
   isFireEventMethod: IsFireEventMethodFn;
   isUserEventMethod: IsUserEventMethodFn;
   isRenderUtil: IsRenderUtilFn;
@@ -173,7 +173,7 @@ export function detectTestingLibraryUtils<
      *    reporting)
      */
     function isTestingLibraryUtil(
-      node: TSESTree.Identifier | null,
+      node: TSESTree.Identifier,
       isUtilCallback: (
         identifierNodeName: string,
         originalNodeName?: string
@@ -429,7 +429,7 @@ export function detectTestingLibraryUtils<
      *
      * Not to be confused with {@link isFireEventMethod}
      */
-    const isFireEventUtil = (node: TSESTree.Identifier | null): boolean => {
+    const isFireEventUtil = (node: TSESTree.Identifier): boolean => {
       return isTestingLibraryUtil(
         node,
         (identifierNodeName, originalNodeName) => {
@@ -443,11 +443,7 @@ export function detectTestingLibraryUtils<
      *
      * Not to be confused with {@link isUserEventMethod}
      */
-    const isUserEventUtil = (node: TSESTree.Identifier | null): boolean => {
-      if (!node) {
-        return false;
-      }
-
+    const isUserEventUtil = (node: TSESTree.Identifier): boolean => {
       const userEvent = findImportedUserEventSpecifier();
       let userEventName: string | undefined;
 

--- a/lib/node-utils/is-node-of-type.ts
+++ b/lib/node-utils/is-node-of-type.ts
@@ -16,6 +16,15 @@ export const isCallExpression = isNodeOfType(AST_NODE_TYPES.CallExpression);
 export const isExpressionStatement = isNodeOfType(
   AST_NODE_TYPES.ExpressionStatement
 );
+export const isVariableDeclaration = isNodeOfType(
+  AST_NODE_TYPES.VariableDeclaration
+);
+export const isAssignmentExpression = isNodeOfType(
+  AST_NODE_TYPES.AssignmentExpression
+);
+export const isSequenceExpression = isNodeOfType(
+  AST_NODE_TYPES.SequenceExpression
+);
 export const isImportDeclaration = isNodeOfType(
   AST_NODE_TYPES.ImportDeclaration
 );

--- a/lib/rules/no-wait-for-side-effects.ts
+++ b/lib/rules/no-wait-for-side-effects.ts
@@ -69,7 +69,6 @@ export default createTestingLibraryRule<Options, MessageIds>({
           node.declarations.some((declaration) =>
             helpers.isRenderVariableDeclarator(declaration)
           );
-
         if (isRenderInVariableDeclaration) {
           return true;
         }
@@ -80,7 +79,6 @@ export default createTestingLibraryRule<Options, MessageIds>({
           helpers.isRenderUtil(
             getPropertyIdentifierNode(node.expression.right)
           );
-
         if (isRenderInAssignment) {
           return true;
         }

--- a/lib/rules/no-wait-for-side-effects.ts
+++ b/lib/rules/no-wait-for-side-effects.ts
@@ -99,11 +99,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
           return false;
         }
 
-        if (isRenderInVariableDeclaration(node)) {
-          return true;
-        }
-
-        if (isRenderInAssignment(node)) {
+        if (isRenderInVariableDeclaration(node) || isRenderInAssignment(node)) {
           return true;
         }
 

--- a/lib/rules/no-wait-for-side-effects.ts
+++ b/lib/rules/no-wait-for-side-effects.ts
@@ -117,8 +117,9 @@ export default createTestingLibraryRule<Options, MessageIds>({
         return;
       }
 
-      const expressionIdentifier =
-        isCallExpression(node) && getPropertyIdentifierNode(node.callee);
+      const expressionIdentifier = isCallExpression(node)
+        ? getPropertyIdentifierNode(node.callee)
+        : null;
       const isRenderInAssignment =
         isAssignmentExpression(node) &&
         helpers.isRenderUtil(getPropertyIdentifierNode(node.right));
@@ -131,9 +132,9 @@ export default createTestingLibraryRule<Options, MessageIds>({
         );
 
       if (
-        !helpers.isFireEventUtil(expressionIdentifier || null) &&
-        !helpers.isUserEventUtil(expressionIdentifier || null) &&
-        !helpers.isRenderUtil(expressionIdentifier || null) &&
+        !helpers.isFireEventUtil(expressionIdentifier) &&
+        !helpers.isUserEventUtil(expressionIdentifier) &&
+        !helpers.isRenderUtil(expressionIdentifier) &&
         !isRenderInAssignment &&
         !isRenderInSequenceAssignment
       ) {

--- a/lib/rules/no-wait-for-side-effects.ts
+++ b/lib/rules/no-wait-for-side-effects.ts
@@ -59,9 +59,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
     function isRenderInVariableDeclaration(node: TSESTree.Node) {
       return (
         isVariableDeclaration(node) &&
-        node.declarations.some((declaration) =>
-          helpers.isRenderVariableDeclarator(declaration)
-        )
+        node.declarations.some(helpers.isRenderVariableDeclarator)
       );
     }
 

--- a/lib/rules/no-wait-for-side-effects.ts
+++ b/lib/rules/no-wait-for-side-effects.ts
@@ -64,13 +64,15 @@ export default createTestingLibraryRule<Options, MessageIds>({
           return false;
         }
 
-        const expressionIdentifier = getPropertyIdentifierNode(node);
-
         const isRenderInVariableDeclaration =
           isVariableDeclaration(node) &&
           node.declarations.some((declaration) =>
             helpers.isRenderVariableDeclarator(declaration)
           );
+
+        if (isRenderInVariableDeclaration) {
+          return true;
+        }
 
         const isRenderInAssignment =
           isExpressionStatement(node) &&
@@ -79,12 +81,16 @@ export default createTestingLibraryRule<Options, MessageIds>({
             getPropertyIdentifierNode(node.expression.right)
           );
 
+        if (isRenderInAssignment) {
+          return true;
+        }
+
+        const expressionIdentifier = getPropertyIdentifierNode(node);
+
         return (
           helpers.isFireEventUtil(expressionIdentifier) ||
           helpers.isUserEventUtil(expressionIdentifier) ||
-          helpers.isRenderUtil(expressionIdentifier) ||
-          isRenderInVariableDeclaration ||
-          isRenderInAssignment
+          helpers.isRenderUtil(expressionIdentifier)
         );
       }) as TSESTree.ExpressionStatement[];
     }

--- a/lib/rules/no-wait-for-side-effects.ts
+++ b/lib/rules/no-wait-for-side-effects.ts
@@ -65,7 +65,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
       );
     }
 
-    function isRenderInAssignment(node: TSESTree.Node) {
+    function isRenderInExpressionStatement(node: TSESTree.Node) {
       if (
         !isExpressionStatement(node) ||
         !isAssignmentExpression(node.expression)
@@ -84,27 +84,12 @@ export default createTestingLibraryRule<Options, MessageIds>({
       return helpers.isRenderUtil(expressionIdentifier);
     }
 
-    function isRenderInImplicitReturnAssignment(node: TSESTree.Node) {
+    function isRenderInAssignmentExpression(node: TSESTree.Node) {
       if (!isAssignmentExpression(node)) {
         return false;
       }
 
       const expressionIdentifier = getPropertyIdentifierNode(node.right);
-
-      if (!expressionIdentifier) {
-        return false;
-      }
-
-      return helpers.isRenderUtil(expressionIdentifier);
-    }
-
-    function isExpressionRenderUtil(expression: TSESTree.Expression) {
-      if (!isAssignmentExpression(expression)) {
-        return false;
-      }
-
-      const expressionIdentifier = getPropertyIdentifierNode(expression.right);
-
       if (!expressionIdentifier) {
         return false;
       }
@@ -117,7 +102,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
         return false;
       }
 
-      return node.expressions.some(isExpressionRenderUtil);
+      return node.expressions.some(isRenderInAssignmentExpression);
     }
 
     function getSideEffectNodes(
@@ -128,7 +113,10 @@ export default createTestingLibraryRule<Options, MessageIds>({
           return false;
         }
 
-        if (isRenderInVariableDeclaration(node) || isRenderInAssignment(node)) {
+        if (
+          isRenderInVariableDeclaration(node) ||
+          isRenderInExpressionStatement(node)
+        ) {
           return true;
         }
 
@@ -180,7 +168,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 
       if (
         !expressionIdentifier &&
-        !isRenderInImplicitReturnAssignment(node) &&
+        !isRenderInAssignmentExpression(node) &&
         !isRenderInSequenceAssignment(node)
       ) {
         return;

--- a/tests/lib/rules/no-wait-for-side-effects.test.ts
+++ b/tests/lib/rules/no-wait-for-side-effects.test.ts
@@ -180,8 +180,331 @@ ruleTester.run(RULE_NAME, rule, {
         await waitFor(() => userEvent.click(button))
       `,
     },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+        import { waitFor } from 'somewhere-else';
+        await waitFor(() => render(<App />))
+      `,
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+        import { waitFor } from 'somewhere-else';
+        await waitFor(() => {
+          const { container } = render(<App />)
+        })
+      `,
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+        import { waitFor } from 'somewhere-else';
+        const { rerender } = render(<App />)
+        await waitFor(() => {
+          rerender(<App />)
+        })
+      `,
+    },
+    {
+      settings: { 'testing-library/utils-module': '~/test-utils' },
+      code: `
+        import { waitFor } from '~/test-utils';
+        import { render } from 'somewhere-else';
+        await waitFor(() => render(<App />))
+      `,
+    },
+    {
+      settings: { 'testing-library/utils-module': '~/test-utils' },
+      code: `
+        import { waitFor } from '@testing-library/react';
+        import { render } from 'somewhere-else';
+        await waitFor(() => render(<App />))
+      `,
+    },
+    {
+      settings: { 'testing-library/custom-renders': ['renderHelper'] },
+      code: `
+        import { waitFor } from '@testing-library/react';
+        import { renderWrapper } from 'somewhere-else';
+        await waitFor(() => renderWrapper(<App />))
+      `,
+    },
+    {
+      settings: { 'testing-library/custom-renders': ['renderHelper'] },
+      code: `
+        import { waitFor } from '@testing-library/react';
+        import { renderWrapper } from 'somewhere-else';
+        await waitFor(() => {
+          renderWrapper(<App />)
+        })
+      `,
+    },
+    {
+      settings: { 'testing-library/custom-renders': ['renderHelper'] },
+      code: `
+        import { waitFor } from '@testing-library/react';
+        import { renderWrapper } from 'somewhere-else';
+        await waitFor(() => {
+          const { container } = renderWrapper(<App />)
+        })
+      `,
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+        import { waitFor } from 'somewhere-else';
+        await waitFor(() => {
+          render(<App />)
+        })
+      `,
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+        import { waitFor } from 'test-utils';
+        import { render } from 'somewhere-else';
+        await waitFor(() => {
+          render(<App />)
+        })
+      `,
+    },
+    {
+      settings: { 'testing-library/custom-renders': ['renderHelper'] },
+      code: `
+        import { waitFor } from '@testing-library/react';
+        import { renderWrapper } from 'somewhere-else';
+        await waitFor(() => {
+          renderWrapper(<App />)
+        })
+      `,
+    },
+    {
+      settings: { 'testing-library/custom-renders': ['renderHelper'] },
+      code: `
+        import { waitFor } from '@testing-library/react';
+        await waitFor(() => result = renderWrapper(<App />))
+      `,
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+        import { waitFor } from 'test-utils';
+        import { render } from 'somewhere-else';
+        await waitFor(() => result = render(<App />))
+      `,
+    },
+    {
+      settings: { 'testing-library/utils-module': 'test-utils' },
+      code: `
+        import { waitFor } from 'somewhere-else';
+        await waitFor(() => result = render(<App />))
+      `,
+    },
   ],
   invalid: [
+    // render
+    {
+      code: `
+        import { waitFor } from '@testing-library/react';
+        await waitFor(() => render(<App />))
+      `,
+      errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
+    },
+    {
+      code: `
+        import { waitFor } from '@testing-library/react';
+        await waitFor(function() {
+          render(<App />)
+        })
+      `,
+      errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+    },
+    {
+      code: `
+        import { waitFor } from '@testing-library/react';
+        await waitFor(function() {
+          const { container } = renderHelper(<App />)
+        })
+      `,
+      errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+    },
+    {
+      settings: { 'testing-library/custom-renders': ['renderHelper'] },
+      code: `
+        import { waitFor } from '@testing-library/react';
+        import { renderHelper } from 'somewhere-else';
+        await waitFor(() => renderHelper(<App />))
+      `,
+      errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
+    },
+    {
+      settings: { 'testing-library/custom-renders': ['renderHelper'] },
+      code: `
+        import { waitFor } from '@testing-library/react';
+        import { renderHelper } from 'somewhere-else';
+        await waitFor(() => {
+          renderHelper(<App />)
+        })
+      `,
+      errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
+    },
+    {
+      settings: { 'testing-library/custom-renders': ['renderHelper'] },
+      code: `
+        import { waitFor } from '@testing-library/react';
+        import { renderHelper } from 'somewhere-else';
+        await waitFor(() => {
+          const { container } = renderHelper(<App />)
+        })
+      `,
+      errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
+    },
+    {
+      settings: { 'testing-library/custom-renders': ['renderHelper'] },
+      code: `
+        import { waitFor } from '@testing-library/react';
+        import { renderHelper } from 'somewhere-else';
+        let container;
+        await waitFor(() => {
+          ({ container } = renderHelper(<App />))
+        })
+      `,
+      errors: [{ line: 6, column: 11, messageId: 'noSideEffectsWaitFor' }],
+    },
+    {
+      code: `
+        import { waitFor } from '@testing-library/react';
+        await waitFor(() => result = render(<App />))
+      `,
+      errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
+    },
+    {
+      code: `
+        import { waitFor } from '@testing-library/react';
+        await waitFor(() => (a = 5, result = render(<App />)))
+      `,
+      errors: [{ line: 3, column: 30, messageId: 'noSideEffectsWaitFor' }],
+    },
+    {
+      code: `
+        import { waitFor } from '@testing-library/react';
+        const { rerender } = render(<App />)
+        await waitFor(() => rerender(<App />))
+      `,
+      errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
+    },
+    {
+      code: `
+        import { waitFor, render } from '@testing-library/react';
+        await waitFor(() => render(<App />))
+      `,
+      errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
+    },
+    {
+      code: `
+        import { waitFor } from '@testing-library/react';
+        const { rerender } = render(<App />)
+        await waitFor(() => rerender(<App />))
+      `,
+      errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
+    },
+    {
+      code: `
+        import { waitFor } from '@testing-library/react';
+        await waitFor(() => renderHelper(<App />))
+      `,
+      errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
+    },
+    {
+      code: `
+        import { waitFor } from '@testing-library/react';
+        import { render } from 'somewhere-else';
+        await waitFor(() => render(<App />))
+      `,
+      errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
+    },
+    {
+      settings: { 'testing-library/utils-module': '~/test-utils' },
+      code: `
+        import { waitFor, render } from '~/test-utils';
+        await waitFor(() => render(<App />))
+      `,
+      errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
+    },
+    {
+      settings: { 'testing-library/custom-renders': ['renderWrapper'] },
+      code: `
+        import { waitFor } from '@testing-library/react';
+        import { renderWrapper } from 'somewhere-else';
+        await waitFor(() => renderWrapper(<App />))
+      `,
+      errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
+    },
+    {
+      code: `
+        import { waitFor } from '@testing-library/react';
+        await waitFor(() => {
+          render(<App />)
+        })
+      `,
+      errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+    },
+    {
+      code: `
+        import { waitFor } from '@testing-library/react';
+        await waitFor(() => {
+          const { container } = render(<App />)
+        })
+      `,
+      errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+    },
+    {
+      code: `
+        import { waitFor } from '@testing-library/react';
+        await waitFor(() => {
+          const a = 5,
+          { container } = render(<App />)
+        })
+      `,
+      errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+    },
+    {
+      code: `
+        import { waitFor } from '@testing-library/react';
+        const { rerender } = render(<App />)
+        await waitFor(() => {
+          rerender(<App />)
+        })
+      `,
+      errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
+    },
+    {
+      code: `
+        import { waitFor } from '@testing-library/react';
+        await waitFor(() => {
+          render(<App />)
+          fireEvent.keyDown(input, {key: 'ArrowDown'})
+        })
+      `,
+      errors: [
+        { line: 4, column: 11, messageId: 'noSideEffectsWaitFor' },
+        { line: 5, column: 11, messageId: 'noSideEffectsWaitFor' },
+      ],
+    },
+    {
+      code: `
+        import { waitFor } from '@testing-library/react';
+        await waitFor(() => {
+          render(<App />)
+          userEvent.click(button)
+        })
+      `,
+      errors: [
+        { line: 4, column: 11, messageId: 'noSideEffectsWaitFor' },
+        { line: 5, column: 11, messageId: 'noSideEffectsWaitFor' },
+      ],
+    },
     // fireEvent
     {
       code: `

--- a/tests/lib/rules/no-wait-for-side-effects.test.ts
+++ b/tests/lib/rules/no-wait-for-side-effects.test.ts
@@ -463,6 +463,15 @@ ruleTester.run(RULE_NAME, rule, {
       code: `
         import { waitFor } from '@testing-library/react';
         await waitFor(() => {
+          result = render(<App />)
+        })
+      `,
+      errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+    },
+    {
+      code: `
+        import { waitFor } from '@testing-library/react';
+        await waitFor(() => {
           const a = 5,
           { container } = render(<App />)
         })


### PR DESCRIPTION
Closes https://github.com/testing-library/eslint-plugin-testing-library/issues/360

We should decide how we want to release this enhancement. Seems like the discussion is centered around:
a) minor version bump without an option
b) minor version bump with an option, which is off by default

Also, I've noticed this rule is NOT reporting this case. Is that intentional? 🤔 

```
    await waitFor(() => {
      userEvent.click(button) // reported
      const a = userEvent.click(button) // NOT reported
    })
```