### PR TITLE
refactor(no-wait-for-side-effects): simplify `reportSideEffects`

### DIFF
--- a/lib/rules/no-wait-for-side-effects.ts
+++ b/lib/rules/no-wait-for-side-effects.ts
@@ -73,17 +73,12 @@ export default createTestingLibraryRule<Options, MessageIds>({
         return;
       }
 
-      const sideEffectNodes = getSideEffectNodes(node.body);
-      if (sideEffectNodes.length === 0) {
-        return;
-      }
-
-      for (const sideEffectNode of sideEffectNodes) {
+      getSideEffectNodes(node.body).forEach((sideEffectNode) =>
         context.report({
           node: sideEffectNode,
           messageId: 'noSideEffectsWaitFor',
-        });
-      }
+        })
+      );
     }
 
     function reportImplicitReturnSideEffect(node: TSESTree.CallExpression) {


### PR DESCRIPTION
When looking at #363, I saw this part could be simplified