### PR TITLE
chore: prevent stalebot to close issues flagged as bug

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,6 +6,7 @@ daysUntilClose: 7
 exemptLabels:
   - pinned
   - security
+  - bug
 # Label to use when marking an issue as stale
 staleLabel: wontfix
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
The stale bot is trying to close issues flagged as bugs. I think we should prevent this and leave them open until we can handle them.