### PR TITLE
docs: use HTTPS for link to ESLint homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ## Installation
 
-You'll first need to install [ESLint](https://eslint.org/):
+You'll first need to install [ESLint](https://eslint.org):
 
 ```shell
 $ npm install --save-dev eslint

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ## Installation
 
-You'll first need to install [ESLint](http://eslint.org):
+You'll first need to install [ESLint](https://eslint.org/):
 
 ```shell
 $ npm install --save-dev eslint


### PR DESCRIPTION
## Changes:

- Use HTTPS for link to ESLint homepage

## Context:

It's a good idea to use HTTPS where possible.