### PR TITLE
refactor(no-unnecessary-act): simplify `checkNoUnnecessaryActFromBlockStatement`'s `shouldBeReported` assigning

### DIFF
--- a/lib/rules/no-unnecessary-act.ts
+++ b/lib/rules/no-unnecessary-act.ts
@@ -144,9 +144,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
       }
 
       const shouldBeReported = isStrict
-        ? (hasSomeNonTestingLibraryCall(blockStatementNode.body) &&
-            hasTestingLibraryCall(blockStatementNode.body)) ||
-          !hasSomeNonTestingLibraryCall(blockStatementNode.body)
+        ? hasTestingLibraryCall(blockStatementNode.body)
         : !hasSomeNonTestingLibraryCall(blockStatementNode.body);
 
       if (shouldBeReported) {


### PR DESCRIPTION
After some thinking I came to the conclusion that `shouldBeReported` can be simplified