### PR TITLE
chore: create bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,11 +51,11 @@ body:
     validations:
       required: true
 
-- type: textarea
-  id: bug_description
-  attributes:
-    label: Bug description
-    description: "Describe the bug at a high level."
-    placeholder: "I was doing ..., but I expected ..."
-  validations:
-    required: true
+  - type: textarea
+    id: bug_description
+    attributes:
+      label: Bug description
+      description: "Describe the bug at a high level."
+      placeholder: "I was doing ..., but I expected ..."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -89,7 +89,7 @@ body:
   - type: textarea
     id: rule_affected
     attributes:
-      label: Rules(s) affected
+      label: Rule(s) affected
       description: Tell us what `eslint-pluging-testing-library` rule(s) are affected by this bug.
       placeholder: 'Tip: check your `.eslintrc` for rules.'
     validations:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -91,7 +91,7 @@ body:
     attributes:
       label: Rules(s) affected
       description: Tell us what `eslint-pluging-testing-library` rule(s) are affected by this bug.
-      placeholder: TODO ADD EXAMPLE OF A RULE
+      placeholder: Tip: check your `.eslintrc` for rules.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -82,7 +82,7 @@ body:
     attributes:
       label: ESLint configuration
       description: Copy/paste your ESLint configuration into this field.
-      placeholder: Tip: you can find your ESLint configuration in the `.eslintrc` file.
+      placeholder: 'Tip: you can find your ESLint configuration in the `.eslintrc` file.'
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -91,7 +91,7 @@ body:
     attributes:
       label: Rules(s) affected
       description: Tell us what `eslint-pluging-testing-library` rule(s) are affected by this bug.
-      placeholder: Tip: check your `.eslintrc` for rules.
+      placeholder: 'Tip: check your `.eslintrc` for rules.'
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -82,7 +82,7 @@ body:
     attributes:
       label: ESLint configuration
       description: Copy/paste your ESLint configuration into this field.
-      placeholder: You can find your ESLint configuration in these files TODO ADD LIST OF VALID FILENAMES
+      placeholder: Tip: you can find your ESLint configuration in the `.eslintrc` file.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -50,3 +50,12 @@ body:
       placeholder: macOS Big Sur, version 11.4
     validations:
       required: true
+
+- type: textarea
+  id: bug_description
+  attributes:
+    label: Bug description
+    description: "Describe the bug at a high level."
+    placeholder: "I was doing ..., but I expected ..."
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -102,7 +102,7 @@ body:
       description: If there's anything else we need to know, tell us about it here.
       placeholder: By the way, you also need to know about...
     validations:
-      required: true
+      required: false
 
   - type: dropdown
     id: want_to_submit_pr_to_fix_bug

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
     id: plugin_version
     attributes:
       label: Plugin version
-      description: What version of the plugin are you using?
+      description: What version of `eslint-plugin-testing-library` are you using?
       placeholder: v4.10.1
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,52 @@
+name: Bug Report
+description: File a bug report
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: '## User environment'
+
+  - type: input
+    id: plugin_version
+    attributes:
+      label: Plugin version
+      description: What version of the plugin are you using?
+      placeholder: v4.10.1
+    validations:
+      required: true
+
+  - type: input
+    id: eslint_version
+    attributes:
+      label: ESLint version
+      description: What version of ESLint are you using?
+      placeholder: v7.31.0
+    validations:
+      required: true
+
+  - type: input
+    id: node_js_version
+    attributes:
+      label: Node.js version
+      description: What version of Node.js are you using?
+      placeholder: 14.17.3
+    validations:
+      required: true
+ 
+  - type: input
+    id: npm_yarn_version
+    attributes:
+      label: npm/yarn version
+      description: Tell us whether you use npm or yarn as your package manager, and what version.
+      placeholder: npm 6.14.13
+    validations:
+      required: true
+      
+  - type: input
+    id: operating_system
+    attributes:
+      label: Operating system
+      description: Tell us what operating system you use, and what version.
+      placeholder: macOS Big Sur, version 11.4
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,7 +32,7 @@ body:
       placeholder: 14.17.3
     validations:
       required: true
- 
+
   - type: input
     id: npm_yarn_version
     attributes:
@@ -41,7 +41,7 @@ body:
       placeholder: npm 6.14.13
     validations:
       required: true
-      
+
   - type: input
     id: operating_system
     attributes:
@@ -55,7 +55,67 @@ body:
     id: bug_description
     attributes:
       label: Bug description
-      description: "Describe the bug at a high level."
-      placeholder: "I was doing ..., but I expected ..."
+      description: Describe the bug at a high level.
+      placeholder: I was doing ..., but I expected ...
     validations:
       required: true
+
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Give the steps to reproduce the problem
+      placeholder: |
+        1. Go to ...
+        2. Do ....
+        3. See bug
+    validations:
+      required: true
+
+  - type: textarea
+    id: error_output_screenshots
+    attributes:
+      label: Error output/screenshots
+      description: Copy/paste any error messages or helpful screenshots into this field.
+      placeholder: 'Tip: you can copy/paste error messages in here. You can click and drag screenshots into this field.'
+    validations:
+      required: false
+
+  - type: textarea
+    id: eslint_config
+    attributes:
+      label: ESLint configuration
+      description: Copy/paste your ESLint configuration into this field.
+      placeholder: You can find your eslint configuration in these files TODO ADD LIST OF VALID FILENAMES
+    validations:
+      required: true
+
+  - type: textarea
+    id: rule_affected
+    attributes:
+      label: Rules(s) affected
+      description: Tell us what `eslint-pluging-testing-library` rule(s) are affected by this bug.
+      placeholder: TODO ADD EXAMPLE OF A RULE
+    validations:
+      required: true
+
+  - type: textarea
+    id: anything_else
+    attributes:
+      label: Anything else we need to know?
+      description: If there's anything else we need to know, tell us about it!
+      placeholder: Tell us anything else we need to know.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: want_to_submit_pr_to_fix_bug
+    attributes:
+      label: Do you want to submit a pull request to fix this bug?
+      options:
+        - 'Yes'
+        - 'Yes, but need help'
+        - 'No'
+    validations:
+      required: true
+ 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,10 +2,6 @@ name: Bug Report
 description: File a bug report
 labels: [bug]
 body:
-  - type: markdown
-    attributes:
-      value: '## User environment'
-
   - type: input
     id: plugin_version
     attributes:
@@ -64,7 +60,7 @@ body:
     id: steps_to_reproduce
     attributes:
       label: Steps to reproduce
-      description: Give the steps to reproduce the problem
+      description: Give us a ordered list of the steps to reproduce the problem.
       placeholder: |
         1. Go to ...
         2. Do ....
@@ -86,7 +82,7 @@ body:
     attributes:
       label: ESLint configuration
       description: Copy/paste your ESLint configuration into this field.
-      placeholder: You can find your eslint configuration in these files TODO ADD LIST OF VALID FILENAMES
+      placeholder: You can find your ESLint configuration in these files TODO ADD LIST OF VALID FILENAMES
     validations:
       required: true
 
@@ -102,9 +98,9 @@ body:
   - type: textarea
     id: anything_else
     attributes:
-      label: Anything else we need to know?
-      description: If there's anything else we need to know, tell us about it!
-      placeholder: Tell us anything else we need to know.
+      label: Anything else?
+      description: If there's anything else we need to know, tell us about it here.
+      placeholder: By the way, you also need to know about...
     validations:
       required: true
 
@@ -118,4 +114,3 @@ body:
         - 'No'
     validations:
       required: true
- 


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [ ] If some rule is added/updated/removed, I've regenerated the rules list.
- [ ] If some rule meta info is changed, I've regenerated the plugin shared configs.

## Changes

- Create bug report form

## Context

Work in progress.

Go to https://github.com/HonkingGoose/eslint-plugin-testing-library/blob/patch-2/.github/ISSUE_TEMPLATE/bug_report.yml to see a rendered preview of the bug report form.

Helps with issue #400, but doesn't close it as we want forms for other things as well. 😉 

> - Ideally we would have other issue forms to propose a new rule, to request a rule change, or to request a general change.

**GItHub docs for the Issue Form:**

- [Syntax for issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms)
- [Syntax for GitHub's form schema](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema)