### PR TITLE
chore: configure GitHub template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,9 @@
 blank_issues_enabled: false
 contact_links:
+  - name: ESLint
+    url: https://github.com/eslint/eslint/issues
+    about: Report problems with the ESLint program itself to the ESLint project.
+
   - name: Ask a Question, Discuss
     url: https://github.com/testing-library/eslint-plugin-testing-library/discussions
     about: Look for `eslint-plugin-testing-library` Questions and Discussions or start a new one

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: ESLint
-    url: https://github.com/eslint/eslint/issues
-    about: Report problems with the ESLint program itself to the ESLint project.
+  - name: Ask a Question, Discuss
+    url: https://github.com/testing-library/eslint-plugin-testing-library/discussions
+    about: Look for `eslint-plugin-testing-library` Questions and Discussions or start a new one

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: ESLint
     url: https://github.com/eslint/eslint/issues

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: ESLint
+    url: https://github.com/eslint/eslint/issues
+    about: Report problems with the ESLint program itself to the ESLint project.


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [ ] If some rule is added/updated/removed, I've regenerated the rules list.
- [ ] If some rule meta info is changed, I've regenerated the plugin shared configs.

## Changes

<!-- List the changes you're making with this pull request. -->

- Block empty issues
- Redirect issues that should go to upstream ESLint project
- Add link to our discussions page on GitHub

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

Fixes #431.

**EDIT:** Now that I have created the PRs for the Issue Forms, it makes more sense to wait until those 3 Issue Form PRs have been merged into `main`, and then review and merge this PR.