### PR TITLE
chore(devDeps): make `ts-jest`'s version exact

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "lint-staged": "^11.1.2",
     "prettier": "2.3.2",
     "semantic-release": "^17.4.5",
-    "ts-jest": "^27.0.5",
+    "ts-jest": "27.0.5",
     "ts-node": "^10.2.1",
     "typescript": "^4.3.5"
   },


### PR DESCRIPTION
As said in https://github.com/testing-library/eslint-plugin-testing-library/pull/456#issuecomment-903276903, `ts-jest` doesn't apply SemVer, so we should make it an exact version

https://github.com/kulshekhar/ts-jest#versioning