### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,10 +45,10 @@
     "@typescript-eslint/experimental-utils": "^4.30.0"
   },
   "devDependencies": {
-    "@commitlint/cli": "^12.1.4",
-    "@commitlint/config-conventional": "^12.1.4",
+    "@commitlint/cli": "^13.1.0",
+    "@commitlint/config-conventional": "^13.1.0",
     "@types/jest": "^27.0.1",
-    "@types/node": "^10.17.60",
+    "@types/node": "^12.20.23",
     "@typescript-eslint/eslint-plugin": "^4.30.0",
     "@typescript-eslint/parser": "^4.30.0",
     "cpy-cli": "^3.1.1",


### PR DESCRIPTION
As of #463, we can now have dependencies that require Node 12

---

Closes #443
Closes #444
Closes #460