### PR TITLE
feat(no-debug): rename to `no-debugging-utils`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ If you ever need to update a snapshot, you can run `npm run test:update`
 
 Based on [ESLint's Rule Naming Conventions](https://eslint.org/docs/developer-guide/working-with-rules#rule-naming-conventions), you must follow these rules:
 
-- If your rule is disallowing something, prefix it with `no-` such as `no-debug`
+- If your rule is disallowing something, prefix it with `no-` such as `no-debugging-utils`
   for disallowing `debug()`.
 - If your rule is suggesting to prefer a way of doing something, among other ways, you can **optionally** prefix it with
   `prefer-`. For example, `prefer-screen-queries` suggests to use `screen.getByText()` from imported `screen` rather
@@ -57,11 +57,11 @@ Based on [ESLint's Rule Naming Conventions](https://eslint.org/docs/developer-gu
 ## Adding new rules
 
 In the [same way as ESLint](https://eslint.org/docs/developer-guide/working-with-rules),
-each rule has three files named with its identifier (e.g. `no-debug`):
+each rule has three files named with its identifier (e.g. `no-debugging-utils`):
 
-- in the `lib/rules` directory: a source file (e.g. `no-debug.ts`)
-- in the `tests/lib/rules` directory: a test file (e.g. `no-debug.ts`)
-- in the `docs/rules` directory: a Markdown documentation file (e.g. `no-debug.md`)
+- in the `lib/rules` directory: a source file (e.g. `no-debugging-utils.ts`)
+- in the `tests/lib/rules` directory: a test file (e.g. `no-debugging-utils.ts`)
+- in the `docs/rules` directory: a Markdown documentation file (e.g. `no-debugging-utils.md`)
 
 Additionally, you need to do a couple of extra things:
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Then configure the rules you want to use within `rules` property of your `.eslin
   "rules": {
     "testing-library/await-async-query": "error",
     "testing-library/no-await-sync-query": "error",
-    "testing-library/no-debug": "warn",
+    "testing-library/no-debugging-utils": "warn",
     "testing-library/no-dom-import": "off"
   }
 }
@@ -193,7 +193,7 @@ To enable this configuration use the `extends` property in your
 | [`testing-library/no-await-sync-events`](./docs/rules/no-await-sync-events.md)                       | Disallow unnecessary `await` for sync events                                                 |     |                                                                   |
 | [`testing-library/no-await-sync-query`](./docs/rules/no-await-sync-query.md)                         | Disallow unnecessary `await` for sync queries                                                |     | ![dom-badge][] ![angular-badge][] ![react-badge][] ![vue-badge][] |
 | [`testing-library/no-container`](./docs/rules/no-container.md)                                       | Disallow the use of `container` methods                                                      |     | ![angular-badge][] ![react-badge][] ![vue-badge][]                |
-| [`testing-library/no-debug`](./docs/rules/no-debug.md)                                               | Disallow the use of debugging utilities like `debug`                                         |     | ![angular-badge][] ![react-badge][] ![vue-badge][]                |
+| [`testing-library/no-debugging-utils`](./docs/rules/no-debugging-utils.md)                           | Disallow the use of debugging utilities like `debug`                                         |     | ![angular-badge][] ![react-badge][] ![vue-badge][]                |
 | [`testing-library/no-dom-import`](./docs/rules/no-dom-import.md)                                     | Disallow importing from DOM Testing Library                                                  | 🔧  | ![angular-badge][] ![react-badge][] ![vue-badge][]                |
 | [`testing-library/no-manual-cleanup`](./docs/rules/no-manual-cleanup.md)                             | Disallow the use of `cleanup`                                                                |     |                                                                   |
 | [`testing-library/no-node-access`](./docs/rules/no-node-access.md)                                   | Disallow direct Node access                                                                  |     | ![angular-badge][] ![react-badge][] ![vue-badge][]                |

--- a/docs/rules/no-debugging-utils.md
+++ b/docs/rules/no-debugging-utils.md
@@ -1,4 +1,4 @@
-# Disallow the use of debugging utilities like `debug` (`testing-library/no-debug`)
+# Disallow the use of debugging utilities (`testing-library/no-debugging-utils`)
 
 Just like `console.log` statements pollutes the browser's output, debug statements also pollutes the tests if one of your teammates forgot to remove it. `debug` statements should be used when you actually want to debug your tests but should not be pushed to the codebase.
 
@@ -41,7 +41,7 @@ You can control which debugging utils are checked for with the `utilsToCheckFor`
 
 ```json
 {
-  "testing-library/no-debug": [
+  "testing-library/no-debugging-utils": [
     "error",
     {
       "utilsToCheckFor": {

--- a/lib/configs/angular.ts
+++ b/lib/configs/angular.ts
@@ -9,7 +9,7 @@ export = {
     'testing-library/await-async-utils': 'error',
     'testing-library/no-await-sync-query': 'error',
     'testing-library/no-container': 'error',
-    'testing-library/no-debug': 'error',
+    'testing-library/no-debugging-utils': 'error',
     'testing-library/no-dom-import': ['error', 'angular'],
     'testing-library/no-node-access': 'error',
     'testing-library/no-promise-in-fire-event': 'error',

--- a/lib/configs/react.ts
+++ b/lib/configs/react.ts
@@ -9,7 +9,7 @@ export = {
     'testing-library/await-async-utils': 'error',
     'testing-library/no-await-sync-query': 'error',
     'testing-library/no-container': 'error',
-    'testing-library/no-debug': 'error',
+    'testing-library/no-debugging-utils': 'error',
     'testing-library/no-dom-import': ['error', 'react'],
     'testing-library/no-node-access': 'error',
     'testing-library/no-promise-in-fire-event': 'error',

--- a/lib/configs/vue.ts
+++ b/lib/configs/vue.ts
@@ -10,7 +10,7 @@ export = {
     'testing-library/await-fire-event': 'error',
     'testing-library/no-await-sync-query': 'error',
     'testing-library/no-container': 'error',
-    'testing-library/no-debug': 'error',
+    'testing-library/no-debugging-utils': 'error',
     'testing-library/no-dom-import': ['error', 'vue'],
     'testing-library/no-node-access': 'error',
     'testing-library/no-promise-in-fire-event': 'error',

--- a/lib/rules/no-debugging-utils.ts
+++ b/lib/rules/no-debugging-utils.ts
@@ -21,7 +21,7 @@ type DebugUtilsToCheckFor = Partial<
   Record<typeof DEBUG_UTILS[number], boolean>
 >;
 
-export const RULE_NAME = 'no-debug';
+export const RULE_NAME = 'no-debugging-utils';
 export type MessageIds = 'noDebug';
 type Options = [{ utilsToCheckFor?: DebugUtilsToCheckFor }];
 

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -11,7 +11,7 @@ Object {
       "testing-library/await-async-utils": "error",
       "testing-library/no-await-sync-query": "error",
       "testing-library/no-container": "error",
-      "testing-library/no-debug": "error",
+      "testing-library/no-debugging-utils": "error",
       "testing-library/no-dom-import": Array [
         "error",
         "angular",
@@ -47,7 +47,7 @@ Object {
       "testing-library/await-async-utils": "error",
       "testing-library/no-await-sync-query": "error",
       "testing-library/no-container": "error",
-      "testing-library/no-debug": "error",
+      "testing-library/no-debugging-utils": "error",
       "testing-library/no-dom-import": Array [
         "error",
         "react",
@@ -70,7 +70,7 @@ Object {
       "testing-library/await-fire-event": "error",
       "testing-library/no-await-sync-query": "error",
       "testing-library/no-container": "error",
-      "testing-library/no-debug": "error",
+      "testing-library/no-debugging-utils": "error",
       "testing-library/no-dom-import": Array [
         "error",
         "vue",

--- a/tests/lib/rules/no-debugging-utils.test.ts
+++ b/tests/lib/rules/no-debugging-utils.test.ts
@@ -1,4 +1,4 @@
-import rule, { RULE_NAME } from '../../../lib/rules/no-debug';
+import rule, { RULE_NAME } from '../../../lib/rules/no-debugging-utils';
 import { createRuleTester } from '../test-utils';
 
 const ruleTester = createRuleTester();


### PR DESCRIPTION
Closes #467

BREAKING CHANGE: `no-debug` is now called `no-debugging-utils`