### PR TITLE
fix(prefer-explicit-assert): check property existence

### DIFF
--- a/lib/rules/prefer-explicit-assert.ts
+++ b/lib/rules/prefer-explicit-assert.ts
@@ -158,7 +158,17 @@ export default createTestingLibraryRule<Options, MessageIds>({
 
             const expectStatement =
               expectCallNode.parent as TSESTree.MemberExpression;
-            const property = expectStatement.property as TSESTree.Identifier;
+
+            if (!isMemberExpression(expectStatement)) {
+              return;
+            }
+
+            const property = expectStatement.property;
+
+            if (!ASTUtils.isIdentifier(property)) {
+              return;
+            }
+
             let matcher = property.name;
             let isNegatedMatcher = false;
 

--- a/lib/rules/prefer-explicit-assert.ts
+++ b/lib/rules/prefer-explicit-assert.ts
@@ -156,9 +156,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
             const expectCallNode = findClosestCallNode(node, 'expect');
             if (!expectCallNode) return;
 
-            const expectStatement =
-              expectCallNode.parent as TSESTree.MemberExpression;
-
+            const expectStatement = expectCallNode.parent;
             if (!isMemberExpression(expectStatement)) {
               return;
             }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@typescript-eslint/experimental-utils": "^4.30.0"
   },
   "devDependencies": {
+    "@babel/eslint-plugin": "^7.14.5",
     "@commitlint/cli": "^12.1.4",
     "@commitlint/config-conventional": "^12.1.4",
     "@types/jest": "^27.0.1",

--- a/tests/lib/rules/prefer-explicit-assert.test.ts
+++ b/tests/lib/rules/prefer-explicit-assert.test.ts
@@ -167,6 +167,11 @@ ruleTester.run(RULE_NAME, rule, {
     expect('something');
     expect(getByText('foo'));
     `,
+      options: [
+        {
+          assertion: 'toBeInTheDocument',
+        },
+      ],
     },
   ],
   invalid: [

--- a/tests/lib/rules/prefer-explicit-assert.test.ts
+++ b/tests/lib/rules/prefer-explicit-assert.test.ts
@@ -160,6 +160,14 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     })),
+    {
+      // https://github.com/testing-library/eslint-plugin-testing-library/issues/475
+      code: `
+    // incomplete expect statement should be ignored
+    expect('something');
+    expect(getByText('foo'));
+    `,
+    },
   ],
   invalid: [
     ...COMBINED_QUERIES_METHODS.map(


### PR DESCRIPTION
## Checks

- [X] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [ ] If some rule is added/updated/removed, I've regenerated the rules list.
- [ ] If some rule meta info is changed, I've regenerated the plugin shared configs.

## Changes

<!-- List the changes you're making with this pull request. -->

- Check some properties' existence instead of just assuming they always exist.

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->
Fixes #475 