### PR TITLE
Use disjunction to separate allowed render result names

### DIFF
--- a/lib/rules/render-result-naming-convention.ts
+++ b/lib/rules/render-result-naming-convention.ts
@@ -14,9 +14,9 @@ export type MessageIds = 'renderResultNamingConvention';
 type Options = [];
 
 const ALLOWED_VAR_NAMES = ['view', 'utils'];
-const ALLOWED_VAR_NAMES_TEXT = ALLOWED_VAR_NAMES.map(
-  (name) => `\`${name}\``
-).join(', ');
+const ALLOWED_VAR_NAMES_TEXT = ALLOWED_VAR_NAMES.map((name) => `\`${name}\``)
+  .join(', ')
+  .replace(/, ([^,]*)$/, ', or $1');
 
 export default createTestingLibraryRule<Options, MessageIds>({
   name: RULE_NAME,


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [x] If some rule is added/updated/removed, I've regenerated the rules list.
- [x] If some rule meta info is changed, I've regenerated the plugin shared configs.

## Changes

- Use disjunction to separate allowed render result names

## Context

Separate allowed render result names by comma and an "or" before the last one.

Before:
```
`wrapper` is not a recommended name for `render` returned value. Instead, you should destructure it, or name it using one of: `view`, `utils`
```

After:
```
`wrapper` is not a recommended name for `render` returned value. Instead, you should destructure it, or name it using one of: `view`, or `utils`
```

