### PR TITLE
docs(no-unnecessary-act): isStrict is enabled by default

### DIFF
--- a/docs/rules/no-unnecessary-act.md
+++ b/docs/rules/no-unnecessary-act.md
@@ -91,7 +91,7 @@ await act(async () => {
 
 This rule has one option:
 
-- `isStrict`: **disabled by default**. Wrapping both things related and not related to Testing Library in `act` is reported
+- `isStrict`: **enabled by default**. Wrapping both things related and not related to Testing Library in `act` is reported
 
   ```js
   "testing-library/no-unnecessary-act": ["error", {"isStrict": true}]


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [ ] If some rule is added/updated/removed, I've regenerated the rules list.
- [ ] If some rule meta info is changed, I've regenerated the plugin shared configs.

## Changes

Tweak docs to reflect `isStrict` option on `no-unnecessary-act` being enabled by default

## Context

I've noticed https://github.com/testing-library/eslint-plugin-testing-library/pull/479 didn't change docs to reflect default `isStrict` option.
