### PR TITLE
fix(prefer-find-by): fix report with querySelector

### DIFF
--- a/lib/rules/prefer-find-by.ts
+++ b/lib/rules/prefer-find-by.ts
@@ -373,6 +373,10 @@ export default createTestingLibraryRule<Options, MessageIds>({
           const callArguments = getQueryArguments(argument.body);
           const queryMethod = fullQueryMethod.split('By')[1];
 
+          if (!queryMethod) {
+            return;
+          }
+
           reportInvalidUsage(node, {
             queryMethod,
             queryVariant,

--- a/tests/lib/rules/prefer-find-by.test.ts
+++ b/tests/lib/rules/prefer-find-by.test.ts
@@ -149,6 +149,14 @@ ruleTester.run(RULE_NAME, rule, {
         })
       `,
     },
+    {
+      code: `
+        import {screen, waitFor} from '@testing-library/foo';
+        it('tests', async () => {
+          await waitFor(() => expect(screen.querySelector('baz')).toBeInTheDocument());
+        })
+      `,
+    },
   ],
   invalid: [
     ...createScenario((waitMethod: string, queryMethod: string) => ({

--- a/tests/lib/rules/prefer-find-by.test.ts
+++ b/tests/lib/rules/prefer-find-by.test.ts
@@ -157,6 +157,15 @@ ruleTester.run(RULE_NAME, rule, {
         })
       `,
     },
+    {
+      code: `
+        import {waitFor} from '@testing-library/foo';
+        it('tests', async () => {
+          const { container } = render()
+          await waitFor(() => expect(container.querySelector('baz')).toBeInTheDocument());
+        })
+      `,
+    },
   ],
   invalid: [
     ...createScenario((waitMethod: string, queryMethod: string) => ({


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [ ] If some rule is added/updated/removed, I've regenerated the rules list.
- [ ] If some rule meta info is changed, I've regenerated the plugin shared configs.

## Changes

- No longer report invalid usages with a missing query method.
- Add a test covering the code changes.

## Context

Fixes #501
