### PR TITLE
test: wait for async process completion

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,10 +1,12 @@
 import { exec } from 'child_process';
 import { existsSync } from 'fs';
 import { resolve } from 'path';
+import util from 'util';
 
 import plugin from '../lib';
 
-const generateConfigs = () => exec(`npm run generate:configs`);
+const execAsync = util.promisify(exec);
+const generateConfigs = () => execAsync(`npm run generate:configs`);
 
 const numberOfRules = 26;
 const ruleNames = Object.keys(plugin.rules);
@@ -47,11 +49,11 @@ it('should have the correct amount of rules', () => {
 });
 
 it("should have run 'generate:configs' script when changing config rules", async () => {
-  generateConfigs();
+  await generateConfigs();
 
   const allConfigs = plugin.configs;
   expect(allConfigs).toMatchSnapshot();
-});
+}, 20000);
 
 it('should export configs that refer to actual rules', () => {
   const allConfigs = plugin.configs;


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [ ] If some rule is added/updated/removed, I've regenerated the rules list.
- [ ] If some rule meta info is changed, I've regenerated the plugin shared configs.

## Changes

`generateConfigs()` function executes a nodejs [exec] that takes many
seconds to complete. As the test was not waiting for the process to
terminate, Jest was complaining with the following error message:

```
Jest did not exit one second after the test run has completed.

This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
```

Additionally, this test could have a false positive expectation since it
was likely to run the snapshot comparison with previously generated
plugin configurations.

By default Jest tests will timeout if they take longer than 5 seconds to
complete, since this test takes more than 10 seconds to complete on my
local machine, this test timeout configuration has been increased to 20
seconds.

[exec]: https://nodejs.org/api/child_process.html#child_processexeccommand-options-callback