### PR TITLE
fix: move to non-experimental TS-ESLint utils

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,7 +36,7 @@
     "no-restricted-imports": [
       "error",
       {
-        "patterns": ["@typescript-eslint/experimental-utils/dist/*"]
+        "patterns": ["@typescript-eslint/utils/dist/*"]
       }
     ],
 

--- a/lib/configs/index.ts
+++ b/lib/configs/index.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 
-import type { TSESLint } from '@typescript-eslint/experimental-utils';
+import type { TSESLint } from '@typescript-eslint/utils';
 
 import {
   importDefault,

--- a/lib/create-testing-library-rule/detect-testing-library-utils.ts
+++ b/lib/create-testing-library-rule/detect-testing-library-utils.ts
@@ -1,8 +1,4 @@
-import {
-  ASTUtils,
-  TSESLint,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { ASTUtils, TSESLint, TSESTree } from '@typescript-eslint/utils';
 
 import {
   findClosestVariableDeclaratorNode,

--- a/lib/create-testing-library-rule/index.ts
+++ b/lib/create-testing-library-rule/index.ts
@@ -1,4 +1,4 @@
-import { ESLintUtils, TSESLint } from '@typescript-eslint/experimental-utils';
+import { ESLintUtils, TSESLint } from '@typescript-eslint/utils';
 
 import { getDocsUrl, TestingLibraryRuleMeta } from '../utils';
 

--- a/lib/node-utils/index.ts
+++ b/lib/node-utils/index.ts
@@ -4,7 +4,7 @@ import {
   TSESLint,
   TSESLintScope,
   TSESTree,
-} from '@typescript-eslint/experimental-utils';
+} from '@typescript-eslint/utils';
 
 import {
   isArrayExpression,

--- a/lib/node-utils/is-node-of-type.ts
+++ b/lib/node-utils/is-node-of-type.ts
@@ -1,7 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 
 const isNodeOfType =
   <NodeType extends AST_NODE_TYPES>(nodeType: NodeType) =>

--- a/lib/rules/await-async-query.ts
+++ b/lib/rules/await-async-query.ts
@@ -1,4 +1,4 @@
-import { ASTUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { ASTUtils, TSESTree } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {

--- a/lib/rules/await-async-utils.ts
+++ b/lib/rules/await-async-utils.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { TSESTree } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {

--- a/lib/rules/await-fire-event.ts
+++ b/lib/rules/await-fire-event.ts
@@ -1,4 +1,4 @@
-import { ASTUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { ASTUtils, TSESTree } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {

--- a/lib/rules/index.ts
+++ b/lib/rules/index.ts
@@ -1,7 +1,7 @@
 import { readdirSync } from 'fs';
 import { join, parse } from 'path';
 
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 
 import { importDefault, TestingLibraryRuleMeta } from '../utils';
 

--- a/lib/rules/no-await-sync-events.ts
+++ b/lib/rules/no-await-sync-events.ts
@@ -1,4 +1,4 @@
-import { ASTUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { ASTUtils, TSESTree } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {

--- a/lib/rules/no-await-sync-query.ts
+++ b/lib/rules/no-await-sync-query.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { TSESTree } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import { getDeepestIdentifierNode } from '../node-utils';

--- a/lib/rules/no-container.ts
+++ b/lib/rules/no-container.ts
@@ -1,4 +1,4 @@
-import { ASTUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { ASTUtils, TSESTree } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {

--- a/lib/rules/no-debugging-utils.ts
+++ b/lib/rules/no-debugging-utils.ts
@@ -1,8 +1,4 @@
-import {
-  ASTUtils,
-  TSESTree,
-  JSONSchema,
-} from '@typescript-eslint/experimental-utils';
+import { ASTUtils, TSESTree, JSONSchema } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {

--- a/lib/rules/no-dom-import.ts
+++ b/lib/rules/no-dom-import.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { TSESTree } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import { isCallExpression } from '../node-utils';

--- a/lib/rules/no-manual-cleanup.ts
+++ b/lib/rules/no-manual-cleanup.ts
@@ -1,8 +1,4 @@
-import {
-  ASTUtils,
-  TSESTree,
-  TSESLint,
-} from '@typescript-eslint/experimental-utils';
+import { ASTUtils, TSESTree, TSESLint } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {

--- a/lib/rules/no-node-access.ts
+++ b/lib/rules/no-node-access.ts
@@ -1,4 +1,4 @@
-import { TSESTree, ASTUtils } from '@typescript-eslint/experimental-utils';
+import { TSESTree, ASTUtils } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import { ALL_RETURNING_NODES } from '../utils';

--- a/lib/rules/no-promise-in-fire-event.ts
+++ b/lib/rules/no-promise-in-fire-event.ts
@@ -1,4 +1,4 @@
-import { ASTUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { ASTUtils, TSESTree } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {

--- a/lib/rules/no-render-in-setup.ts
+++ b/lib/rules/no-render-in-setup.ts
@@ -1,4 +1,4 @@
-import { ASTUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { ASTUtils, TSESTree } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {

--- a/lib/rules/no-unnecessary-act.ts
+++ b/lib/rules/no-unnecessary-act.ts
@@ -1,4 +1,4 @@
-import { TSESTree, ASTUtils } from '@typescript-eslint/experimental-utils';
+import { TSESTree, ASTUtils } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {

--- a/lib/rules/no-wait-for-empty-callback.ts
+++ b/lib/rules/no-wait-for-empty-callback.ts
@@ -1,4 +1,4 @@
-import { ASTUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { ASTUtils, TSESTree } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {

--- a/lib/rules/no-wait-for-multiple-assertions.ts
+++ b/lib/rules/no-wait-for-multiple-assertions.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { TSESTree } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {

--- a/lib/rules/no-wait-for-side-effects.ts
+++ b/lib/rules/no-wait-for-side-effects.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { TSESTree } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {

--- a/lib/rules/no-wait-for-snapshot.ts
+++ b/lib/rules/no-wait-for-snapshot.ts
@@ -1,4 +1,4 @@
-import { ASTUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { ASTUtils, TSESTree } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {

--- a/lib/rules/prefer-explicit-assert.ts
+++ b/lib/rules/prefer-explicit-assert.ts
@@ -1,4 +1,4 @@
-import { TSESTree, ASTUtils } from '@typescript-eslint/experimental-utils';
+import { TSESTree, ASTUtils } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {

--- a/lib/rules/prefer-find-by.ts
+++ b/lib/rules/prefer-find-by.ts
@@ -1,8 +1,4 @@
-import {
-  TSESTree,
-  ASTUtils,
-  TSESLint,
-} from '@typescript-eslint/experimental-utils';
+import { TSESTree, ASTUtils, TSESLint } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {

--- a/lib/rules/prefer-presence-queries.ts
+++ b/lib/rules/prefer-presence-queries.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { TSESTree } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import { findClosestCallNode, isMemberExpression } from '../node-utils';

--- a/lib/rules/prefer-query-by-disappearance.ts
+++ b/lib/rules/prefer-query-by-disappearance.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { TSESTree } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {

--- a/lib/rules/prefer-screen-queries.ts
+++ b/lib/rules/prefer-screen-queries.ts
@@ -1,4 +1,4 @@
-import { ASTUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { ASTUtils, TSESTree } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {

--- a/lib/rules/prefer-user-event.ts
+++ b/lib/rules/prefer-user-event.ts
@@ -1,4 +1,4 @@
-import { TSESTree, ASTUtils } from '@typescript-eslint/experimental-utils';
+import { TSESTree, ASTUtils } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {

--- a/lib/rules/prefer-wait-for.ts
+++ b/lib/rules/prefer-wait-for.ts
@@ -1,4 +1,4 @@
-import { TSESTree, ASTUtils } from '@typescript-eslint/experimental-utils';
+import { TSESTree, ASTUtils } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {

--- a/lib/rules/render-result-naming-convention.ts
+++ b/lib/rules/render-result-naming-convention.ts
@@ -1,4 +1,4 @@
-import { ASTUtils, TSESTree } from '@typescript-eslint/experimental-utils';
+import { ASTUtils, TSESTree } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {

--- a/lib/utils/types.ts
+++ b/lib/utils/types.ts
@@ -1,10 +1,10 @@
-import type { TSESLint } from '@typescript-eslint/experimental-utils';
+import type { TSESLint } from '@typescript-eslint/utils';
 
 type RecommendedConfig<TOptions extends readonly unknown[]> =
   | TSESLint.RuleMetaDataDocs['recommended']
   | [TSESLint.RuleMetaDataDocs['recommended'], ...TOptions];
 
-// These 2 types are copied from @typescript-eslint/experimental-utils' CreateRuleMeta
+// These 2 types are copied from @typescript-eslint/utils' CreateRuleMeta
 // and modified to our needs
 export type TestingLibraryRuleMetaDocs<TOptions extends readonly unknown[]> =
   Omit<TSESLint.RuleMetaDataDocs, 'recommended' | 'url'> & {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "prepare": "is-ci || husky install"
   },
   "dependencies": {
-    "@typescript-eslint/experimental-utils": "^5.9.0"
+    "@typescript-eslint/utils": "^5.10.2"
   },
   "devDependencies": {
     "@babel/eslint-plugin": "^7.16.5",
@@ -50,8 +50,8 @@
     "@commitlint/config-conventional": "^16.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^16.11.19",
-    "@typescript-eslint/eslint-plugin": "^5.9.0",
-    "@typescript-eslint/parser": "^5.9.0",
+    "@typescript-eslint/eslint-plugin": "^5.10.2",
+    "@typescript-eslint/parser": "^5.10.2",
     "cpy-cli": "^3.1.1",
     "eslint": "^8.6.0",
     "eslint-config-kentcdodds": "^20.0.1",

--- a/tests/fake-rule.ts
+++ b/tests/fake-rule.ts
@@ -2,7 +2,7 @@
  * @file Fake rule to be able to test createTestingLibraryRule and
  * detectTestingLibraryUtils properly
  */
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { TSESTree } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../lib/create-testing-library-rule';
 

--- a/tests/lib/rules/await-async-query.test.ts
+++ b/tests/lib/rules/await-async-query.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 
 import rule, { RULE_NAME } from '../../../lib/rules/await-async-query';
 import {

--- a/tests/lib/rules/consistent-data-testid.test.ts
+++ b/tests/lib/rules/consistent-data-testid.test.ts
@@ -1,4 +1,4 @@
-import type { TSESLint } from '@typescript-eslint/experimental-utils';
+import type { TSESLint } from '@typescript-eslint/utils';
 
 import rule, {
   MessageIds,

--- a/tests/lib/rules/no-unnecessary-act.test.ts
+++ b/tests/lib/rules/no-unnecessary-act.test.ts
@@ -1,4 +1,4 @@
-import type { TSESLint } from '@typescript-eslint/experimental-utils';
+import type { TSESLint } from '@typescript-eslint/utils';
 
 import rule, {
   MessageIds,

--- a/tests/lib/rules/prefer-find-by.test.ts
+++ b/tests/lib/rules/prefer-find-by.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 
 import rule, {
   WAIT_METHODS,

--- a/tests/lib/rules/prefer-presence-queries.test.ts
+++ b/tests/lib/rules/prefer-presence-queries.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 
 import rule, {
   RULE_NAME,

--- a/tests/lib/rules/prefer-user-event.test.ts
+++ b/tests/lib/rules/prefer-user-event.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 
 import rule, {
   MAPPING_TO_USER_EVENT,

--- a/tests/lib/test-utils.ts
+++ b/tests/lib/test-utils.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'path';
 
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 
 const DEFAULT_TEST_CASE_CONFIG = {
   filename: 'MyComponent.test.js',

--- a/tools/generate-configs/utils.ts
+++ b/tools/generate-configs/utils.ts
@@ -1,7 +1,7 @@
 import { writeFileSync } from 'fs';
 import { resolve } from 'path';
 
-import type { TSESLint } from '@typescript-eslint/experimental-utils';
+import type { TSESLint } from '@typescript-eslint/utils';
 import { format, resolveConfig } from 'prettier';
 
 const prettierConfig = resolveConfig.sync(__dirname);


### PR DESCRIPTION
@typescript-eslint has renamed `experimental-utils` to just `utils` in https://github.com/typescript-eslint/typescript-eslint/pull/4172

Some other plugins have already started migrating to the newer name too:
- https://github.com/jest-community/eslint-plugin-jest/pull/1035