### PR TITLE
fix: use `ASTUtils`'s `isNodeOfType` instead of own version

### DIFF
--- a/lib/node-utils/is-node-of-type.ts
+++ b/lib/node-utils/is-node-of-type.ts
@@ -1,48 +1,61 @@
-import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, ASTUtils } from '@typescript-eslint/utils';
 
-const isNodeOfType =
-  <NodeType extends AST_NODE_TYPES>(nodeType: NodeType) =>
-  (
-    node: TSESTree.Node | null | undefined
-  ): node is TSESTree.Node & { type: NodeType } =>
-    node?.type === nodeType;
-
-export const isArrayExpression = isNodeOfType(AST_NODE_TYPES.ArrayExpression);
-export const isArrowFunctionExpression = isNodeOfType(
+export const isArrayExpression = ASTUtils.isNodeOfType(
+  AST_NODE_TYPES.ArrayExpression
+);
+export const isArrowFunctionExpression = ASTUtils.isNodeOfType(
   AST_NODE_TYPES.ArrowFunctionExpression
 );
-export const isBlockStatement = isNodeOfType(AST_NODE_TYPES.BlockStatement);
-export const isCallExpression = isNodeOfType(AST_NODE_TYPES.CallExpression);
-export const isExpressionStatement = isNodeOfType(
+export const isBlockStatement = ASTUtils.isNodeOfType(
+  AST_NODE_TYPES.BlockStatement
+);
+export const isCallExpression = ASTUtils.isNodeOfType(
+  AST_NODE_TYPES.CallExpression
+);
+export const isExpressionStatement = ASTUtils.isNodeOfType(
   AST_NODE_TYPES.ExpressionStatement
 );
-export const isVariableDeclaration = isNodeOfType(
+export const isVariableDeclaration = ASTUtils.isNodeOfType(
   AST_NODE_TYPES.VariableDeclaration
 );
-export const isAssignmentExpression = isNodeOfType(
+export const isAssignmentExpression = ASTUtils.isNodeOfType(
   AST_NODE_TYPES.AssignmentExpression
 );
-export const isSequenceExpression = isNodeOfType(
+export const isSequenceExpression = ASTUtils.isNodeOfType(
   AST_NODE_TYPES.SequenceExpression
 );
-export const isImportDeclaration = isNodeOfType(
+export const isImportDeclaration = ASTUtils.isNodeOfType(
   AST_NODE_TYPES.ImportDeclaration
 );
-export const isImportDefaultSpecifier = isNodeOfType(
+export const isImportDefaultSpecifier = ASTUtils.isNodeOfType(
   AST_NODE_TYPES.ImportDefaultSpecifier
 );
-export const isImportNamespaceSpecifier = isNodeOfType(
+export const isImportNamespaceSpecifier = ASTUtils.isNodeOfType(
   AST_NODE_TYPES.ImportNamespaceSpecifier
 );
-export const isImportSpecifier = isNodeOfType(AST_NODE_TYPES.ImportSpecifier);
-export const isJSXAttribute = isNodeOfType(AST_NODE_TYPES.JSXAttribute);
-export const isLiteral = isNodeOfType(AST_NODE_TYPES.Literal);
-export const isMemberExpression = isNodeOfType(AST_NODE_TYPES.MemberExpression);
-export const isNewExpression = isNodeOfType(AST_NODE_TYPES.NewExpression);
-export const isObjectExpression = isNodeOfType(AST_NODE_TYPES.ObjectExpression);
-export const isObjectPattern = isNodeOfType(AST_NODE_TYPES.ObjectPattern);
-export const isProperty = isNodeOfType(AST_NODE_TYPES.Property);
-export const isReturnStatement = isNodeOfType(AST_NODE_TYPES.ReturnStatement);
-export const isFunctionExpression = isNodeOfType(
+export const isImportSpecifier = ASTUtils.isNodeOfType(
+  AST_NODE_TYPES.ImportSpecifier
+);
+export const isJSXAttribute = ASTUtils.isNodeOfType(
+  AST_NODE_TYPES.JSXAttribute
+);
+export const isLiteral = ASTUtils.isNodeOfType(AST_NODE_TYPES.Literal);
+export const isMemberExpression = ASTUtils.isNodeOfType(
+  AST_NODE_TYPES.MemberExpression
+);
+export const isNewExpression = ASTUtils.isNodeOfType(
+  AST_NODE_TYPES.NewExpression
+);
+export const isObjectExpression = ASTUtils.isNodeOfType(
+  AST_NODE_TYPES.ObjectExpression
+);
+export const isObjectPattern = ASTUtils.isNodeOfType(
+  AST_NODE_TYPES.ObjectPattern
+);
+export const isProperty = ASTUtils.isNodeOfType(AST_NODE_TYPES.Property);
+export const isReturnStatement = ASTUtils.isNodeOfType(
+  AST_NODE_TYPES.ReturnStatement
+);
+export const isFunctionExpression = ASTUtils.isNodeOfType(
   AST_NODE_TYPES.FunctionExpression
 );

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "prepare": "is-ci || husky install"
   },
   "dependencies": {
-    "@typescript-eslint/utils": "^5.10.2"
+    "@typescript-eslint/utils": "^5.13.0"
   },
   "devDependencies": {
     "@babel/eslint-plugin": "^7.16.5",
@@ -50,8 +50,8 @@
     "@commitlint/config-conventional": "^16.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^16.11.19",
-    "@typescript-eslint/eslint-plugin": "^5.10.2",
-    "@typescript-eslint/parser": "^5.10.2",
+    "@typescript-eslint/eslint-plugin": "^5.13.0",
+    "@typescript-eslint/parser": "^5.13.0",
     "cpy-cli": "^3.1.1",
     "eslint": "^8.6.0",
     "eslint-config-kentcdodds": "^20.0.1",


### PR DESCRIPTION
Now that https://github.com/typescript-eslint/typescript-eslint/pull/4503 is merged & released, we can get rid of our own version of `isNodeOfType`