### PR TITLE
feat(prefer-presence-queries): add `absence` & `presence` options

### DIFF
--- a/docs/rules/prefer-presence-queries.md
+++ b/docs/rules/prefer-presence-queries.md
@@ -59,6 +59,27 @@ test('some test', async () => {
 });
 ```
 
+## Options
+
+| Option     | Required | Default | Details                                                                                                                                                      |
+| ---------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `presence` | No       | `true`  | If enabled, this rule will ensure `getBy*` is used to validate whether an element is present. If disabled, `queryBy*` will be accepted for presence queries. |
+| `absence`  | No       | `true`  | If enabled, this rule will ensure `queryBy*` is used to validate whether an element is absent. If disabled, `getBy*` will be accepted for absence queries.   |
+
+## Example
+
+```json
+{
+  "testing-library/prefer-presence-queries": [
+    2,
+    {
+      "presence": true,
+      "absence": false
+    }
+  ]
+}
+```
+
 ## Further Reading
 
 - [Testing Library queries cheatsheet](https://testing-library.com/docs/dom-testing-library/cheatsheet#queries)

--- a/lib/rules/prefer-presence-queries.ts
+++ b/lib/rules/prefer-presence-queries.ts
@@ -5,7 +5,12 @@ import { findClosestCallNode, isMemberExpression } from '../node-utils';
 
 export const RULE_NAME = 'prefer-presence-queries';
 export type MessageIds = 'wrongAbsenceQuery' | 'wrongPresenceQuery';
-type Options = [];
+export type Options = [
+  {
+    presence?: boolean;
+    absence?: boolean;
+  }
+];
 
 export default createTestingLibraryRule<Options, MessageIds>({
   name: RULE_NAME,
@@ -26,12 +31,31 @@ export default createTestingLibraryRule<Options, MessageIds>({
       wrongAbsenceQuery:
         'Use `queryBy*` queries rather than `getBy*` for checking element is NOT present',
     },
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          presence: {
+            type: 'boolean',
+          },
+          absence: {
+            type: 'boolean',
+          },
+        },
+      },
+    ],
     type: 'suggestion',
   },
-  defaultOptions: [],
+  defaultOptions: [
+    {
+      presence: true,
+      absence: true,
+    },
+  ],
 
-  create(context, _, helpers) {
+  create(context, [options], helpers) {
+    const { presence, absence } = options;
     return {
       'CallExpression Identifier'(node: TSESTree.Identifier) {
         const expectCallNode = findClosestCallNode(node, 'expect');
@@ -55,9 +79,9 @@ export default createTestingLibraryRule<Options, MessageIds>({
           return;
         }
 
-        if (isPresenceAssert && !isPresenceQuery) {
+        if (presence && isPresenceAssert && !isPresenceQuery) {
           context.report({ node, messageId: 'wrongPresenceQuery' });
-        } else if (isAbsenceAssert && isPresenceQuery) {
+        } else if (absence && isAbsenceAssert && isPresenceQuery) {
           context.report({ node, messageId: 'wrongAbsenceQuery' });
         }
       },

--- a/lib/rules/prefer-presence-queries.ts
+++ b/lib/rules/prefer-presence-queries.ts
@@ -54,8 +54,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
     },
   ],
 
-  create(context, [options], helpers) {
-    const { presence, absence } = options;
+  create(context, [{ absence = true, presence = true }], helpers) {
     return {
       'CallExpression Identifier'(node: TSESTree.Identifier) {
         const expectCallNode = findClosestCallNode(node, 'expect');


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [x] If some rule is added/updated/removed, I've regenerated the rules list.
- [x] If some rule meta info is changed, I've regenerated the plugin shared configs.

## Changes

<!-- List the changes you're making with this pull request. -->

- Added configuration options to `testing-library/prefer-presence-queries` to enable or disable just the presence/absence checks by themselves;
- I started out trying to implement the check for `within`, but I think I'd have to do a lot more reading about eslint before I can tackle that, whereas this configuration-based change was a lot simpler. I do have a stash with some changes based on that, but I'm unlikely to get to them soon.

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->
Provides a patch for #518 (without entirely fixing it).
