### PR TITLE
fix(no-global-regexp-flag-in-query): check if empty name property node

### DIFF
--- a/lib/rules/no-global-regexp-flag-in-query.ts
+++ b/lib/rules/no-global-regexp-flag-in-query.ts
@@ -96,8 +96,11 @@ export default createTestingLibraryRule<Options, MessageIds>({
               ASTUtils.isIdentifier(p.key) &&
               p.key.name === 'name' &&
               isLiteral(p.value)
-          ) as TSESTree.ObjectLiteralElement & { value: TSESTree.Literal };
-          report(namePropertyNode.value);
+          ) as TSESTree.Property | undefined;
+
+          if (namePropertyNode) {
+            report(namePropertyNode.value);
+          }
         }
       },
     };

--- a/tests/lib/rules/no-global-regexp-flag-in-query.test.ts
+++ b/tests/lib/rules/no-global-regexp-flag-in-query.test.ts
@@ -80,8 +80,7 @@ ruleTester.run(RULE_NAME, rule, {
     `,
 
     // issue #565
-    {
-      code: `
+    `
       import { screen } from "@testing-library/react"
 
       describe("App", () => {
@@ -90,7 +89,6 @@ ruleTester.run(RULE_NAME, rule, {
         })
       })
     `,
-    },
   ],
   invalid: [
     {

--- a/tests/lib/rules/no-global-regexp-flag-in-query.test.ts
+++ b/tests/lib/rules/no-global-regexp-flag-in-query.test.ts
@@ -78,6 +78,19 @@ ruleTester.run(RULE_NAME, rule, {
         const utils = render(<Component/>)
         utils.notAQuery(/hello/i)
     `,
+
+    // issue #565
+    {
+      code: `
+      import { screen } from "@testing-library/react"
+
+      describe("App", () => {
+        test("is rendered", async () => {
+          await screen.findByText("Hello World", { exact: false });
+        })
+      })
+    `,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
## Checks

- [X] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [X] If some rule is added/updated/removed, I've regenerated the rules list.
- [X] If some rule meta info is changed, I've regenerated the plugin shared configs.

## Changes

<!-- List the changes you're making with this pull request. -->

- check if the `namePropertyNode` var exists since it can be `undefined`.

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

Closes #565
