### PR TITLE
fix(no-await-sync-events): define option schema correctly

### DIFF
--- a/lib/rules/no-await-sync-events.ts
+++ b/lib/rules/no-await-sync-events.ts
@@ -40,7 +40,11 @@ export default createTestingLibraryRule<Options, MessageIds>({
         type: 'object',
         properties: {
           eventModules: {
-            enum: VALID_EVENT_MODULES,
+            type: 'array',
+            minItems: 1,
+            items: {
+              enum: VALID_EVENT_MODULES,
+            },
           },
         },
         additionalProperties: false,

--- a/tests/lib/rules/no-await-sync-events.test.ts
+++ b/tests/lib/rules/no-await-sync-events.test.ts
@@ -175,7 +175,7 @@ ruleTester.run(RULE_NAME, rule, {
           await fireEvent.${func}('foo');
         });
       `,
-      options: [{ eventModules: 'user-event' }],
+      options: [{ eventModules: ['user-event'] }],
     })),
 
     // valid tests for user-event when only fire-event set in eventModules
@@ -186,7 +186,7 @@ ruleTester.run(RULE_NAME, rule, {
           await userEvent.${func}('foo');
         });
       `,
-      options: [{ eventModules: 'fire-event' }],
+      options: [{ eventModules: ['fire-event'] }],
     })),
   ],
 
@@ -243,7 +243,7 @@ ruleTester.run(RULE_NAME, rule, {
           await fireEvent.${func}('foo');
         });
       `,
-          options: [{ eventModules: 'fire-event' }],
+          options: [{ eventModules: ['fire-event'] }],
           errors: [
             {
               line: 4,
@@ -265,7 +265,7 @@ ruleTester.run(RULE_NAME, rule, {
           await userEvent.${func}('foo');
         });
       `,
-          options: [{ eventModules: 'user-event' }],
+          options: [{ eventModules: ['user-event'] }],
           errors: [
             {
               line: 4,


### PR DESCRIPTION
## Checks

- [X] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [X] If some rule is added/updated/removed, I've regenerated the rules list.
- [X] If some rule meta info is changed, I've regenerated the plugin shared configs.

## Changes

<!-- List the changes you're making with this pull request. -->

- Define `eventModules` option schema correctly (array of enum instead of just enum)

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

Relates to https://github.com/testing-library/eslint-plugin-testing-library/pull/569#discussion_r847850631
