### PR TITLE
test: refactor `@marko/testing-library` tests

### DIFF
--- a/tests/create-testing-library-rule.test.ts
+++ b/tests/create-testing-library-rule.test.ts
@@ -442,40 +442,26 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     },
-    {
-      code: `
+    ...['@testing-library/react', '@marko/testing-library'].map(
+      (testingFramework) =>
+        ({
+          code: `
       // case: render imported from Testing Library module
-      import { render } from '@testing-library/react'
+      import { render } from '${testingFramework}'
       import { somethingElse } from 'another-module'
       const foo = require('bar')
 
       const utils = render();
       `,
-      errors: [
-        {
-          line: 7,
-          column: 21,
-          messageId: 'renderError',
-        },
-      ],
-    },
-    {
-      code: `
-      // case: render imported from Testing Library module
-      import { render } from '@marko/testing-library'
-      import { somethingElse } from 'another-module'
-      const foo = require('bar')
-
-      const utils = render();
-      `,
-      errors: [
-        {
-          line: 7,
-          column: 21,
-          messageId: 'renderError',
-        },
-      ],
-    },
+          errors: [
+            {
+              line: 7,
+              column: 21,
+              messageId: 'renderError',
+            },
+          ],
+        } as const)
+    ),
     {
       code: `
       // case: render imported from Testing Library module (require version)

--- a/tests/lib/rules/await-async-query.test.ts
+++ b/tests/lib/rules/await-async-query.test.ts
@@ -11,6 +11,11 @@ import { createRuleTester } from '../test-utils';
 
 const ruleTester = createRuleTester();
 
+const SUPPORTED_TESTING_FRAMEWORKS = [
+  '@testing-library/react',
+  '@marko/testing-library',
+];
+
 interface TestCode {
   code: string;
   isAsync?: boolean;
@@ -325,33 +330,21 @@ ruleTester.run(RULE_NAME, rule, {
   ],
 
   invalid: [
-    ...ALL_ASYNC_COMBINATIONS_TO_TEST.map(
-      (query) =>
-        ({
-          code: `// async queries without await operator or then method are not valid
-      import { render } from '@testing-library/react'
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) =>
+      ALL_ASYNC_COMBINATIONS_TO_TEST.map(
+        (query) =>
+          ({
+            code: `// async queries without await operator or then method are not valid
+      import { render } from '${testingFramework}'
 
       test("An example test", async () => {
         doSomething()
         const foo = ${query}('foo')
       });
       `,
-          errors: [{ messageId: 'awaitAsyncQuery', line: 6, column: 21 }],
-        } as const)
-    ),
-    ...ALL_ASYNC_COMBINATIONS_TO_TEST.map(
-      (query) =>
-        ({
-          code: `// async queries for @marko/testing-library without await operator or then method are not valid
-      import { render } from '@marko/testing-library'
-
-      test("An example test", async () => {
-        doSomething()
-        const foo = ${query}('foo')
-      });
-      `,
-          errors: [{ messageId: 'awaitAsyncQuery', line: 6, column: 21 }],
-        } as const)
+            errors: [{ messageId: 'awaitAsyncQuery', line: 6, column: 21 }],
+          } as const)
+      )
     ),
     ...ALL_ASYNC_COMBINATIONS_TO_TEST.map(
       (query) =>

--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -4,21 +4,25 @@ import { createRuleTester } from '../test-utils';
 
 const ruleTester = createRuleTester();
 
+const SUPPORTED_TESTING_FRAMEWORKS = [
+  '@testing-library/dom',
+  '@marko/testing-library',
+];
+
 ruleTester.run(RULE_NAME, rule, {
-  valid: [
+  valid: SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
+        import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util directly waited with await operator is valid', async () => {
           doSomethingElse();
           await ${asyncUtil}(() => getByLabelText('email'));
         });
       `,
     })),
-
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
+        import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util promise saved in var and waited with await operator is valid', async () => {
           doSomethingElse();
           const aPromise = ${asyncUtil}(() => getByLabelText('email'));
@@ -26,20 +30,18 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
     })),
-
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
+        import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util directly chained with then is valid', () => {
           doSomethingElse();
           ${asyncUtil}(() => getByLabelText('email')).then(() => { console.log('done') });
         });
       `,
     })),
-
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
+        import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util promise saved in var and chained with then is valid', () => {
           doSomethingElse();
           const aPromise = ${asyncUtil}(() => getByLabelText('email'));
@@ -47,10 +49,9 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
     })),
-
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
+        import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util directly returned in arrow function is valid', async () => {
           const makeCustomWait = () =>
             ${asyncUtil}(() =>
@@ -59,10 +60,9 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
     })),
-
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
+        import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util explicitly returned in arrow function is valid', async () => {
           const makeCustomWait = () => {
             return ${asyncUtil}(() =>
@@ -72,10 +72,9 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
     })),
-
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
+        import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util returned in regular function is valid', async () => {
           function makeCustomWait() {
             return ${asyncUtil}(() =>
@@ -85,10 +84,9 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
     })),
-
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
+        import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util promise saved in var and returned in function is valid', async () => {
           const makeCustomWait = () => {
             const aPromise =  ${asyncUtil}(() =>
@@ -132,7 +130,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
+        import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util used in with Promise.all() is valid', async () => {
           await Promise.all([
             ${asyncUtil}(callback1),
@@ -143,7 +141,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
+        import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util used in with Promise.all() with an await is valid', async () => {
           await Promise.all([
             await ${asyncUtil}(callback1),
@@ -154,7 +152,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
+        import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util used in with Promise.all() with ".then" is valid', async () => {
           Promise.all([
             ${asyncUtil}(callback1),
@@ -165,7 +163,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       code: `
-        import { waitFor, waitForElementToBeRemoved } from '@testing-library/dom';
+        import { waitFor, waitForElementToBeRemoved } from '${testingFramework}';
         test('combining different async methods with Promise.all does not throw an error', async () => {
           await Promise.all([
             waitFor(() => getByLabelText('email')),
@@ -176,7 +174,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { waitForElementToBeRemoved } from '@testing-library/dom';
+        import { waitForElementToBeRemoved } from '${testingFramework}';
         test('waitForElementToBeRemoved receiving element rather than callback is valid', async () => {
           doSomethingElse();
           const emailInput = getByLabelText('email');
@@ -186,7 +184,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
+        import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util used in Promise.allSettled + await expression is valid', async () => {
           await Promise.allSettled([
             ${asyncUtil}(callback1),
@@ -197,7 +195,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
+        import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util used in Promise.allSettled + then method is valid', async () => {
           Promise.allSettled([
             ${asyncUtil}(callback1),
@@ -208,7 +206,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...ASYNC_UTILS.map((asyncUtil) => ({
       code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
+        import { ${asyncUtil} } from '${testingFramework}';
         
         function waitForSomethingAsync() {
           return ${asyncUtil}(() => somethingAsync())
@@ -230,23 +228,24 @@ ruleTester.run(RULE_NAME, rule, {
       })
       `,
     },
-
-    // edge case for coverage
-    // valid async query usage without any function defined
-    // so there is no innermost function scope found
-    `
-    import { waitFor } from '@testing-library/dom';
-    test('edge case for no innermost function scope', () => {
-      const foo = waitFor
-    })
-    `,
-  ],
-  invalid: [
+    {
+      // edge case for coverage
+      // valid async query usage without any function defined
+      // so there is no innermost function scope found
+      code: `
+        import { waitFor } from '${testingFramework}';
+        test('edge case for no innermost function scope', () => {
+          const foo = waitFor
+        })
+      `,
+    },
+  ]),
+  invalid: SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
     ...ASYNC_UTILS.map(
       (asyncUtil) =>
         ({
           code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
+        import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util not waited is invalid', () => {
           doSomethingElse();
           ${asyncUtil}(() => getByLabelText('email'));
@@ -266,7 +265,7 @@ ruleTester.run(RULE_NAME, rule, {
       (asyncUtil) =>
         ({
           code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
+        import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util not waited is invalid', () => {
           doSomethingElse();
           const el = ${asyncUtil}(() => getByLabelText('email'));
@@ -286,7 +285,7 @@ ruleTester.run(RULE_NAME, rule, {
       (asyncUtil) =>
         ({
           code: `
-        import * as asyncUtil from '@testing-library/dom';
+        import * as asyncUtil from '${testingFramework}';
         test('asyncUtil.${asyncUtil} util not handled is invalid', () => {
           doSomethingElse();
           asyncUtil.${asyncUtil}(() => getByLabelText('email'));
@@ -306,7 +305,7 @@ ruleTester.run(RULE_NAME, rule, {
       (asyncUtil) =>
         ({
           code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
+        import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util promise saved not handled is invalid', () => {
           doSomethingElse();
           const aPromise = ${asyncUtil}(() => getByLabelText('email'));
@@ -326,7 +325,7 @@ ruleTester.run(RULE_NAME, rule, {
       (asyncUtil) =>
         ({
           code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
+        import { ${asyncUtil} } from '${testingFramework}';
         test('several ${asyncUtil} utils not handled are invalid', () => {
           const aPromise = ${asyncUtil}(() => getByLabelText('username'));
           doSomethingElse(aPromise);
@@ -353,7 +352,7 @@ ruleTester.run(RULE_NAME, rule, {
       (asyncUtil) =>
         ({
           code: `
-        import { ${asyncUtil}, render } from '@testing-library/dom';
+        import { ${asyncUtil}, render } from '${testingFramework}';
         
         function waitForSomethingAsync() {
           return ${asyncUtil}(() => somethingAsync())
@@ -400,7 +399,7 @@ ruleTester.run(RULE_NAME, rule, {
       (asyncUtil) =>
         ({
           code: `
-        import { ${asyncUtil}, render } from '@testing-library/dom';
+        import { ${asyncUtil}, render } from '${testingFramework}';
         
         function waitForSomethingAsync() {
           return ${asyncUtil}(() => somethingAsync())
@@ -443,5 +442,5 @@ ruleTester.run(RULE_NAME, rule, {
           ],
         } as const)
     ),
-  ],
+  ]),
 });

--- a/tests/lib/rules/await-fire-event.test.ts
+++ b/tests/lib/rules/await-fire-event.test.ts
@@ -10,148 +10,148 @@ const COMMON_FIRE_EVENT_METHODS: string[] = [
   'blur',
   'keyDown',
 ];
+const SUPPORTED_TESTING_FRAMEWORKS = [
+  '@testing-library/vue',
+  '@marko/testing-library',
+];
 
 ruleTester.run(RULE_NAME, rule, {
-  valid: [
+  valid: SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
     ...COMMON_FIRE_EVENT_METHODS.map((fireEventMethod) => ({
       code: `
-      import { fireEvent } from '@testing-library/vue'
-      test('fire event method not called is valid', () => {
-        fireEvent.${fireEventMethod}
-      })
-      `,
-    })),
-    ...COMMON_FIRE_EVENT_METHODS.map((fireEventMethod) => ({
-      code: `
-      import { fireEvent } from '@testing-library/vue'
-      test('await promise from fire event method is valid', async () => {
-        await fireEvent.${fireEventMethod}(getByLabelText('username'))
-      })
-      `,
-    })),
-    ...COMMON_FIRE_EVENT_METHODS.map((fireEventMethod) => ({
-      code: `
-      import { fireEvent } from '@marko/testing-library'
-      test('await promise from fire event method is valid', async () => {
-        await fireEvent.${fireEventMethod}(getByLabelText('username'))
-      })
-      `,
-    })),
-    ...COMMON_FIRE_EVENT_METHODS.map((fireEventMethod) => ({
-      code: `
-      import { fireEvent } from '@testing-library/vue'
-      test('await several promises from fire event methods is valid', async () => {
-        await fireEvent.${fireEventMethod}(getByLabelText('username'))
-        await fireEvent.${fireEventMethod}(getByLabelText('username'))
-      })
-      `,
-    })),
-    ...COMMON_FIRE_EVENT_METHODS.map((fireEventMethod) => ({
-      code: `
-      import { fireEvent } from '@testing-library/vue'
-      test('await promise kept in a var from fire event method is valid', async () => {
-        const promise = fireEvent.${fireEventMethod}(getByLabelText('username'))
-        await promise
-      })
-      `,
-    })),
-    ...COMMON_FIRE_EVENT_METHODS.map((fireEventMethod) => ({
-      code: `
-      import { fireEvent } from '@testing-library/vue'
-      test('chain then method to promise from fire event method is valid', async (done) => {
-        fireEvent.${fireEventMethod}(getByLabelText('username'))
-          .then(() => { done() })
-      })
-      `,
-    })),
-    ...COMMON_FIRE_EVENT_METHODS.map((fireEventMethod) => ({
-      code: `
-      import { fireEvent } from '@testing-library/vue'
-      test('chain then method to several promises from fire event methods is valid', async (done) => {
-        fireEvent.${fireEventMethod}(getByLabelText('username')).then(() => {
-          fireEvent.${fireEventMethod}(getByLabelText('username')).then(() => { done() })
+        import { fireEvent } from '${testingFramework}'
+        test('fire event method not called is valid', () => {
+          fireEvent.${fireEventMethod}
         })
-      })
-      `,
-    })),
-    `import { fireEvent } from '@testing-library/vue'
-
-    test('fireEvent methods wrapped with Promise.all are valid', async () => {
-      await Promise.all([
-        fireEvent.blur(getByText('Click me')),
-        fireEvent.click(getByText('Click me')),
-      ])
-    })
-    `,
-    ...COMMON_FIRE_EVENT_METHODS.map((fireEventMethod) => ({
-      code: `
-      import { fireEvent } from '@testing-library/vue'
-      test('return promise from fire event methods is valid', () => {
-        function triggerEvent() {
-          doSomething()
-          return fireEvent.${fireEventMethod}(getByLabelText('username'))
-        }
-      })
-      `,
+        `,
     })),
     ...COMMON_FIRE_EVENT_METHODS.map((fireEventMethod) => ({
       code: `
-      import { fireEvent } from '@testing-library/vue'
-      test('await promise returned from function wrapping fire event method is valid', () => {
-        function triggerEvent() {
-          doSomething()
-          return fireEvent.${fireEventMethod}(getByLabelText('username'))
-        }
-
-        await triggerEvent()
-      })
-      `,
+        import { fireEvent } from '${testingFramework}'
+        test('await promise from fire event method is valid', async () => {
+          await fireEvent.${fireEventMethod}(getByLabelText('username'))
+        })
+        `,
+    })),
+    ...COMMON_FIRE_EVENT_METHODS.map((fireEventMethod) => ({
+      code: `
+        import { fireEvent } from '${testingFramework}'
+        test('await several promises from fire event methods is valid', async () => {
+          await fireEvent.${fireEventMethod}(getByLabelText('username'))
+          await fireEvent.${fireEventMethod}(getByLabelText('username'))
+        })
+        `,
+    })),
+    ...COMMON_FIRE_EVENT_METHODS.map((fireEventMethod) => ({
+      code: `
+        import { fireEvent } from '${testingFramework}'
+        test('await promise kept in a var from fire event method is valid', async () => {
+          const promise = fireEvent.${fireEventMethod}(getByLabelText('username'))
+          await promise
+        })
+        `,
+    })),
+    ...COMMON_FIRE_EVENT_METHODS.map((fireEventMethod) => ({
+      code: `
+        import { fireEvent } from '${testingFramework}'
+        test('chain then method to promise from fire event method is valid', async (done) => {
+          fireEvent.${fireEventMethod}(getByLabelText('username'))
+            .then(() => { done() })
+        })
+        `,
+    })),
+    ...COMMON_FIRE_EVENT_METHODS.map((fireEventMethod) => ({
+      code: `
+        import { fireEvent } from '${testingFramework}'
+        test('chain then method to several promises from fire event methods is valid', async (done) => {
+          fireEvent.${fireEventMethod}(getByLabelText('username')).then(() => {
+            fireEvent.${fireEventMethod}(getByLabelText('username')).then(() => { done() })
+          })
+        })
+        `,
+    })),
+    {
+      code: `
+        import { fireEvent } from '${testingFramework}'
+        test('fireEvent methods wrapped with Promise.all are valid', async () => {
+          await Promise.all([
+            fireEvent.blur(getByText('Click me')),
+            fireEvent.click(getByText('Click me')),
+          ])
+        })
+        `,
+    },
+    ...COMMON_FIRE_EVENT_METHODS.map((fireEventMethod) => ({
+      code: `
+        import { fireEvent } from '${testingFramework}'
+        test('return promise from fire event methods is valid', () => {
+          function triggerEvent() {
+            doSomething()
+            return fireEvent.${fireEventMethod}(getByLabelText('username'))
+          }
+        })
+        `,
+    })),
+    ...COMMON_FIRE_EVENT_METHODS.map((fireEventMethod) => ({
+      code: `
+        import { fireEvent } from '${testingFramework}'
+        test('await promise returned from function wrapping fire event method is valid', () => {
+          function triggerEvent() {
+            doSomething()
+            return fireEvent.${fireEventMethod}(getByLabelText('username'))
+          }
+  
+          await triggerEvent()
+        })
+        `,
     })),
     ...COMMON_FIRE_EVENT_METHODS.map((fireEventMethod) => ({
       settings: {
         'testing-library/utils-module': 'test-utils',
       },
       code: `
-      import { fireEvent } from 'somewhere-else'
-      test('unhandled promise from fire event not related to TL is valid', async () => {
-        fireEvent.${fireEventMethod}(getByLabelText('username'))
-      })
-      `,
+        import { fireEvent } from 'somewhere-else'
+        test('unhandled promise from fire event not related to TL is valid', async () => {
+          fireEvent.${fireEventMethod}(getByLabelText('username'))
+        })
+        `,
     })),
     ...COMMON_FIRE_EVENT_METHODS.map((fireEventMethod) => ({
       settings: {
         'testing-library/utils-module': 'test-utils',
       },
       code: `
-      import { fireEvent } from 'test-utils'
-      test('await promise from fire event method imported from custom module is valid', async () => {
-        await fireEvent.${fireEventMethod}(getByLabelText('username'))
-      })
-      `,
+        import { fireEvent } from 'test-utils'
+        test('await promise from fire event method imported from custom module is valid', async () => {
+          await fireEvent.${fireEventMethod}(getByLabelText('username'))
+        })
+        `,
     })),
 
-    // edge case for coverage:
-    // valid use case without call expression
-    // so there is no innermost function scope found
-    `
-    import { fireEvent } from 'test-utils'
-    test('edge case for innermost function without call expression', async () => {
-      function triggerEvent() {
-          doSomething()
-          return fireEvent.focus(getByLabelText('username'))
-        }
+    {
+      // edge case for coverage:
+      // valid use case without call expression
+      // so there is no innermost function scope found
+      code: `
+        import { fireEvent } from 'test-utils'
+        test('edge case for innermost function without call expression', async () => {
+          function triggerEvent() {
+              doSomething()
+              return fireEvent.focus(getByLabelText('username'))
+            }
+    
+          const reassignedFunction = triggerEvent
+        })
+        `,
+    },
+  ]),
 
-      const reassignedFunction = triggerEvent
-    })
-    `,
-  ],
-
-  invalid: [
+  invalid: SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
     ...COMMON_FIRE_EVENT_METHODS.map(
       (fireEventMethod) =>
         ({
           code: `
-      import { fireEvent } from '@testing-library/vue'
+      import { fireEvent } from '${testingFramework}'
       test('unhandled promise from fire event method is invalid', async () => {
         fireEvent.${fireEventMethod}(getByLabelText('username'))
       })
@@ -171,27 +171,7 @@ ruleTester.run(RULE_NAME, rule, {
       (fireEventMethod) =>
         ({
           code: `
-      import { fireEvent } from '@marko/testing-library'
-      test('unhandled promise from fire event method is invalid', async () => {
-        fireEvent.${fireEventMethod}(getByLabelText('username'))
-      })
-      `,
-          errors: [
-            {
-              line: 4,
-              column: 9,
-              endColumn: 19 + fireEventMethod.length,
-              messageId: 'awaitFireEvent',
-              data: { name: fireEventMethod },
-            },
-          ],
-        } as const)
-    ),
-    ...COMMON_FIRE_EVENT_METHODS.map(
-      (fireEventMethod) =>
-        ({
-          code: `
-      import { fireEvent as testingLibraryFireEvent } from '@testing-library/vue'
+      import { fireEvent as testingLibraryFireEvent } from '${testingFramework}'
       test('unhandled promise from aliased fire event method is invalid', async () => {
         testingLibraryFireEvent.${fireEventMethod}(getByLabelText('username'))
       })
@@ -211,7 +191,7 @@ ruleTester.run(RULE_NAME, rule, {
       (fireEventMethod) =>
         ({
           code: `
-      import * as testingLibrary from '@testing-library/vue'
+      import * as testingLibrary from '${testingFramework}'
       test('unhandled promise from wildcard imported fire event method is invalid', async () => {
         testingLibrary.fireEvent.${fireEventMethod}(getByLabelText('username'))
       })
@@ -231,7 +211,7 @@ ruleTester.run(RULE_NAME, rule, {
       (fireEventMethod) =>
         ({
           code: `
-      import { fireEvent } from '@testing-library/vue'
+      import { fireEvent } from '${testingFramework}'
       test('several unhandled promises from fire event methods is invalid', async () => {
         fireEvent.${fireEventMethod}(getByLabelText('username'))
         fireEvent.${fireEventMethod}(getByLabelText('username'))
@@ -260,7 +240,7 @@ ruleTester.run(RULE_NAME, rule, {
             'testing-library/utils-module': 'test-utils',
           },
           code: `
-      import { fireEvent } from '@testing-library/vue'
+      import { fireEvent } from '${testingFramework}'
       test('unhandled promise from fire event method with aggressive reporting opted-out is invalid', async () => {
         fireEvent.${fireEventMethod}(getByLabelText('username'))
       })
@@ -306,7 +286,7 @@ ruleTester.run(RULE_NAME, rule, {
             'testing-library/utils-module': 'test-utils',
           },
           code: `
-      import { fireEvent } from '@testing-library/vue'
+      import { fireEvent } from '${testingFramework}'
       test(
       'unhandled promise from fire event method imported from default module with aggressive reporting opted-out is invalid',
       () => {
@@ -328,7 +308,7 @@ ruleTester.run(RULE_NAME, rule, {
       (fireEventMethod) =>
         ({
           code: `
-      import { fireEvent } from '@testing-library/vue'
+      import { fireEvent } from '${testingFramework}'
       test(
       'unhandled promise from fire event method kept in a var is invalid',
       () => {
@@ -349,7 +329,7 @@ ruleTester.run(RULE_NAME, rule, {
       (fireEventMethod) =>
         ({
           code: `
-      import { fireEvent } from '@testing-library/vue'
+      import { fireEvent } from '${testingFramework}'
       test('unhandled promise returned from function wrapping fire event method is invalid', () => {
         function triggerEvent() {
           doSomething()
@@ -369,5 +349,5 @@ ruleTester.run(RULE_NAME, rule, {
           ],
         } as const)
     ),
-  ],
+  ]),
 });

--- a/tests/lib/rules/no-await-sync-query.test.ts
+++ b/tests/lib/rules/no-await-sync-query.test.ts
@@ -7,6 +7,11 @@ import { createRuleTester } from '../test-utils';
 
 const ruleTester = createRuleTester();
 
+const SUPPORTED_TESTING_FRAMEWORKS = [
+  '@testing-library/react',
+  '@marko/testing-library',
+];
+
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     // sync queries without await are valid
@@ -225,28 +230,19 @@ ruleTester.run(RULE_NAME, rule, {
 
     // sync query awaited and related to testing library module
     // with custom module setting is not valid
-    {
-      settings: { 'testing-library/utils-module': 'test-utils' },
-      code: `
-      import { screen } from '@testing-library/react'
+    ...SUPPORTED_TESTING_FRAMEWORKS.map(
+      (testingFramework) =>
+        ({
+          settings: { 'testing-library/utils-module': 'test-utils' },
+          code: `
+      import { screen } from '${testingFramework}'
       () => {
         const element = await screen.getByRole('button')
       }
       `,
-      errors: [{ messageId: 'noAwaitSyncQuery', line: 4, column: 38 }],
-    },
-    // sync query awaited and related to testing library module
-    // with custom module setting is not valid
-    {
-      settings: { 'testing-library/utils-module': 'test-utils' },
-      code: `
-      import { screen } from '@marko/testing-library'
-      () => {
-        const element = await screen.getByRole('button')
-      }
-      `,
-      errors: [{ messageId: 'noAwaitSyncQuery', line: 4, column: 38 }],
-    },
+          errors: [{ messageId: 'noAwaitSyncQuery', line: 4, column: 38 }],
+        } as const)
+    ),
     // sync query awaited and related to custom module is not valid
     {
       settings: { 'testing-library/utils-module': 'test-utils' },

--- a/tests/lib/rules/no-container.test.ts
+++ b/tests/lib/rules/no-container.test.ts
@@ -3,6 +3,11 @@ import { createRuleTester } from '../test-utils';
 
 const ruleTester = createRuleTester();
 
+const SUPPORTED_TESTING_FRAMEWORKS = [
+  '@testing-library/react',
+  '@marko/testing-library',
+];
+
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     {
@@ -48,24 +53,18 @@ ruleTester.run(RULE_NAME, rule, {
         expect(firstChild).toBeDefined();
       `,
     },
-    {
-      settings: { 'testing-library/utils-module': 'test-utils' },
-      code: `
-        import { render as renamed } from '@testing-library/react'
-        import { render } from 'somewhere-else'
-        const { container } = render(<Example />);
-        const button = container.querySelector('.btn-primary');
-      `,
-    },
-    {
-      settings: { 'testing-library/utils-module': 'test-utils' },
-      code: `
-        import { render as renamed } from '@marko/testing-library'
-        import { render } from 'somewhere-else'
-        const { container } = render(<Example />);
-        const button = container.querySelector('.btn-primary');
-      `,
-    },
+    ...SUPPORTED_TESTING_FRAMEWORKS.map(
+      (testingFramework) =>
+        ({
+          settings: { 'testing-library/utils-module': 'test-utils' },
+          code: `
+          import { render as renamed } from '${testingFramework}'
+          import { render } from 'somewhere-else'
+          const { container } = render(<Example />);
+          const button = container.querySelector('.btn-primary');
+        `,
+        } as const)
+    ),
     {
       settings: {
         'testing-library/custom-renders': ['customRender', 'renderWithRedux'],
@@ -106,57 +105,45 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     },
-    {
-      settings: { 'testing-library/utils-module': 'test-utils' },
-      code: `
-        import { render as testingRender } from '@testing-library/react'
+    ...SUPPORTED_TESTING_FRAMEWORKS.map(
+      (testingFramework) =>
+        ({
+          settings: { 'testing-library/utils-module': 'test-utils' },
+          code: `
+        import { render as testingRender } from '${testingFramework}'
         const { container: renamed } = testingRender(<Example />);
         const button = renamed.querySelector('.btn-primary');
       `,
-      errors: [
-        {
-          line: 4,
-          column: 24,
-          messageId: 'noContainer',
-        },
-      ],
-    },
-    {
-      settings: { 'testing-library/utils-module': 'test-utils' },
-      code: `
-        import { render } from '@testing-library/react'
+          errors: [
+            {
+              line: 4,
+              column: 24,
+              messageId: 'noContainer',
+            },
+          ],
+        } as const)
+    ),
+    ...SUPPORTED_TESTING_FRAMEWORKS.map(
+      (testingFramework) =>
+        ({
+          settings: { 'testing-library/utils-module': 'test-utils' },
+          code: `
+        import { render } from '${testingFramework}'
 
         const setup = () => render(<Example />)
 
         const { container } = setup()
         const button = container.querySelector('.btn-primary');
       `,
-      errors: [
-        {
-          line: 7,
-          column: 24,
-          messageId: 'noContainer',
-        },
-      ],
-    },
-    {
-      settings: { 'testing-library/utils-module': 'test-utils' },
-      code: `
-        import { render } from '@marko/testing-library'
-
-        const setup = () => render(<Example />)
-
-        const { container } = setup()
-        const button = container.querySelector('.btn-primary');
-      `,
-      errors: [
-        {
-          line: 7,
-          column: 24,
-          messageId: 'noContainer',
-        },
-      ],
-    },
+          errors: [
+            {
+              line: 7,
+              column: 24,
+              messageId: 'noContainer',
+            },
+          ],
+        } as const)
+    ),
     {
       code: `
         const { container } = render(<Example />);
@@ -209,21 +196,24 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     },
-    {
-      settings: { 'testing-library/utils-module': 'test-utils' },
-      code: `
-        import { render } from '@testing-library/react'
+    ...SUPPORTED_TESTING_FRAMEWORKS.map(
+      (testingFramework) =>
+        ({
+          settings: { 'testing-library/utils-module': 'test-utils' },
+          code: `
+        import { render } from '${testingFramework}'
         const { container: { querySelector } } = render(<Example />);
         querySelector('foo');
       `,
-      errors: [
-        {
-          line: 4,
-          column: 9,
-          messageId: 'noContainer',
-        },
-      ],
-    },
+          errors: [
+            {
+              line: 4,
+              column: 9,
+              messageId: 'noContainer',
+            },
+          ],
+        } as const)
+    ),
     {
       settings: {
         'testing-library/custom-renders': ['customRender', 'renderWithRedux'],

--- a/tests/lib/rules/no-debugging-utils.test.ts
+++ b/tests/lib/rules/no-debugging-utils.test.ts
@@ -3,6 +3,11 @@ import { createRuleTester } from '../test-utils';
 
 const ruleTester = createRuleTester();
 
+const SUPPORTED_TESTING_FRAMEWORKS = [
+  '@testing-library/react',
+  '@marko/testing-library',
+];
+
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     {
@@ -149,10 +154,10 @@ ruleTester.run(RULE_NAME, rule, {
       debug()
       `,
     },
-    {
+    ...SUPPORTED_TESTING_FRAMEWORKS.map((testingFramework) => ({
       settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
-      import { render as testingRender } from '@testing-library/react'
+      import { render as testingRender } from '${testingFramework}'
       import { render } from 'somewhere-else'
 
       const { debug } = render(element)
@@ -160,23 +165,11 @@ ruleTester.run(RULE_NAME, rule, {
       somethingElse()
       debug()
       `,
-    },
-    {
+    })),
+    ...SUPPORTED_TESTING_FRAMEWORKS.map((testingFramework) => ({
       settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
-      import { render as testingRender } from '@marko/testing-library'
-      import { render } from 'somewhere-else'
-
-      const { debug } = render(element)
-
-      somethingElse()
-      debug()
-      `,
-    },
-    {
-      settings: { 'testing-library/utils-module': 'test-utils' },
-      code: `
-      import { render as testingRender } from '@testing-library/react'
+      import { render as testingRender } from '${testingFramework}'
       import { render } from 'somewhere-else'
 
       const { debug } = render(element)
@@ -185,11 +178,14 @@ ruleTester.run(RULE_NAME, rule, {
       somethingElse()
       debug()
       `,
-    },
+    })),
 
-    `// cover edge case for https://github.com/testing-library/eslint-plugin-testing-library/issues/306
-    thing.method.lastCall.args[0]();
-    `,
+    {
+      code: `
+      // cover edge case for https://github.com/testing-library/eslint-plugin-testing-library/issues/306
+      thing.method.lastCall.args[0]();
+      `,
+    },
   ],
 
   invalid: [
@@ -595,30 +591,21 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [{ line: 7, column: 7, messageId: 'noDebug' }],
     },
-    {
-      settings: { 'testing-library/utils-module': 'test-utils' },
-      code: `
-      import { render } from '@testing-library/react'
+    ...SUPPORTED_TESTING_FRAMEWORKS.map(
+      (testingFramework) =>
+        ({
+          settings: { 'testing-library/utils-module': 'test-utils' },
+          code: `
+      import { render } from '${testingFramework}'
 
       const { debug } = render(element)
 
       somethingElse()
       debug()
       `,
-      errors: [{ line: 7, column: 7, messageId: 'noDebug' }],
-    },
-    {
-      settings: { 'testing-library/utils-module': 'test-utils' },
-      code: `
-      import { render } from '@marko/testing-library'
-
-      const { debug } = render(element)
-
-      somethingElse()
-      debug()
-      `,
-      errors: [{ line: 7, column: 7, messageId: 'noDebug' }],
-    },
+          errors: [{ line: 7, column: 7, messageId: 'noDebug' }],
+        } as const)
+    ),
     {
       settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
@@ -631,18 +618,21 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [{ line: 7, column: 7, messageId: 'noDebug' }],
     },
-    {
-      settings: { 'testing-library/utils-module': 'test-utils' },
-      code: `
-      import { render } from '@testing-library/react'
+    ...SUPPORTED_TESTING_FRAMEWORKS.map(
+      (testingFramework) =>
+        ({
+          settings: { 'testing-library/utils-module': 'test-utils' },
+          code: `
+      import { render } from '${testingFramework}'
 
       const utils = render(element)
 
       somethingElse()
       utils.debug()
       `,
-      errors: [{ line: 7, column: 13, messageId: 'noDebug' }],
-    },
+          errors: [{ line: 7, column: 13, messageId: 'noDebug' }],
+        } as const)
+    ),
     {
       settings: {
         'testing-library/utils-module': 'test-utils',
@@ -658,10 +648,12 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [{ line: 7, column: 7, messageId: 'noDebug' }],
     },
-    {
-      settings: { 'testing-library/utils-module': 'test-utils' },
-      code: `
-      import { render } from '@testing-library/react'
+    ...SUPPORTED_TESTING_FRAMEWORKS.map(
+      (testingFramework) =>
+        ({
+          settings: { 'testing-library/utils-module': 'test-utils' },
+          code: `
+      import { render } from '${testingFramework}'
 
       const utils = render(element)
       const { debug: renamedDestructuredDebug } = console
@@ -674,7 +666,8 @@ ruleTester.run(RULE_NAME, rule, {
       utils.debug()
       renamedDestructuredDebug('foo')
       `,
-      errors: [{ line: 12, column: 13, messageId: 'noDebug' }],
-    },
+          errors: [{ line: 12, column: 13, messageId: 'noDebug' }],
+        } as const)
+    ),
   ],
 });

--- a/tests/lib/rules/no-dom-import.test.ts
+++ b/tests/lib/rules/no-dom-import.test.ts
@@ -3,25 +3,30 @@ import { createRuleTester } from '../test-utils';
 
 const ruleTester = createRuleTester();
 
+const SUPPORTED_TESTING_FRAMEWORKS = [
+  'react-testing-library',
+  '@testing-library/react',
+  '@marko/testing-library',
+];
+
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     'import { foo } from "foo"',
     'import "foo"',
-    'import { fireEvent } from "react-testing-library"',
-    'import * as testing from "react-testing-library"',
-    'import { fireEvent } from "@testing-library/react"',
-    'import * as testing from "@testing-library/react"',
-    'import "react-testing-library"',
-    'import "@testing-library/react"',
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
+      `import { fireEvent } from "${testingFramework}"`,
+      `import * as testing from "${testingFramework}"`,
+      `import "${testingFramework}"`,
+    ]),
     'const { foo } = require("foo")',
     'require("foo")',
     'require("")',
     'require()',
-    'const { fireEvent } = require("react-testing-library")',
-    'const { fireEvent } = require("@testing-library/react")',
-    'require("react-testing-library")',
-    'require("@testing-library/react")',
-    'require("@marko/testing-library")',
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
+      `const { fireEvent } = require("${testingFramework}")`,
+      `const { fireEvent: testing } = require("${testingFramework}")`,
+      `require("${testingFramework}")`,
+    ]),
     {
       code: 'import { fireEvent } from "test-utils"',
       settings: { 'testing-library/utils-module': 'test-utils' },

--- a/tests/lib/rules/no-node-access.test.ts
+++ b/tests/lib/rules/no-node-access.test.ts
@@ -3,18 +3,23 @@ import { createRuleTester } from '../test-utils';
 
 const ruleTester = createRuleTester();
 
+const SUPPORTED_TESTING_FRAMEWORKS = [
+  '@testing-library/react',
+  '@marko/testing-library',
+];
+
 ruleTester.run(RULE_NAME, rule, {
-  valid: [
+  valid: SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const buttonText = screen.getByText('submit');
       `,
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const { getByText } = screen
         const firstChild = getByText('submit');
@@ -23,7 +28,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const firstChild = screen.getByText('submit');
         expect(firstChild).toBeInTheDocument()
@@ -31,15 +36,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@marko/testing-library';
-
-        const firstChild = screen.getByText('submit');
-        expect(firstChild).toBeInTheDocument()
-      `,
-    },
-    {
-      code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const { getByText } = screen;
         const button = getByRole('button');
@@ -48,7 +45,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { render, within } from '@testing-library/react';
+        import { render, within } from '${testingFramework}';
 
         const { getByLabelText } = render(<MyComponent />);
         const signInModal = getByLabelText('Sign In');
@@ -89,8 +86,8 @@ ruleTester.run(RULE_NAME, rule, {
       expect(closestButton).toBeInTheDocument();
       `,
     },
-  ],
-  invalid: [
+  ]),
+  invalid: SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
     {
       settings: {
         'testing-library/utils-module': 'test-utils',
@@ -105,7 +102,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const button = document.getElementById('submit-btn').closest('button');
       `,
@@ -124,26 +121,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@marko/testing-library';
-
-        const button = document.getElementById('submit-btn').closest('button');
-      `,
-      errors: [
-        {
-          line: 4,
-          column: 33,
-          messageId: 'noNodeAccess',
-        },
-        {
-          line: 4,
-          column: 62,
-          messageId: 'noNodeAccess',
-        },
-      ],
-    },
-    {
-      code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         document.getElementById('submit-btn');
       `,
@@ -157,7 +135,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         screen.getByText('submit').closest('button');
       `,
@@ -172,7 +150,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         expect(screen.getByText('submit').closest('button').textContent).toBe('Submit');
       `,
@@ -186,7 +164,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { render } from '@testing-library/react';
+        import { render } from '${testingFramework}';
 
         const { getByText } = render(<Example />)
         getByText('submit').closest('button');
@@ -195,7 +173,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const buttons = screen.getAllByRole('button');
         const childA = buttons[1].firstChild;
@@ -219,7 +197,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const buttonText = screen.getByText('submit');
         const button = buttonText.closest('button');
@@ -228,7 +206,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { render } from '@testing-library/react';
+        import { render } from '${testingFramework}';
 
         const { getByText } = render(<Example />)
         const buttonText = getByText('submit');
@@ -244,7 +222,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { render } from '@testing-library/react';
+        import { render } from '${testingFramework}';
 
         const { getByText } = render(<Example />)
         const button = getByText('submit').closest('button');
@@ -253,7 +231,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         function getExampleDOM() {
             const container = document.createElement('div');
@@ -283,7 +261,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         function getExampleDOM() {
             const container = document.createElement('div');
@@ -311,5 +289,5 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     },
-  ],
+  ]),
 });

--- a/tests/lib/rules/no-promise-in-fire-event.test.ts
+++ b/tests/lib/rules/no-promise-in-fire-event.test.ts
@@ -3,42 +3,52 @@ import { createRuleTester } from '../test-utils';
 
 const ruleTester = createRuleTester();
 
+const SUPPORTED_TESTING_FRAMEWORKS = [
+  '@testing-library/foo',
+  '@marko/testing-library',
+];
+
 ruleTester.run(RULE_NAME, rule, {
   valid: [
-    {
-      code: `
-        import {fireEvent} from '@testing-library/foo';
-        
-        fireEvent.click(screen.getByRole('button'))
-      `,
-    },
-    {
-      code: `
-        import {fireEvent} from '@testing-library/foo';
-
-        fireEvent.click(queryByRole('button'))`,
-    },
-    {
-      code: `
-        import {fireEvent} from '@testing-library/foo';
-
-        fireEvent.click(someRef)`,
-    },
-    {
-      code: `
-        import {fireEvent} from '@testing-library/foo';
-        
-        fireEvent.click(await screen.findByRole('button'))
-      `,
-    },
-    {
-      code: `
-        import {fireEvent} from '@testing-library/foo'
-
-        const elementPromise = screen.findByRole('button')
-        const button = await elementPromise
-        fireEvent.click(button)`,
-    },
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
+      {
+        code: `
+          import {fireEvent} from '${testingFramework}';
+          
+          fireEvent.click(screen.getByRole('button'))
+        `,
+      },
+      {
+        code: `
+          import {fireEvent} from '${testingFramework}';
+  
+          fireEvent.click(queryByRole('button'))
+        `,
+      },
+      {
+        code: `
+          import {fireEvent} from '${testingFramework}';
+  
+          fireEvent.click(someRef)
+        `,
+      },
+      {
+        code: `
+          import {fireEvent} from '${testingFramework}';
+          
+          fireEvent.click(await screen.findByRole('button'))
+        `,
+      },
+      {
+        code: `
+          import {fireEvent} from '${testingFramework}'
+  
+          const elementPromise = screen.findByRole('button')
+          const button = await elementPromise
+          fireEvent.click(button)
+        `,
+      },
+    ]),
     {
       settings: {
         'testing-library/utils-module': 'test-utils',
@@ -85,91 +95,93 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     },
-    {
-      code: `
-        import {fireEvent} from '@testing-library/foo';
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
+      {
+        code: `
+        import {fireEvent} from '${testingFramework}';
 
         const promise = new Promise();
         fireEvent.click(promise)`,
-      errors: [
-        {
-          messageId: 'noPromiseInFireEvent',
-          line: 5,
-          column: 25,
-          endColumn: 32,
-        },
-      ],
-    },
-    {
-      code: `
-        import {fireEvent} from '@testing-library/foo'
+        errors: [
+          {
+            messageId: 'noPromiseInFireEvent',
+            line: 5,
+            column: 25,
+            endColumn: 32,
+          },
+        ],
+      } as const,
+      {
+        code: `
+        import {fireEvent} from '${testingFramework}'
 
         const elementPromise = screen.findByRole('button')
         fireEvent.click(elementPromise)`,
-      errors: [
-        {
-          messageId: 'noPromiseInFireEvent',
-          line: 5,
-          column: 25,
-          endColumn: 39,
-        },
-      ],
-    },
-    {
-      code: `
-        import {fireEvent} from '@testing-library/foo';
+        errors: [
+          {
+            messageId: 'noPromiseInFireEvent',
+            line: 5,
+            column: 25,
+            endColumn: 39,
+          },
+        ],
+      } as const,
+      {
+        code: `
+        import {fireEvent} from '${testingFramework}';
 
         fireEvent.click(screen.findByRole('button'))`,
-      errors: [
-        {
-          messageId: 'noPromiseInFireEvent',
-          line: 4,
-          column: 25,
-          endColumn: 52,
-        },
-      ],
-    },
-    {
-      code: `
-        import {fireEvent} from '@testing-library/foo';
+        errors: [
+          {
+            messageId: 'noPromiseInFireEvent',
+            line: 4,
+            column: 25,
+            endColumn: 52,
+          },
+        ],
+      } as const,
+      {
+        code: `
+        import {fireEvent} from '${testingFramework}';
 
         fireEvent.click(findByText('submit'))`,
-      errors: [
-        {
-          messageId: 'noPromiseInFireEvent',
-          line: 4,
-          column: 25,
-          endColumn: 45,
-        },
-      ],
-    },
-    {
-      code: `
-        import {fireEvent} from '@testing-library/foo';
+        errors: [
+          {
+            messageId: 'noPromiseInFireEvent',
+            line: 4,
+            column: 25,
+            endColumn: 45,
+          },
+        ],
+      } as const,
+      {
+        code: `
+        import {fireEvent} from '${testingFramework}';
 
         fireEvent.click(Promise('foo'))`,
-      errors: [
-        {
-          messageId: 'noPromiseInFireEvent',
-          line: 4,
-          column: 25,
-          endColumn: 39,
-        },
-      ],
-    },
-    {
-      code: `
-        import {fireEvent} from '@testing-library/foo';
+        errors: [
+          {
+            messageId: 'noPromiseInFireEvent',
+            line: 4,
+            column: 25,
+            endColumn: 39,
+          },
+        ],
+      } as const,
+      {
+        code: `
+        import {fireEvent} from '${testingFramework}';
 
         fireEvent.click(new Promise('foo'))`,
-      errors: [
-        {
-          messageId: 'noPromiseInFireEvent',
-          line: 4,
-          column: 25,
-          endColumn: 43,
-        },
-      ],
-    },
+        errors: [
+          {
+            messageId: 'noPromiseInFireEvent',
+            line: 4,
+            column: 25,
+            endColumn: 43,
+          },
+        ],
+      } as const,
+    ]),
   ],
 });

--- a/tests/lib/rules/no-wait-for-multiple-assertions.test.ts
+++ b/tests/lib/rules/no-wait-for-multiple-assertions.test.ts
@@ -5,6 +5,11 @@ import { createRuleTester } from '../test-utils';
 
 const ruleTester = createRuleTester();
 
+const SUPPORTED_TESTING_FRAMEWORKS = [
+  '@testing-library/react',
+  '@marko/testing-library',
+];
+
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     {
@@ -29,28 +34,17 @@ ruleTester.run(RULE_NAME, rule, {
         })
       `,
     },
-    {
+    ...SUPPORTED_TESTING_FRAMEWORKS.map((testingFramework) => ({
       settings: { 'testing-library/utils-module': 'test-utils' },
       code: `// Aggressive Reporting disabled - waitFor renamed
-        import { waitFor as renamedWaitFor } from '@testing-library/react'
+        import { waitFor as renamedWaitFor } from '${testingFramework}'
         import { waitFor } from 'somewhere-else'
         await waitFor(() => {
           expect(a).toEqual('a')
           expect(b).toEqual('b')
         })
       `,
-    },
-    {
-      settings: { 'testing-library/utils-module': 'test-utils' },
-      code: `// Aggressive Reporting disabled - waitFor renamed
-        import { waitFor as renamedWaitFor } from '@marko/testing-library'
-        import { waitFor } from 'somewhere-else'
-        await waitFor(() => {
-          expect(a).toEqual('a')
-          expect(b).toEqual('b')
-        })
-      `,
-    },
+    })),
     // this needs to be check by other rule
     {
       code: `
@@ -114,32 +108,22 @@ ruleTester.run(RULE_NAME, rule, {
         { line: 4, column: 11, messageId: 'noWaitForMultipleAssertion' },
       ],
     },
-    {
-      settings: { 'testing-library/utils-module': 'test-utils' },
-      code: `// Aggressive Reporting disabled
-        import { waitFor } from '@testing-library/react'
+    ...SUPPORTED_TESTING_FRAMEWORKS.map(
+      (testingFramework) =>
+        ({
+          settings: { 'testing-library/utils-module': 'test-utils' },
+          code: `// Aggressive Reporting disabled
+        import { waitFor } from '${testingFramework}'
         await waitFor(() => {
           expect(a).toEqual('a')
           expect(b).toEqual('b')
         })
       `,
-      errors: [
-        { line: 5, column: 11, messageId: 'noWaitForMultipleAssertion' },
-      ],
-    },
-    {
-      settings: { 'testing-library/utils-module': 'test-utils' },
-      code: `// Aggressive Reporting disabled
-        import { waitFor } from '@marko/testing-library'
-        await waitFor(() => {
-          expect(a).toEqual('a')
-          expect(b).toEqual('b')
-        })
-      `,
-      errors: [
-        { line: 5, column: 11, messageId: 'noWaitForMultipleAssertion' },
-      ],
-    },
+          errors: [
+            { line: 5, column: 11, messageId: 'noWaitForMultipleAssertion' },
+          ],
+        } as const)
+    ),
     {
       settings: { 'testing-library/utils-module': 'test-utils' },
       code: `// Aggressive Reporting disabled

--- a/tests/lib/rules/no-wait-for-side-effects.test.ts
+++ b/tests/lib/rules/no-wait-for-side-effects.test.ts
@@ -3,101 +3,102 @@ import { createRuleTester } from '../test-utils';
 
 const ruleTester = createRuleTester();
 
+const SUPPORTED_TESTING_FRAMEWORKS = [
+  '@testing-library/react',
+  '@marko/testing-library',
+];
+
 ruleTester.run(RULE_NAME, rule, {
   valid: [
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
-        await waitFor(() => expect(a).toEqual('a'))
-      `,
-    },
-    {
-      code: `
-        import { waitFor } from '@marko/testing-library';
-        await waitFor(() => expect(a).toEqual('a'))
-      `,
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
-        await waitFor(function() {
-          expect(a).toEqual('a')
-        })
-      `,
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
-        await waitFor(() => {
-          console.log('testing-library')
-          expect(b).toEqual('b')
-        })
-      `,
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
-        await waitFor(function() {
-          console.log('testing-library')
-          expect(b).toEqual('b')
-        })
-      `,
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
-        await waitFor(() => {})
-      `,
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
-        await waitFor(function() {})
-      `,
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
-        await waitFor(() => {
-          // testing
-        })
-      `,
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
-        await waitFor(function() {
-          // testing
-        })
-      `,
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
-        fireEvent.keyDown(input, {key: 'ArrowDown'})
-        await waitFor(() => {
-          expect(b).toEqual('b')
-        })
-      `,
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
-        fireEvent.keyDown(input, {key: 'ArrowDown'})
-        await waitFor(function() {
-          expect(b).toEqual('b')
-        })
-      `,
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
-        userEvent.click(button)
-        await waitFor(function() {
-          expect(b).toEqual('b')
-        })
-      `,
-    },
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
+      {
+        code: `
+          import { waitFor } from '${testingFramework}';
+          await waitFor(() => expect(a).toEqual('a'))
+        `,
+      },
+      {
+        code: `
+          import { waitFor } from '${testingFramework}';
+          await waitFor(function() {
+            expect(a).toEqual('a')
+          })
+        `,
+      },
+      {
+        code: `
+          import { waitFor } from '${testingFramework}';
+          await waitFor(() => {
+            console.log('testing-library')
+            expect(b).toEqual('b')
+          })
+        `,
+      },
+      {
+        code: `
+          import { waitFor } from '${testingFramework}';
+          await waitFor(function() {
+            console.log('testing-library')
+            expect(b).toEqual('b')
+          })
+        `,
+      },
+      {
+        code: `
+          import { waitFor } from '${testingFramework}';
+          await waitFor(() => {})
+        `,
+      },
+      {
+        code: `
+          import { waitFor } from '${testingFramework}';
+          await waitFor(function() {})
+        `,
+      },
+      {
+        code: `
+          import { waitFor } from '${testingFramework}';
+          await waitFor(() => {
+            // testing
+          })
+        `,
+      },
+      {
+        code: `
+          import { waitFor } from '${testingFramework}';
+          await waitFor(function() {
+            // testing
+          })
+        `,
+      },
+      {
+        code: `
+          import { waitFor } from '${testingFramework}';
+          fireEvent.keyDown(input, {key: 'ArrowDown'})
+          await waitFor(() => {
+            expect(b).toEqual('b')
+          })
+        `,
+      },
+      {
+        code: `
+          import { waitFor } from '${testingFramework}';
+          fireEvent.keyDown(input, {key: 'ArrowDown'})
+          await waitFor(function() {
+            expect(b).toEqual('b')
+          })
+        `,
+      },
+      {
+        code: `
+          import { waitFor } from '${testingFramework}';
+          userEvent.click(button)
+          await waitFor(function() {
+            expect(b).toEqual('b')
+          })
+        `,
+      },
+    ]),
     {
       settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
@@ -108,9 +109,9 @@ ruleTester.run(RULE_NAME, rule, {
         })
       `,
     },
-    {
+    ...SUPPORTED_TESTING_FRAMEWORKS.map((testingFramework) => ({
       code: `
-        import { waitFor } from '@testing-library/react';
+        import { waitFor } from '${testingFramework}';
 
         anotherFunction(() => {
           fireEvent.keyDown(input, {key: 'ArrowDown'});
@@ -123,7 +124,7 @@ ruleTester.run(RULE_NAME, rule, {
           expect(b).toEqual('b')
         });
       `,
-    },
+    })),
     {
       settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
@@ -171,14 +172,14 @@ ruleTester.run(RULE_NAME, rule, {
         await waitFor(() => fireEvent.keyDown(input, {key: 'ArrowDown'}))
       `,
     },
-    {
+    ...SUPPORTED_TESTING_FRAMEWORKS.map((testingFramework) => ({
       settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
         import { waitFor } from 'somewhere-else';
-        import { userEvent } from '@testing-library/react';
+        import { userEvent } from '${testingFramework}';
         await waitFor(() => userEvent.click(button))
       `,
-    },
+    })),
     {
       settings: { 'testing-library/utils-module': '~/test-utils' },
       code: `
@@ -220,42 +221,44 @@ ruleTester.run(RULE_NAME, rule, {
         await waitFor(() => render(<App />))
       `,
     },
-    {
-      settings: { 'testing-library/utils-module': '~/test-utils' },
-      code: `
-        import { waitFor } from '@testing-library/react';
-        import { render } from 'somewhere-else';
-        await waitFor(() => render(<App />))
-      `,
-    },
-    {
-      settings: { 'testing-library/custom-renders': ['renderHelper'] },
-      code: `
-        import { waitFor } from '@testing-library/react';
-        import { renderWrapper } from 'somewhere-else';
-        await waitFor(() => renderWrapper(<App />))
-      `,
-    },
-    {
-      settings: { 'testing-library/custom-renders': ['renderHelper'] },
-      code: `
-        import { waitFor } from '@testing-library/react';
-        import { renderWrapper } from 'somewhere-else';
-        await waitFor(() => {
-          renderWrapper(<App />)
-        })
-      `,
-    },
-    {
-      settings: { 'testing-library/custom-renders': ['renderHelper'] },
-      code: `
-        import { waitFor } from '@testing-library/react';
-        import { renderWrapper } from 'somewhere-else';
-        await waitFor(() => {
-          const { container } = renderWrapper(<App />)
-        })
-      `,
-    },
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
+      {
+        settings: { 'testing-library/utils-module': '~/test-utils' },
+        code: `
+          import { waitFor } from '${testingFramework}';
+          import { render } from 'somewhere-else';
+          await waitFor(() => render(<App />))
+        `,
+      },
+      {
+        settings: { 'testing-library/custom-renders': ['renderHelper'] },
+        code: `
+          import { waitFor } from '${testingFramework}';
+          import { renderWrapper } from 'somewhere-else';
+          await waitFor(() => renderWrapper(<App />))
+        `,
+      },
+      {
+        settings: { 'testing-library/custom-renders': ['renderHelper'] },
+        code: `
+          import { waitFor } from '${testingFramework}';
+          import { renderWrapper } from 'somewhere-else';
+          await waitFor(() => {
+            renderWrapper(<App />)
+          })
+        `,
+      },
+      {
+        settings: { 'testing-library/custom-renders': ['renderHelper'] },
+        code: `
+          import { waitFor } from '${testingFramework}';
+          import { renderWrapper } from 'somewhere-else';
+          await waitFor(() => {
+            const { container } = renderWrapper(<App />)
+          })
+        `,
+      },
+    ]),
     {
       settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
@@ -275,23 +278,25 @@ ruleTester.run(RULE_NAME, rule, {
         })
       `,
     },
-    {
-      settings: { 'testing-library/custom-renders': ['renderHelper'] },
-      code: `
-        import { waitFor } from '@testing-library/react';
-        import { renderWrapper } from 'somewhere-else';
-        await waitFor(() => {
-          renderWrapper(<App />)
-        })
-      `,
-    },
-    {
-      settings: { 'testing-library/custom-renders': ['renderHelper'] },
-      code: `
-        import { waitFor } from '@testing-library/react';
-        await waitFor(() => result = renderWrapper(<App />))
-      `,
-    },
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
+      {
+        settings: { 'testing-library/custom-renders': ['renderHelper'] },
+        code: `
+          import { waitFor } from '${testingFramework}';
+          import { renderWrapper } from 'somewhere-else';
+          await waitFor(() => {
+            renderWrapper(<App />)
+          })
+        `,
+      },
+      {
+        settings: { 'testing-library/custom-renders': ['renderHelper'] },
+        code: `
+          import { waitFor } from '${testingFramework}';
+          await waitFor(() => result = renderWrapper(<App />))
+        `,
+      },
+    ]),
     {
       settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
@@ -310,133 +315,128 @@ ruleTester.run(RULE_NAME, rule, {
   ],
   invalid: [
     // render
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(() => render(<App />))
       `,
-      errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@marko/testing-library';
-        await waitFor(() => render(<App />))
-      `,
-      errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(function() {
           render(<App />)
         })
       `,
-      errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(function() {
           const { container } = renderHelper(<App />)
         })
       `,
-      errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      settings: { 'testing-library/custom-renders': ['renderHelper'] },
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        settings: { 'testing-library/custom-renders': ['renderHelper'] },
+        code: `
+        import { waitFor } from '${testingFramework}';
         import { renderHelper } from 'somewhere-else';
         await waitFor(() => renderHelper(<App />))
       `,
-      errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      settings: { 'testing-library/custom-renders': ['renderHelper'] },
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        settings: { 'testing-library/custom-renders': ['renderHelper'] },
+        code: `
+        import { waitFor } from '${testingFramework}';
         import { renderHelper } from 'somewhere-else';
         await waitFor(() => {
           renderHelper(<App />)
         })
       `,
-      errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      settings: { 'testing-library/custom-renders': ['renderHelper'] },
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        settings: { 'testing-library/custom-renders': ['renderHelper'] },
+        code: `
+        import { waitFor } from '${testingFramework}';
         import { renderHelper } from 'somewhere-else';
         await waitFor(() => {
           const { container } = renderHelper(<App />)
         })
       `,
-      errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      settings: { 'testing-library/custom-renders': ['renderHelper'] },
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        settings: { 'testing-library/custom-renders': ['renderHelper'] },
+        code: `
+        import { waitFor } from '${testingFramework}';
         import { renderHelper } from 'somewhere-else';
         let container;
         await waitFor(() => {
           ({ container } = renderHelper(<App />))
         })
       `,
-      errors: [{ line: 6, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 6, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(() => result = render(<App />))
       `,
-      errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(() => (a = 5, result = render(<App />)))
       `,
-      errors: [{ line: 3, column: 30, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 3, column: 30, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         const { rerender } = render(<App />)
         await waitFor(() => rerender(<App />))
       `,
-      errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor, render } from '@testing-library/react';
+        errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor, render } from '${testingFramework}';
         await waitFor(() => render(<App />))
       `,
-      errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         const { rerender } = render(<App />)
         await waitFor(() => rerender(<App />))
       `,
-      errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(() => renderHelper(<App />))
       `,
-      errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         import { render } from 'somewhere-else';
         await waitFor(() => render(<App />))
       `,
-      errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
-    },
+        errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+    ]),
     {
       settings: { 'testing-library/utils-module': '~/test-utils' },
       code: `
@@ -445,96 +445,101 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
     },
-    {
-      settings: { 'testing-library/custom-renders': ['renderWrapper'] },
-      code: `
-        import { waitFor } from '@testing-library/react';
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
+      {
+        settings: { 'testing-library/custom-renders': ['renderWrapper'] },
+        code: `
+        import { waitFor } from '${testingFramework}';
         import { renderWrapper } from 'somewhere-else';
         await waitFor(() => renderWrapper(<App />))
       `,
-      errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           render(<App />)
         })
       `,
-      errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           const { container } = render(<App />)
         })
       `,
-      errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           result = render(<App />)
         })
       `,
-      errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           const a = 5,
           { container } = render(<App />)
         })
       `,
-      errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         const { rerender } = render(<App />)
         await waitFor(() => {
           rerender(<App />)
         })
       `,
-      errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           render(<App />)
           fireEvent.keyDown(input, {key: 'ArrowDown'})
         })
       `,
-      errors: [
-        { line: 4, column: 11, messageId: 'noSideEffectsWaitFor' },
-        { line: 5, column: 11, messageId: 'noSideEffectsWaitFor' },
-      ],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [
+          { line: 4, column: 11, messageId: 'noSideEffectsWaitFor' },
+          { line: 5, column: 11, messageId: 'noSideEffectsWaitFor' },
+        ],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           render(<App />)
           userEvent.click(button)
         })
       `,
-      errors: [
-        { line: 4, column: 11, messageId: 'noSideEffectsWaitFor' },
-        { line: 5, column: 11, messageId: 'noSideEffectsWaitFor' },
-      ],
-    },
+        errors: [
+          { line: 4, column: 11, messageId: 'noSideEffectsWaitFor' },
+          { line: 5, column: 11, messageId: 'noSideEffectsWaitFor' },
+        ],
+      } as const,
+    ]),
     // fireEvent
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+    ...SUPPORTED_TESTING_FRAMEWORKS.map(
+      (testingFramework) =>
+        ({
+          code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(() => fireEvent.keyDown(input, {key: 'ArrowDown'}))
       `,
-      errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
-    },
+          errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
+        } as const)
+    ),
     {
       settings: { 'testing-library/utils-module': '~/test-utils' },
       code: `
@@ -543,24 +548,26 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
     },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           fireEvent.keyDown(input, {key: 'ArrowDown'})
         })
       `,
-      errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor, fireEvent as renamedFireEvent } from '@testing-library/react';
+        errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor, fireEvent as renamedFireEvent } from '${testingFramework}';
         await waitFor(() => {
           renamedFireEvent.keyDown(input, {key: 'ArrowDown'})
         })
       `,
-      errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
+        errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+    ]),
     {
       settings: { 'testing-library/utils-module': '~/test-utils' },
       code: `
@@ -571,82 +578,86 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
     },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           expect(b).toEqual('b')
           fireEvent.keyDown(input, {key: 'ArrowDown'})
         })
       `,
-      errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           fireEvent.keyDown(input, {key: 'ArrowDown'})
           expect(b).toEqual('b')
         })
       `,
-      errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(function() {
           fireEvent.keyDown(input, {key: 'ArrowDown'})
         })
       `,
-      errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(function() {
           expect(b).toEqual('b')
           fireEvent.keyDown(input, {key: 'ArrowDown'})
         })
       `,
-      errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(function() {
           fireEvent.keyDown(input, {key: 'ArrowDown'})
           expect(b).toEqual('b')
         })
       `,
-      errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
+        errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+    ]),
     // userEvent
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(() => userEvent.click(button))
       `,
-      errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           userEvent.click(button)
         })
       `,
-      errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         import renamedUserEvent from '@testing-library/user-event'
         await waitFor(() => {
           renamedUserEvent.click(button)
         })
       `,
-      errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
+        errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+    ]),
     {
       settings: { 'testing-library/utils-module': '~/test-utils' },
       code: `
@@ -658,55 +669,57 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
     },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           expect(b).toEqual('b')
           userEvent.click(button)
         })
       `,
-      errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           userEvent.click(button)
           expect(b).toEqual('b')
         })
       `,
-      errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(function() {
           userEvent.click(button)
         })
       `,
-      errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(function() {
           expect(b).toEqual('b')
           userEvent.click(button)
         })
       `,
-      errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
-    {
-      code: `
-        import { waitFor } from '@testing-library/react';
+        errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+      {
+        code: `
+        import { waitFor } from '${testingFramework}';
         await waitFor(function() {
           userEvent.click(button)
           expect(b).toEqual('b')
         })
       `,
-      errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-    },
+        errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+      } as const,
+    ]),
 
     {
       settings: { 'testing-library/utils-module': 'test-utils' },

--- a/tests/lib/rules/no-wait-for-snapshot.test.ts
+++ b/tests/lib/rules/no-wait-for-snapshot.test.ts
@@ -4,52 +4,59 @@ import { createRuleTester } from '../test-utils';
 
 const ruleTester = createRuleTester();
 
+const SUPPORTED_TESTING_FRAMEWORKS = [
+  '@testing-library/dom',
+  '@marko/testing-library',
+];
+
 ruleTester.run(RULE_NAME, rule, {
   valid: [
-    ...ASYNC_UTILS.map((asyncUtil) => ({
-      code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
-        test('snapshot calls outside of ${asyncUtil} are valid', () => {
-          expect(foo).toMatchSnapshot()
-          await ${asyncUtil}(() => expect(foo).toBeDefined())
-          expect(foo).toMatchInlineSnapshot()
-        })
-      `,
-    })),
-    ...ASYNC_UTILS.map((asyncUtil) => ({
-      code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
-        test('snapshot calls outside of ${asyncUtil} are valid', () => {
-          expect(foo).toMatchSnapshot()
-          await ${asyncUtil}(() => {
-              expect(foo).toBeDefined()
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
+      ...ASYNC_UTILS.map((asyncUtil) => ({
+        code: `
+          import { ${asyncUtil} } from '${testingFramework}';
+          test('snapshot calls outside of ${asyncUtil} are valid', () => {
+            expect(foo).toMatchSnapshot()
+            await ${asyncUtil}(() => expect(foo).toBeDefined())
+            expect(foo).toMatchInlineSnapshot()
           })
-          expect(foo).toMatchInlineSnapshot()
-        })
-      `,
-    })),
-    ...ASYNC_UTILS.map((asyncUtil) => ({
-      code: `
-        import * as asyncUtils from '@testing-library/dom';
-        test('snapshot calls outside of ${asyncUtil} are valid', () => {
-          expect(foo).toMatchSnapshot()
-          await asyncUtils.${asyncUtil}(() => expect(foo).toBeDefined())
-          expect(foo).toMatchInlineSnapshot()
-        })
-      `,
-    })),
-    ...ASYNC_UTILS.map((asyncUtil) => ({
-      code: `
-        import * as asyncUtils from '@testing-library/dom';
-        test('snapshot calls outside of ${asyncUtil} are valid', () => {
-          expect(foo).toMatchSnapshot()
-          await asyncUtils.${asyncUtil}(() => {
-              expect(foo).toBeDefined()
+        `,
+      })),
+      ...ASYNC_UTILS.map((asyncUtil) => ({
+        code: `
+          import { ${asyncUtil} } from '${testingFramework}';
+          test('snapshot calls outside of ${asyncUtil} are valid', () => {
+            expect(foo).toMatchSnapshot()
+            await ${asyncUtil}(() => {
+                expect(foo).toBeDefined()
+            })
+            expect(foo).toMatchInlineSnapshot()
           })
-          expect(foo).toMatchInlineSnapshot()
-        })
-      `,
-    })),
+        `,
+      })),
+      ...ASYNC_UTILS.map((asyncUtil) => ({
+        code: `
+          import * as asyncUtils from '${testingFramework}';
+          test('snapshot calls outside of ${asyncUtil} are valid', () => {
+            expect(foo).toMatchSnapshot()
+            await asyncUtils.${asyncUtil}(() => expect(foo).toBeDefined())
+            expect(foo).toMatchInlineSnapshot()
+          })
+        `,
+      })),
+      ...ASYNC_UTILS.map((asyncUtil) => ({
+        code: `
+          import * as asyncUtils from '${testingFramework}';
+          test('snapshot calls outside of ${asyncUtil} are valid', () => {
+            expect(foo).toMatchSnapshot()
+            await asyncUtils.${asyncUtil}(() => {
+                expect(foo).toBeDefined()
+            })
+            expect(foo).toMatchInlineSnapshot()
+          })
+        `,
+      })),
+    ]),
     ...ASYNC_UTILS.map((asyncUtil) => ({
       settings: {
         'testing-library/utils-module': 'test-utils',
@@ -151,12 +158,12 @@ ruleTester.run(RULE_NAME, rule, {
       `,
     })),
   ],
-  invalid: [
+  invalid: SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
     ...ASYNC_UTILS.map(
       (asyncUtil) =>
         ({
           code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
+        import { ${asyncUtil} } from '${testingFramework}';
         test('snapshot calls within ${asyncUtil} are not valid', async () => {
           await ${asyncUtil}(() => expect(foo).toMatchSnapshot());
         });
@@ -175,7 +182,7 @@ ruleTester.run(RULE_NAME, rule, {
       (asyncUtil) =>
         ({
           code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
+        import { ${asyncUtil} } from '${testingFramework}';
         test('snapshot calls within ${asyncUtil} are not valid', async () => {
           await ${asyncUtil}(() => {
               expect(foo).toMatchSnapshot()
@@ -196,7 +203,7 @@ ruleTester.run(RULE_NAME, rule, {
       (asyncUtil) =>
         ({
           code: `
-        import * as asyncUtils from '@testing-library/dom';
+        import * as asyncUtils from '${testingFramework}';
         test('snapshot calls within ${asyncUtil} are not valid', async () => {
           await asyncUtils.${asyncUtil}(() => expect(foo).toMatchSnapshot());
         });
@@ -215,7 +222,7 @@ ruleTester.run(RULE_NAME, rule, {
       (asyncUtil) =>
         ({
           code: `
-        import * as asyncUtils from '@testing-library/dom';
+        import * as asyncUtils from '${testingFramework}';
         test('snapshot calls within ${asyncUtil} are not valid', async () => {
           await asyncUtils.${asyncUtil}(() => {
               expect(foo).toMatchSnapshot()
@@ -236,7 +243,7 @@ ruleTester.run(RULE_NAME, rule, {
       (asyncUtil) =>
         ({
           code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
+        import { ${asyncUtil} } from '${testingFramework}';
         test('snapshot calls within ${asyncUtil} are not valid', async () => {
           await ${asyncUtil}(() => expect(foo).toMatchInlineSnapshot());
         });
@@ -255,7 +262,7 @@ ruleTester.run(RULE_NAME, rule, {
       (asyncUtil) =>
         ({
           code: `
-        import { ${asyncUtil} } from '@testing-library/dom';
+        import { ${asyncUtil} } from '${testingFramework}';
         test('snapshot calls within ${asyncUtil} are not valid', async () => {
           await ${asyncUtil}(() => {
               expect(foo).toMatchInlineSnapshot()
@@ -276,7 +283,7 @@ ruleTester.run(RULE_NAME, rule, {
       (asyncUtil) =>
         ({
           code: `
-        import * as asyncUtils from '@testing-library/dom';
+        import * as asyncUtils from '${testingFramework}';
         test('snapshot calls within ${asyncUtil} are not valid', async () => {
           await asyncUtils.${asyncUtil}(() => expect(foo).toMatchInlineSnapshot());
         });
@@ -295,7 +302,7 @@ ruleTester.run(RULE_NAME, rule, {
       (asyncUtil) =>
         ({
           code: `
-        import * as asyncUtils from '@testing-library/dom';
+        import * as asyncUtils from '${testingFramework}';
         test('snapshot calls within ${asyncUtil} are not valid', async () => {
           await asyncUtils.${asyncUtil}(() => {
               expect(foo).toMatchInlineSnapshot()
@@ -312,5 +319,5 @@ ruleTester.run(RULE_NAME, rule, {
           ],
         } as const)
     ),
-  ],
+  ]),
 });

--- a/tests/lib/rules/prefer-find-by.test.ts
+++ b/tests/lib/rules/prefer-find-by.test.ts
@@ -14,6 +14,11 @@ import { createRuleTester } from '../test-utils';
 
 const ruleTester = createRuleTester();
 
+const SUPPORTED_TESTING_FRAMEWORKS = [
+  '@testing-library/foo',
+  '@marko/testing-library',
+];
+
 function buildFindByMethod(queryMethod: string) {
   return `${getFindByQueryVariant(queryMethod)}${queryMethod.split('By')[1]}`;
 }
@@ -35,7 +40,7 @@ function createScenario<
 }
 
 ruleTester.run(RULE_NAME, rule, {
-  valid: [
+  valid: SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
     ...ASYNC_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `
         it('tests', async () => {
@@ -46,7 +51,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...ASYNC_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `
-        import {screen} from '@testing-library/foo';
+        import {screen} from '${testingFramework}';
         it('tests', async () => {
           const submitButton = await screen.${queryMethod}('foo')
         })
@@ -54,7 +59,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...SYNC_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `
-        import {waitForElementToBeRemoved} from '@testing-library/foo';
+        import {waitForElementToBeRemoved} from '${testingFramework}';
         it('tests', async () => {
           await waitForElementToBeRemoved(() => ${queryMethod}(baz))
         })
@@ -62,7 +67,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...SYNC_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `
-        import {waitFor} from '@testing-library/foo';
+        import {waitFor} from '${testingFramework}';
         it('tests', async () => {
           await waitFor(function() {
             return ${queryMethod}('baz', { name: 'foo' })
@@ -72,7 +77,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       code: `
-        import {waitFor} from '@testing-library/foo';
+        import {waitFor} from '${testingFramework}';
         it('tests', async () => {
           await waitFor(() => myCustomFunction())
         })
@@ -80,7 +85,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import {waitFor} from '@testing-library/foo';
+        import {waitFor} from '${testingFramework}';
         it('tests', async () => {
           await waitFor(customFunctionReference)
         })
@@ -88,7 +93,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-      import {waitForElementToBeRemoved} from '@testing-library/foo';
+      import {waitForElementToBeRemoved} from '${testingFramework}';
       it('tests', async () => {
         const { container } = render()
         await waitForElementToBeRemoved(container.querySelector('foo'))
@@ -97,7 +102,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     ...SYNC_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `
-        import {waitFor} from '@testing-library/foo';
+        import {waitFor} from '${testingFramework}';
         it('tests', async () => {
           await waitFor(() => {
             foo()
@@ -108,7 +113,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...SYNC_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `
-        import {screen, waitFor} from '@testing-library/foo';
+        import {screen, waitFor} from '${testingFramework}';
         it('tests', async () => {
           await waitFor(() => expect(screen.${queryMethod}('baz')).toBeDisabled());
         })
@@ -116,7 +121,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...SYNC_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `
-        import {screen, waitFor} from '@testing-library/foo';
+        import {screen, waitFor} from '${testingFramework}';
         it('tests', async () => {
           const { ${queryMethod} } = render()
           await waitFor(() => expect(${queryMethod}('baz')).toBeDisabled());
@@ -125,7 +130,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...SYNC_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `
-        import {waitFor} from '@testing-library/foo';
+        import {waitFor} from '${testingFramework}';
         it('tests', async () => {
           await waitFor(() => expect(screen.${queryMethod}('baz')).not.toBeInTheDocument());
         })
@@ -133,7 +138,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...SYNC_QUERIES_COMBINATIONS.map((queryMethod) => ({
       code: `
-        import {waitFor} from '@testing-library/foo';
+        import {waitFor} from '${testingFramework}';
         it('tests', async () => {
           const { ${queryMethod} } = render()
           await waitFor(() => expect(${queryMethod}('baz')).not.toBeInTheDocument());
@@ -142,7 +147,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     {
       code: `
-        import {waitFor} from '@testing-library/foo';
+        import {waitFor} from '${testingFramework}';
         it('tests', async () => {
           await waitFor();
           await wait();
@@ -151,7 +156,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import {screen, waitFor} from '@testing-library/foo';
+        import {screen, waitFor} from '${testingFramework}';
         it('tests', async () => {
           await waitFor(() => expect(screen.querySelector('baz')).toBeInTheDocument());
         })
@@ -159,18 +164,18 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import {waitFor} from '@testing-library/foo';
+        import {waitFor} from '${testingFramework}';
         it('tests', async () => {
           const { container } = render()
           await waitFor(() => expect(container.querySelector('baz')).toBeInTheDocument());
         })
       `,
     },
-  ],
-  invalid: [
+  ]),
+  invalid: SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
     ...createScenario((waitMethod: string, queryMethod: string) => ({
       code: `
-          import {${waitMethod}, screen} from '@testing-library/foo';
+          import {${waitMethod}, screen} from '${testingFramework}';
           it('tests', async () => {
             const submitButton = await ${waitMethod}(() => screen.${queryMethod}('foo', { name: 'baz' }))
           })
@@ -187,7 +192,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
       output: `
-          import {${waitMethod}, screen} from '@testing-library/foo';
+          import {${waitMethod}, screen} from '${testingFramework}';
           it('tests', async () => {
             const submitButton = await screen.${buildFindByMethod(
               queryMethod
@@ -200,7 +205,7 @@ ruleTester.run(RULE_NAME, rule, {
       (waitMethod: string) =>
         ({
           code: `
-          import {${waitMethod}} from '@testing-library/foo';
+          import {${waitMethod}} from '${testingFramework}';
           const { getByText, queryByLabelText, findAllByRole } = customRender()
           it('tests', async () => {
             const submitButton = await ${waitMethod}(() => getByText('baz', { name: 'button' }))
@@ -218,7 +223,7 @@ ruleTester.run(RULE_NAME, rule, {
             },
           ],
           output: `
-          import {${waitMethod}} from '@testing-library/foo';
+          import {${waitMethod}} from '${testingFramework}';
           const { getByText, queryByLabelText, findAllByRole, findByText } = customRender()
           it('tests', async () => {
             const submitButton = await findByText('baz', { name: 'button' })
@@ -231,7 +236,7 @@ ruleTester.run(RULE_NAME, rule, {
       (waitMethod: string) =>
         ({
           code: `
-          import {${waitMethod}} from '@testing-library/foo';
+          import {${waitMethod}} from '${testingFramework}';
           const { getAllByRole, findAllByRole } = customRender()
           it('tests', async () => {
             const submitButton = await ${waitMethod}(() => getAllByRole('baz', { name: 'button' }))
@@ -249,7 +254,7 @@ ruleTester.run(RULE_NAME, rule, {
             },
           ],
           output: `
-          import {${waitMethod}} from '@testing-library/foo';
+          import {${waitMethod}} from '${testingFramework}';
           const { getAllByRole, findAllByRole } = customRender()
           it('tests', async () => {
             const submitButton = await findAllByRole('baz', { name: 'button' })
@@ -300,7 +305,7 @@ ruleTester.run(RULE_NAME, rule, {
       (waitMethod: string) =>
         ({
           code: `
-          import {${waitMethod},render} from '@testing-library/foo';
+          import {${waitMethod},render} from '${testingFramework}';
           it('tests', async () => {
             const { getByCustomQuery } = render()
             const submitButton = await ${waitMethod}(() => getByCustomQuery('baz'))
@@ -318,7 +323,7 @@ ruleTester.run(RULE_NAME, rule, {
             },
           ],
           output: `
-          import {${waitMethod},render} from '@testing-library/foo';
+          import {${waitMethod},render} from '${testingFramework}';
           it('tests', async () => {
             const { getByCustomQuery } = render()
             const submitButton = await ${waitMethod}(() => getByCustomQuery('baz'))
@@ -331,7 +336,7 @@ ruleTester.run(RULE_NAME, rule, {
       (waitMethod: string) =>
         ({
           code: `
-          import {${waitMethod},render,screen} from '@testing-library/foo';
+          import {${waitMethod},render,screen} from '${testingFramework}';
           it('tests', async () => {
             const { getByCustomQuery } = render()
             const submitButton = await ${waitMethod}(() => screen.getByCustomQuery('baz'))
@@ -349,7 +354,7 @@ ruleTester.run(RULE_NAME, rule, {
             },
           ],
           output: `
-          import {${waitMethod},render,screen} from '@testing-library/foo';
+          import {${waitMethod},render,screen} from '${testingFramework}';
           it('tests', async () => {
             const { getByCustomQuery } = render()
             const submitButton = await ${waitMethod}(() => screen.getByCustomQuery('baz'))
@@ -360,7 +365,7 @@ ruleTester.run(RULE_NAME, rule, {
     // presence matchers
     ...createScenario((waitMethod: string, queryMethod: string) => ({
       code: `
-        import {${waitMethod}} from '@testing-library/foo';
+        import {${waitMethod}} from '${testingFramework}';
         it('tests', async () => {
           const { ${queryMethod} } = render()
           const submitButton = await ${waitMethod}(() => ${queryMethod}('foo', { name: 'baz' }))
@@ -378,7 +383,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
       output: `
-        import {${waitMethod}} from '@testing-library/foo';
+        import {${waitMethod}} from '${testingFramework}';
         it('tests', async () => {
           const { ${queryMethod}, ${buildFindByMethod(queryMethod)} } = render()
           const submitButton = await ${buildFindByMethod(
@@ -389,7 +394,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...createScenario((waitMethod: string, queryMethod: string) => ({
       code: `
-        import {${waitMethod}} from '@testing-library/foo';
+        import {${waitMethod}} from '${testingFramework}';
         it('tests', async () => {
           const { ${queryMethod} } = render()
           const submitButton = await ${waitMethod}(() => expect(${queryMethod}('foo', { name: 'baz' })).toBeInTheDocument())
@@ -407,7 +412,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
       output: `
-        import {${waitMethod}} from '@testing-library/foo';
+        import {${waitMethod}} from '${testingFramework}';
         it('tests', async () => {
           const { ${queryMethod}, ${buildFindByMethod(queryMethod)} } = render()
           const submitButton = await ${buildFindByMethod(
@@ -418,7 +423,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...createScenario((waitMethod: string, queryMethod: string) => ({
       code: `
-        import {${waitMethod}} from '@testing-library/foo';
+        import {${waitMethod}} from '${testingFramework}';
         it('tests', async () => {
           const { ${queryMethod} } = render()
           const submitButton = await ${waitMethod}(() => expect(${queryMethod}('foo', { name: 'baz' })).toBeDefined())
@@ -436,7 +441,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
       output: `
-        import {${waitMethod}} from '@testing-library/foo';
+        import {${waitMethod}} from '${testingFramework}';
         it('tests', async () => {
           const { ${queryMethod}, ${buildFindByMethod(queryMethod)} } = render()
           const submitButton = await ${buildFindByMethod(
@@ -447,7 +452,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...createScenario((waitMethod: string, queryMethod: string) => ({
       code: `
-        import {${waitMethod}} from '@testing-library/foo';
+        import {${waitMethod}} from '${testingFramework}';
         it('tests', async () => {
           const { ${queryMethod} } = render()
           const submitButton = await ${waitMethod}(() => expect(${queryMethod}('foo', { name: 'baz' })).not.toBeNull())
@@ -465,7 +470,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
       output: `
-        import {${waitMethod}} from '@testing-library/foo';
+        import {${waitMethod}} from '${testingFramework}';
         it('tests', async () => {
           const { ${queryMethod}, ${buildFindByMethod(queryMethod)} } = render()
           const submitButton = await ${buildFindByMethod(
@@ -476,7 +481,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...createScenario((waitMethod: string, queryMethod: string) => ({
       code: `
-        import {${waitMethod}} from '@testing-library/foo';
+        import {${waitMethod}} from '${testingFramework}';
         it('tests', async () => {
           const {${queryMethod}} = render()
           const submitButton = await ${waitMethod}(() => expect(${queryMethod}('foo', { name: 'baz' })).not.toBeNull())
@@ -494,7 +499,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
       output: `
-        import {${waitMethod}} from '@testing-library/foo';
+        import {${waitMethod}} from '${testingFramework}';
         it('tests', async () => {
           const {${queryMethod}, ${buildFindByMethod(queryMethod)}} = render()
           const submitButton = await ${buildFindByMethod(
@@ -505,7 +510,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...createScenario((waitMethod: string, queryMethod: string) => ({
       code: `
-        import {${waitMethod}} from '@testing-library/foo';
+        import {${waitMethod}} from '${testingFramework}';
         it('tests', async () => {
           const { ${queryMethod} } = render()
           const submitButton = await ${waitMethod}(() => expect(${queryMethod}('foo', { name: 'baz' })).toBeTruthy())
@@ -523,7 +528,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
       output: `
-        import {${waitMethod}} from '@testing-library/foo';
+        import {${waitMethod}} from '${testingFramework}';
         it('tests', async () => {
           const { ${queryMethod}, ${buildFindByMethod(queryMethod)} } = render()
           const submitButton = await ${buildFindByMethod(
@@ -534,7 +539,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...createScenario((waitMethod: string, queryMethod: string) => ({
       code: `
-        import {${waitMethod}} from '@testing-library/foo';
+        import {${waitMethod}} from '${testingFramework}';
         it('tests', async () => {
           const { ${queryMethod} } = render()
           const submitButton = await ${waitMethod}(() => expect(${queryMethod}('foo', { name: 'baz' })).not.toBeFalsy())
@@ -552,7 +557,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
       output: `
-        import {${waitMethod}} from '@testing-library/foo';
+        import {${waitMethod}} from '${testingFramework}';
         it('tests', async () => {
           const { ${queryMethod}, ${buildFindByMethod(queryMethod)} } = render()
           const submitButton = await ${buildFindByMethod(
@@ -563,7 +568,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...createScenario((waitMethod: string, queryMethod: string) => ({
       code: `
-          import {${waitMethod}} from '@testing-library/foo';
+          import {${waitMethod}} from '${testingFramework}';
           it('tests', async () => {
             const submitButton = await ${waitMethod}(() => expect(screen.${queryMethod}('foo', { name: 'baz' })).toBeInTheDocument())
           })
@@ -580,7 +585,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
       output: `
-          import {${waitMethod}} from '@testing-library/foo';
+          import {${waitMethod}} from '${testingFramework}';
           it('tests', async () => {
             const submitButton = await screen.${buildFindByMethod(
               queryMethod
@@ -590,7 +595,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...createScenario((waitMethod: string, queryMethod: string) => ({
       code: `
-          import {${waitMethod}} from '@testing-library/foo';
+          import {${waitMethod}} from '${testingFramework}';
           it('tests', async () => {
             const submitButton = await ${waitMethod}(() => expect(screen.${queryMethod}('foo', { name: 'baz' })).toBeDefined())
           })
@@ -607,7 +612,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
       output: `
-          import {${waitMethod}} from '@testing-library/foo';
+          import {${waitMethod}} from '${testingFramework}';
           it('tests', async () => {
             const submitButton = await screen.${buildFindByMethod(
               queryMethod
@@ -617,7 +622,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...createScenario((waitMethod: string, queryMethod: string) => ({
       code: `
-          import {${waitMethod}} from '@testing-library/foo';
+          import {${waitMethod}} from '${testingFramework}';
           it('tests', async () => {
             const submitButton = await ${waitMethod}(() => expect(screen.${queryMethod}('foo', { name: 'baz' })).not.toBeNull())
           })
@@ -634,7 +639,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
       output: `
-          import {${waitMethod}} from '@testing-library/foo';
+          import {${waitMethod}} from '${testingFramework}';
           it('tests', async () => {
             const submitButton = await screen.${buildFindByMethod(
               queryMethod
@@ -644,7 +649,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...createScenario((waitMethod: string, queryMethod: string) => ({
       code: `
-          import {${waitMethod}} from '@testing-library/foo';
+          import {${waitMethod}} from '${testingFramework}';
           it('tests', async () => {
             const submitButton = await ${waitMethod}(() => expect(screen.${queryMethod}('foo', { name: 'baz' })).toBeTruthy())
           })
@@ -661,7 +666,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
       output: `
-          import {${waitMethod}} from '@testing-library/foo';
+          import {${waitMethod}} from '${testingFramework}';
           it('tests', async () => {
             const submitButton = await screen.${buildFindByMethod(
               queryMethod
@@ -671,7 +676,7 @@ ruleTester.run(RULE_NAME, rule, {
     })),
     ...createScenario((waitMethod: string, queryMethod: string) => ({
       code: `
-          import {${waitMethod}} from '@testing-library/foo';
+          import {${waitMethod}} from '${testingFramework}';
           it('tests', async () => {
             const submitButton = await ${waitMethod}(() => expect(screen.${queryMethod}('foo', { name: 'baz' })).not.toBeFalsy())
           })
@@ -688,7 +693,7 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
       output: `
-          import {${waitMethod}} from '@testing-library/foo';
+          import {${waitMethod}} from '${testingFramework}';
           it('tests', async () => {
             const submitButton = await screen.${buildFindByMethod(
               queryMethod
@@ -696,5 +701,5 @@ ruleTester.run(RULE_NAME, rule, {
           })
         `,
     })),
-  ],
+  ]),
 });

--- a/tests/lib/rules/prefer-query-by-disappearance.test.ts
+++ b/tests/lib/rules/prefer-query-by-disappearance.test.ts
@@ -5,11 +5,16 @@ import { createRuleTester } from '../test-utils';
 
 const ruleTester = createRuleTester();
 
+const SUPPORTED_TESTING_FRAMEWORKS = [
+  '@testing-library/react',
+  '@marko/testing-library',
+];
+
 ruleTester.run(RULE_NAME, rule, {
-  valid: [
+  valid: SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const button = screen.getByRole('button')
         await waitForElementToBeRemoved(button)
@@ -17,15 +22,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@marko/testing-library';
-
-        const button = screen.getByRole('button')
-        await waitForElementToBeRemoved(button)
-      `,
-    },
-    {
-      code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const callback = () => screen.getByRole('button')
         await waitForElementToBeRemoved(callback)
@@ -33,14 +30,14 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         await waitForElementToBeRemoved(() => screen.queryByText("hello"))
       `,
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         await waitForElementToBeRemoved(() => {
           screen.queryByText("hello")
@@ -49,7 +46,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         await waitForElementToBeRemoved(() => {
           otherCode()
@@ -59,7 +56,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         await waitForElementToBeRemoved(() => {
           otherCode()
@@ -69,7 +66,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         await waitForElementToBeRemoved(() => {
           return screen.queryByText("hello")
@@ -78,7 +75,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         await waitForElementToBeRemoved(function() {
           screen.queryByText("hello")
@@ -87,7 +84,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         await waitForElementToBeRemoved(function() {
           otherCode()
@@ -97,7 +94,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         await waitForElementToBeRemoved(function() {
           return screen.queryByText('hey')
@@ -106,7 +103,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         await waitForElementToBeRemoved(function() {
           otherCode()
@@ -116,14 +113,14 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         await waitForElementToBeRemoved(screen.queryByText("hello"))
       `,
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const { queryByText } = screen
         await waitForElementToBeRemoved(queryByText("hello"))
@@ -131,7 +128,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const { queryByText } = screen
         await waitForElementToBeRemoved(() => queryByText("hello"))
@@ -139,7 +136,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const { queryByText } = screen
         await waitForElementToBeRemoved(() => {
@@ -149,7 +146,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const { queryByText } = screen
         await waitForElementToBeRemoved(() => {
@@ -159,7 +156,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { render } from '@testing-library/react';
+        import { render } from '${testingFramework}';
 
         const { queryByText } = render(<App />)
         await waitForElementToBeRemoved(() => {
@@ -169,7 +166,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { render } from '@testing-library/react';
+        import { render } from '${testingFramework}';
 
         const { queryByText } = render(<App />)
         await waitForElementToBeRemoved(() => {
@@ -179,7 +176,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { render } from '@testing-library/react';
+        import { render } from '${testingFramework}';
 
         const { queryByText } = render(<App />)
         await waitForElementToBeRemoved(() => queryByText("hello"))
@@ -187,7 +184,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { render } from '@testing-library/react';
+        import { render } from '${testingFramework}';
 
         const { queryByText } = render(<App />)
         await waitForElementToBeRemoved(queryByText("hello"))
@@ -195,7 +192,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { render } from '@testing-library/react';
+        import { render } from '${testingFramework}';
 
         const { queryByText } = render(<App />)
         await waitForElementToBeRemoved(function() {
@@ -205,7 +202,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { render } from '@testing-library/react';
+        import { render } from '${testingFramework}';
 
         const { queryByText } = render(<App />)
         await waitForElementToBeRemoved(function() {
@@ -213,11 +210,11 @@ ruleTester.run(RULE_NAME, rule, {
         })
       `,
     },
-  ],
-  invalid: [
+  ]),
+  invalid: SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
     {
       code: `
-        import { screen, waitForElementToBeRemoved } from '@testing-library/react';
+        import { screen, waitForElementToBeRemoved } from '${testingFramework}';
 
         await waitForElementToBeRemoved(() => screen.getByText("hello"))
       `,
@@ -245,7 +242,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen, waitForElementToBeRemoved } from '@testing-library/react';
+        import { screen, waitForElementToBeRemoved } from '${testingFramework}';
 
         await waitForElementToBeRemoved(() => screen.findByText("hello"))
       `,
@@ -259,7 +256,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen, waitForElementToBeRemoved } from '@testing-library/react';
+        import { screen, waitForElementToBeRemoved } from '${testingFramework}';
 
         await waitForElementToBeRemoved(() => {
           screen.getByText("hello")
@@ -275,7 +272,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen, waitForElementToBeRemoved } from '@testing-library/react';
+        import { screen, waitForElementToBeRemoved } from '${testingFramework}';
 
         await waitForElementToBeRemoved(() => {
           screen.findByText("hello")
@@ -291,7 +288,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen, waitForElementToBeRemoved } from '@testing-library/react';
+        import { screen, waitForElementToBeRemoved } from '${testingFramework}';
 
         await waitForElementToBeRemoved(() => {
           return screen.getByText("hello")
@@ -307,7 +304,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen, waitForElementToBeRemoved } from '@testing-library/react';
+        import { screen, waitForElementToBeRemoved } from '${testingFramework}';
 
         await waitForElementToBeRemoved(() => {
           return screen.findByText("hello")
@@ -323,7 +320,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen, waitForElementToBeRemoved } from '@testing-library/react';
+        import { screen, waitForElementToBeRemoved } from '${testingFramework}';
 
         await waitForElementToBeRemoved(screen.getByText("hello"))
       `,
@@ -337,7 +334,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen, waitForElementToBeRemoved } from '@testing-library/react';
+        import { screen, waitForElementToBeRemoved } from '${testingFramework}';
 
         await waitForElementToBeRemoved(screen.findByText("hello"))
       `,
@@ -351,7 +348,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         await waitForElementToBeRemoved(function() {
           return screen.getByText('hey')
@@ -367,7 +364,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         await waitForElementToBeRemoved(function() {
           return screen.findByText('hey')
@@ -383,7 +380,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         await waitForElementToBeRemoved(function() {
           screen.getByText('hey')
@@ -399,7 +396,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         await waitForElementToBeRemoved(function() {
           screen.findByText('hey')
@@ -415,7 +412,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const { getByText } = screen
         await waitForElementToBeRemoved(function() {
@@ -432,7 +429,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { render } from '@testing-library/react';
+        import { render } from '${testingFramework}';
 
         const { getByText } = render(<App />)
         await waitForElementToBeRemoved(function() {
@@ -449,7 +446,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const { findByText } = screen
         await waitForElementToBeRemoved(function() {
@@ -466,7 +463,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { render } from '@testing-library/react';
+        import { render } from '${testingFramework}';
 
         const { findByText } = render
         await waitForElementToBeRemoved(function() {
@@ -483,7 +480,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const { getByText } = screen
         await waitForElementToBeRemoved(function() {
@@ -500,7 +497,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { render } from '@testing-library/react';
+        import { render } from '${testingFramework}';
 
         const { getByText } = render(<App />)
         await waitForElementToBeRemoved(function() {
@@ -517,7 +514,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const { findByText } = screen
         await waitForElementToBeRemoved(function() {
@@ -534,7 +531,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { render } from '@testing-library/react';
+        import { render } from '${testingFramework}';
 
         const { findByText } = render(<App />)
         await waitForElementToBeRemoved(function() {
@@ -551,7 +548,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const { getByText } = screen
         await waitForElementToBeRemoved(() => {
@@ -568,7 +565,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { render } from '@testing-library/react';
+        import { render } from '${testingFramework}';
 
         const { getByText } = render(<App />)
         await waitForElementToBeRemoved(() => {
@@ -585,7 +582,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const { findByText } = screen
         await waitForElementToBeRemoved(() => {
@@ -602,7 +599,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const { findByText } = render(<App />)
         await waitForElementToBeRemoved(() => {
@@ -619,7 +616,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const { getByText } = screen
         await waitForElementToBeRemoved(() => {
@@ -636,7 +633,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { render } from '@testing-library/react';
+        import { render } from '${testingFramework}';
 
         const { getByText } = render(<App />)
         await waitForElementToBeRemoved(() => {
@@ -653,7 +650,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const { findByText } = screen
         await waitForElementToBeRemoved(() => {
@@ -670,7 +667,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { render } from '@testing-library/react';
+        import { render } from '${testingFramework}';
 
         const { findByText } = render(<App />)
         await waitForElementToBeRemoved(() => {
@@ -687,7 +684,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const { findByText } = screen
         await waitForElementToBeRemoved(() => findByText('hey'))
@@ -702,7 +699,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { render } from '@testing-library/react';
+        import { render } from '${testingFramework}';
 
         const { findByText } = render(<App />)
         await waitForElementToBeRemoved(() => findByText('hey'))
@@ -717,7 +714,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const { getByText } = screen
         await waitForElementToBeRemoved(getByText('hey'))
@@ -732,7 +729,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { render } from '@testing-library/react';
+        import { render } from '${testingFramework}';
 
         const { getByText } = render(<App />)
         await waitForElementToBeRemoved(getByText('hey'))
@@ -747,7 +744,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { screen } from '@testing-library/react';
+        import { screen } from '${testingFramework}';
 
         const { findByText } = screen
         await waitForElementToBeRemoved(findByText('hey'))
@@ -762,7 +759,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
-        import { render } from '@testing-library/react';
+        import { render } from '${testingFramework}';
 
         const { findByText } = render(<App />)
         await waitForElementToBeRemoved(findByText('hey'))
@@ -775,5 +772,5 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     },
-  ],
+  ]),
 });

--- a/tests/lib/rules/render-result-naming-convention.test.ts
+++ b/tests/lib/rules/render-result-naming-convention.test.ts
@@ -5,106 +5,103 @@ import { createRuleTester } from '../test-utils';
 
 const ruleTester = createRuleTester();
 
+const SUPPORTED_TESTING_FRAMEWORKS = [
+  '@testing-library/react',
+  '@marko/testing-library',
+];
+
 ruleTester.run(RULE_NAME, rule, {
   valid: [
-    {
-      code: `
-        import { render } from '@testing-library/react';
-
-        test('should not report straight destructured render result', () => {
-          const { rerender, getByText } = render(<SomeComponent />);
-          const button = getByText('some button');
-        });
-      `,
-    },
-    {
-      code: `
-        import { render } from '@marko/testing-library';
-
-        test('should not report straight destructured render result', () => {
-          const { rerender, getByText } = render(<SomeComponent />);
-          const button = getByText('some button');
-        });
-      `,
-    },
-    {
-      code: `
-        import * as RTL from '@testing-library/react';
-
-        test('should not report straight destructured render result from wildcard import', () => {
-          const { rerender, getByText } = RTL.render(<SomeComponent />);
-          const button = getByText('some button');
-        });
-      `,
-    },
-    {
-      code: `
-        import { render } from '@testing-library/react';
-
-        test('should not report straight render result called "utils"', async () => {
-          const utils = render(<SomeComponent />);
-          await utils.findByRole('button');
-        });
-      `,
-    },
-    {
-      code: `
-        import { render } from '@testing-library/react';
-
-        test('should not report straight render result called "view"', async () => {
-          const view = render(<SomeComponent />);
-          await view.findByRole('button');
-        });
-      `,
-    },
-    {
-      code: `
-        import { render } from '@testing-library/react';
-
-        const setup = () => render(<SomeComponent />);
-
-        test('should not report destructured render result from wrapping function', () => {
-          const { rerender, getByText } = setup();
-          const button = getByText('some button');
-        });
-      `,
-    },
-    {
-      code: `
-        import { render } from '@testing-library/react';
-
-        const setup = () => render(<SomeComponent />);
-
-        test('should not report render result called "utils" from wrapping function', async () => {
-          const utils = setup();
-          await utils.findByRole('button');
-        });
-      `,
-    },
-    {
-      code: `
-        import { render } from '@testing-library/react';
-
-        const setup = () => render(<SomeComponent />);
-
-        test('should not report render result called "view" from wrapping function', async () => {
-          const view = setup();
-          await view.findByRole('button');
-        });
-      `,
-    },
-    {
-      code: `
-        import { screen } from '@testing-library/react';
-        import { customRender } from 'test-utils';
-
-        test('should not report straight destructured render result from custom render', () => {
-          const { unmount } = customRender(<SomeComponent />);
-          const button = screen.getByText('some button');
-        });
-      `,
-      settings: { 'testing-library/custom-renders': ['customRender'] },
-    },
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
+      {
+        code: `
+          import { render } from '${testingFramework}';
+  
+          test('should not report straight destructured render result', () => {
+            const { rerender, getByText } = render(<SomeComponent />);
+            const button = getByText('some button');
+          });
+        `,
+      },
+      {
+        code: `
+          import * as RTL from '${testingFramework}';
+  
+          test('should not report straight destructured render result from wildcard import', () => {
+            const { rerender, getByText } = RTL.render(<SomeComponent />);
+            const button = getByText('some button');
+          });
+        `,
+      },
+      {
+        code: `
+          import { render } from '${testingFramework}';
+  
+          test('should not report straight render result called "utils"', async () => {
+            const utils = render(<SomeComponent />);
+            await utils.findByRole('button');
+          });
+        `,
+      },
+      {
+        code: `
+          import { render } from '${testingFramework}';
+  
+          test('should not report straight render result called "view"', async () => {
+            const view = render(<SomeComponent />);
+            await view.findByRole('button');
+          });
+        `,
+      },
+      {
+        code: `
+          import { render } from '${testingFramework}';
+  
+          const setup = () => render(<SomeComponent />);
+  
+          test('should not report destructured render result from wrapping function', () => {
+            const { rerender, getByText } = setup();
+            const button = getByText('some button');
+          });
+        `,
+      },
+      {
+        code: `
+          import { render } from '${testingFramework}';
+  
+          const setup = () => render(<SomeComponent />);
+  
+          test('should not report render result called "utils" from wrapping function', async () => {
+            const utils = setup();
+            await utils.findByRole('button');
+          });
+        `,
+      },
+      {
+        code: `
+          import { render } from '${testingFramework}';
+  
+          const setup = () => render(<SomeComponent />);
+  
+          test('should not report render result called "view" from wrapping function', async () => {
+            const view = setup();
+            await view.findByRole('button');
+          });
+        `,
+      },
+      {
+        code: `
+          import { screen } from '${testingFramework}';
+          import { customRender } from 'test-utils';
+  
+          test('should not report straight destructured render result from custom render', () => {
+            const { unmount } = customRender(<SomeComponent />);
+            const button = screen.getByText('some button');
+          });
+        `,
+        settings: { 'testing-library/custom-renders': ['customRender'] },
+      },
+    ]),
     {
       code: `
         import { customRender } from 'test-utils';
@@ -127,9 +124,10 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       settings: { 'testing-library/custom-renders': ['customRender'] },
     },
-    {
-      code: `
-        import { render } from '@testing-library/react';
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
+      {
+        code: `
+        import { render } from '${testingFramework}';
 
         const setup = () => {
           // this one must have a valid name
@@ -143,11 +141,11 @@ ruleTester.run(RULE_NAME, rule, {
           await wrapper.findByRole('button');
         });
       `,
-    },
-    {
-      settings: { 'testing-library/utils-module': 'test-utils' },
-      code: `
-        import { render as testingLibraryRender } from '@testing-library/react';
+      },
+      {
+        settings: { 'testing-library/utils-module': 'test-utils' },
+        code: `
+        import { render as testingLibraryRender } from '${testingFramework}';
         import { render } from '@somewhere/else'
 
         const setup = () => render(<SomeComponent />);
@@ -157,7 +155,8 @@ ruleTester.run(RULE_NAME, rule, {
           const button = wrapper.getByText('some button');
         });
       `,
-    },
+      },
+    ]),
     {
       settings: {
         'testing-library/utils-module': 'test-utils',
@@ -205,126 +204,107 @@ ruleTester.run(RULE_NAME, rule, {
     },
   ],
   invalid: [
-    {
-      code: `
-        import { render } from '@testing-library/react';
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
+      {
+        code: `
+        import { render } from '${testingFramework}';
 
         test('should report straight render result called "wrapper"', async () => {
           const wrapper = render(<SomeComponent />);
           await wrapper.findByRole('button');
         });
       `,
-      errors: [
-        {
-          messageId: 'renderResultNamingConvention',
-          data: {
-            renderResultName: 'wrapper',
+        errors: [
+          {
+            messageId: 'renderResultNamingConvention',
+            data: {
+              renderResultName: 'wrapper',
+            },
+            line: 5,
+            column: 17,
           },
-          line: 5,
-          column: 17,
-        },
-      ],
-    },
-    {
-      code: `
-        import { render } from '@marko/testing-library';
-
-        test('should report straight render result called "wrapper"', async () => {
-          const wrapper = render(<SomeComponent />);
-          await wrapper.findByRole('button');
-        });
-      `,
-      errors: [
-        {
-          messageId: 'renderResultNamingConvention',
-          data: {
-            renderResultName: 'wrapper',
-          },
-          line: 5,
-          column: 17,
-        },
-      ],
-    },
-    {
-      code: `
-        import * as RTL from '@testing-library/react';
+        ],
+      } as const,
+      {
+        code: `
+        import * as RTL from '${testingFramework}';
 
         test('should report straight render result called "wrapper" from wildcard import', () => {
           const wrapper = RTL.render(<SomeComponent />);
           const button = wrapper.getByText('some button');
         });
       `,
-      errors: [
-        {
-          messageId: 'renderResultNamingConvention',
-          data: {
-            renderResultName: 'wrapper',
+        errors: [
+          {
+            messageId: 'renderResultNamingConvention',
+            data: {
+              renderResultName: 'wrapper',
+            },
+            line: 5,
+            column: 17,
           },
-          line: 5,
-          column: 17,
-        },
-      ],
-    },
-    {
-      code: `
-        import { render } from '@testing-library/react';
+        ],
+      } as const,
+      {
+        code: `
+        import { render } from '${testingFramework}';
 
         test('should report straight render result called "component"', async () => {
           const component = render(<SomeComponent />);
           await component.findByRole('button');
         });
       `,
-      errors: [
-        {
-          messageId: 'renderResultNamingConvention',
-          data: {
-            renderResultName: 'component',
+        errors: [
+          {
+            messageId: 'renderResultNamingConvention',
+            data: {
+              renderResultName: 'component',
+            },
+            line: 5,
+            column: 17,
           },
-          line: 5,
-          column: 17,
-        },
-      ],
-    },
-    {
-      code: `
-        import { render } from '@testing-library/react';
+        ],
+      } as const,
+      {
+        code: `
+        import { render } from '${testingFramework}';
 
         test('should report straight render result called "notValidName"', async () => {
           const notValidName = render(<SomeComponent />);
           await notValidName.findByRole('button');
         });
       `,
-      errors: [
-        {
-          messageId: 'renderResultNamingConvention',
-          line: 5,
-          column: 17,
-        },
-      ],
-    },
-    {
-      code: `
-        import { render as testingLibraryRender } from '@testing-library/react';
+        errors: [
+          {
+            messageId: 'renderResultNamingConvention',
+            line: 5,
+            column: 17,
+          },
+        ],
+      } as const,
+      {
+        code: `
+        import { render as testingLibraryRender } from '${testingFramework}';
 
         test('should report renamed render result called "wrapper"', async () => {
           const wrapper = testingLibraryRender(<SomeComponent />);
           await wrapper.findByRole('button');
         });
       `,
-      errors: [
-        {
-          messageId: 'renderResultNamingConvention',
-          data: {
-            renderResultName: 'wrapper',
+        errors: [
+          {
+            messageId: 'renderResultNamingConvention',
+            data: {
+              renderResultName: 'wrapper',
+            },
+            line: 5,
+            column: 17,
           },
-          line: 5,
-          column: 17,
-        },
-      ],
-    },
-    {
-      code: `
-        import { render } from '@testing-library/react';
+        ],
+      } as const,
+      {
+        code: `
+        import { render } from '${testingFramework}';
 
         const setup = () => {
           // this one must have a valid name
@@ -338,21 +318,21 @@ ruleTester.run(RULE_NAME, rule, {
           await wrapper.findByRole('button');
         });
       `,
-      errors: [
-        {
-          messageId: 'renderResultNamingConvention',
-          data: {
-            renderResultName: 'wrapper',
+        errors: [
+          {
+            messageId: 'renderResultNamingConvention',
+            data: {
+              renderResultName: 'wrapper',
+            },
+            line: 6,
+            column: 17,
           },
-          line: 6,
-          column: 17,
-        },
-      ],
-    },
-    {
-      settings: { 'testing-library/utils-module': 'test-utils' },
-      code: `
-        import { render } from '@testing-library/react';
+        ],
+      } as const,
+      {
+        settings: { 'testing-library/utils-module': 'test-utils' },
+        code: `
+        import { render } from '${testingFramework}';
 
         const setup = () => render(<SomeComponent />);
 
@@ -361,17 +341,18 @@ ruleTester.run(RULE_NAME, rule, {
           const button = wrapper.getByText('some button');
         });
       `,
-      errors: [
-        {
-          messageId: 'renderResultNamingConvention',
-          data: {
-            renderResultName: 'wrapper',
+        errors: [
+          {
+            messageId: 'renderResultNamingConvention',
+            data: {
+              renderResultName: 'wrapper',
+            },
+            line: 7,
+            column: 17,
           },
-          line: 7,
-          column: 17,
-        },
-      ],
-    },
+        ],
+      } as const,
+    ]),
     {
       settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
@@ -481,9 +462,10 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     },
-    {
-      code: `
-        import { render as testingLibraryRender } from '@testing-library/react';
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
+      {
+        code: `
+        import { render as testingLibraryRender } from '${testingFramework}';
 
         const setup = () => {
           return testingLibraryRender(<SomeComponent />);
@@ -494,21 +476,21 @@ ruleTester.run(RULE_NAME, rule, {
           await wrapper.findByRole('button');
         });
       `,
-      errors: [
-        {
-          messageId: 'renderResultNamingConvention',
-          data: {
-            renderResultName: 'wrapper',
+        errors: [
+          {
+            messageId: 'renderResultNamingConvention',
+            data: {
+              renderResultName: 'wrapper',
+            },
+            line: 9,
+            column: 17,
           },
-          line: 9,
-          column: 17,
-        },
-      ],
-    },
-    {
-      settings: { 'testing-library/utils-module': 'test-utils' },
-      code: `
-        import { render as testingLibraryRender } from '@testing-library/react';
+        ],
+      } as const,
+      {
+        settings: { 'testing-library/utils-module': 'test-utils' },
+        code: `
+        import { render as testingLibraryRender } from '${testingFramework}';
 
         const setup = () => {
           return testingLibraryRender(<SomeComponent />);
@@ -521,17 +503,18 @@ ruleTester.run(RULE_NAME, rule, {
           await wrapper.findByRole('button');
         });
       `,
-      errors: [
-        {
-          messageId: 'renderResultNamingConvention',
-          data: {
-            renderResultName: 'wrapper',
+        errors: [
+          {
+            messageId: 'renderResultNamingConvention',
+            data: {
+              renderResultName: 'wrapper',
+            },
+            line: 11,
+            column: 17,
           },
-          line: 11,
-          column: 17,
-        },
-      ],
-    },
+        ],
+      } as const,
+    ]),
     {
       settings: {
         'testing-library/utils-module': 'test-utils',


### PR DESCRIPTION
Follow-up of #572.

All rules that are included in the `marko` config should test that the rule is working for `@marko/testing-library` as well.

To do so for #572, @PrashantAshok copied over some tests and replaced the import, but didn't include tests for the following rules:
- `await-async-utils`
- `no-promise-in-fire-event`
- `no-render-in-setup`
- `no-wait-for-snapshot`
- `prefer-find-by`

The way I presented in the PR, is to map over an array of the already tested framework + `@marko/testing-library`.
This PR is only doing that.

I'll create a separate PR to test against all testing framework that the rules support.