### PR TITLE
test: refactor `@testing-library/angular` tests

### DIFF
--- a/tests/lib/rules/await-async-query.test.ts
+++ b/tests/lib/rules/await-async-query.test.ts
@@ -13,6 +13,7 @@ const ruleTester = createRuleTester();
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/dom',
+  '@testing-library/angular',
   '@testing-library/react',
   '@marko/testing-library',
 ];

--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -6,6 +6,7 @@ const ruleTester = createRuleTester();
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/dom',
+  '@testing-library/angular',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/no-await-sync-query.test.ts
+++ b/tests/lib/rules/no-await-sync-query.test.ts
@@ -9,6 +9,7 @@ const ruleTester = createRuleTester();
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/dom',
+  '@testing-library/angular',
   '@testing-library/react',
   '@marko/testing-library',
 ];

--- a/tests/lib/rules/no-container.test.ts
+++ b/tests/lib/rules/no-container.test.ts
@@ -4,6 +4,7 @@ import { createRuleTester } from '../test-utils';
 const ruleTester = createRuleTester();
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
+  '@testing-library/angular',
   '@testing-library/react',
   '@marko/testing-library',
 ];

--- a/tests/lib/rules/no-debugging-utils.test.ts
+++ b/tests/lib/rules/no-debugging-utils.test.ts
@@ -4,6 +4,7 @@ import { createRuleTester } from '../test-utils';
 const ruleTester = createRuleTester();
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
+  '@testing-library/angular',
   '@testing-library/react',
   '@marko/testing-library',
 ];

--- a/tests/lib/rules/no-dom-import.test.ts
+++ b/tests/lib/rules/no-dom-import.test.ts
@@ -4,29 +4,50 @@ import { createRuleTester } from '../test-utils';
 const ruleTester = createRuleTester();
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
-  'react-testing-library',
-  '@testing-library/react',
-  '@marko/testing-library',
+  {
+    configOption: 'angular',
+    oldName: '@testing-library/angular',
+    newName: '@testing-library/angular',
+  },
+  {
+    configOption: 'react',
+    oldName: 'react-testing-library',
+    newName: '@testing-library/react',
+  },
+  {
+    configOption: 'vue',
+    oldName: 'vue-testing-library',
+    newName: '@testing-library/vue',
+  },
+  {
+    configOption: 'marko',
+    oldName: '@marko/testing-library',
+    newName: '@marko/testing-library',
+  },
 ];
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     'import { foo } from "foo"',
     'import "foo"',
-    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
-      `import { fireEvent } from "${testingFramework}"`,
-      `import * as testing from "${testingFramework}"`,
-      `import "${testingFramework}"`,
-    ]),
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap(({ oldName, newName }) =>
+      [oldName, newName].flatMap((testingFramework) => [
+        `import { fireEvent } from "${testingFramework}"`,
+        `import * as testing from "${testingFramework}"`,
+        `import "${testingFramework}"`,
+      ])
+    ),
     'const { foo } = require("foo")',
     'require("foo")',
     'require("")',
     'require()',
-    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
-      `const { fireEvent } = require("${testingFramework}")`,
-      `const { fireEvent: testing } = require("${testingFramework}")`,
-      `require("${testingFramework}")`,
-    ]),
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap(({ oldName, newName }) =>
+      [oldName, newName].flatMap((testingFramework) => [
+        `const { fireEvent } = require("${testingFramework}")`,
+        `const { fireEvent: testing } = require("${testingFramework}")`,
+        `require("${testingFramework}")`,
+      ])
+    ),
     {
       code: 'import { fireEvent } from "test-utils"',
       settings: { 'testing-library/utils-module': 'test-utils' },
@@ -59,192 +80,128 @@ ruleTester.run(RULE_NAME, rule, {
       // case: dom-testing-library imported with custom module setting
       import { fireEvent } from "dom-testing-library"`,
     },
-    {
-      code: 'import { fireEvent } from "dom-testing-library"',
-      options: ['react'],
-      errors: [
-        {
-          messageId: 'noDomImportFramework',
-          data: {
-            module: 'react-testing-library',
-          },
-        },
-      ],
-      output: `import { fireEvent } from "react-testing-library"`,
-    },
-    {
-      code: 'import { fireEvent } from "dom-testing-library"',
-      options: ['marko'],
-      errors: [
-        {
-          messageId: 'noDomImportFramework',
-          data: {
-            module: '@marko/testing-library',
-          },
-        },
-      ],
-      output: `import { fireEvent } from "@marko/testing-library"`,
-    },
-    // Single quote or double quotes should not be replaced
-    {
-      code: `import { fireEvent } from 'dom-testing-library'`,
-      options: ['react'],
-      errors: [
-        {
-          messageId: 'noDomImportFramework',
-          data: {
-            module: 'react-testing-library',
-          },
-        },
-      ],
-      output: `import { fireEvent } from 'react-testing-library'`,
-    },
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap(
+      ({ configOption, oldName, newName }) =>
+        [true, false].flatMap((isOldImport) =>
+          // Single quote or double quotes should not be replaced
+          [`'`, `"`].flatMap((quote) => [
+            {
+              code: `const { fireEvent } = require(${quote}${
+                isOldImport ? 'dom-testing-library' : '@testing-library/dom'
+              }${quote})`,
+              options: [configOption],
+              errors: [
+                {
+                  data: { module: isOldImport ? oldName : newName },
+                  messageId: 'noDomImportFramework',
+                },
+              ],
+              output: `const { fireEvent } = require(${quote}${
+                isOldImport ? oldName : newName
+              }${quote})`,
+            } as const,
+            {
+              code: `import { fireEvent } from ${quote}${
+                isOldImport ? 'dom-testing-library' : '@testing-library/dom'
+              }${quote}`,
+              options: [configOption],
+              errors: [
+                {
+                  data: { module: isOldImport ? oldName : newName },
+                  messageId: 'noDomImportFramework',
+                },
+              ],
+              output: `import { fireEvent } from ${quote}${
+                isOldImport ? oldName : newName
+              }${quote}`,
+            } as const,
+          ])
+        )
+    ),
     {
       code: 'import * as testing from "dom-testing-library"',
-      errors: [
-        {
-          messageId: 'noDomImport',
-        },
-      ],
+      errors: [{ messageId: 'noDomImport' }],
     },
     {
-      settings: {
-        'testing-library/utils-module': 'test-utils',
-      },
+      settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
       // case: dom-testing-library wildcard imported with custom module setting
       import * as testing from "dom-testing-library"`,
-      errors: [
-        {
-          line: 3,
-          messageId: 'noDomImport',
-        },
-      ],
+      errors: [{ line: 3, messageId: 'noDomImport' }],
     },
     {
       code: 'import { fireEvent } from "@testing-library/dom"',
-      errors: [
-        {
-          messageId: 'noDomImport',
-        },
-      ],
+      errors: [{ messageId: 'noDomImport' }],
     },
     {
-      settings: {
-        'testing-library/utils-module': 'test-utils',
-      },
+      settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
       // case: @testing-library/dom imported with custom module setting
       import { fireEvent } from "@testing-library/dom"`,
-      errors: [
-        {
-          line: 3,
-          messageId: 'noDomImport',
-        },
-      ],
+      errors: [{ line: 3, messageId: 'noDomImport' }],
     },
     {
       code: 'import * as testing from "@testing-library/dom"',
-      errors: [
-        {
-          messageId: 'noDomImport',
-        },
-      ],
+      errors: [{ messageId: 'noDomImport' }],
     },
     {
       code: 'import "dom-testing-library"',
-      errors: [
-        {
-          messageId: 'noDomImport',
-        },
-      ],
+      errors: [{ messageId: 'noDomImport' }],
     },
     {
       code: 'import "@testing-library/dom"',
-      errors: [
-        {
-          messageId: 'noDomImport',
-        },
-      ],
+      errors: [{ messageId: 'noDomImport' }],
     },
     {
       code: 'const { fireEvent } = require("dom-testing-library")',
-      errors: [
-        {
-          messageId: 'noDomImport',
-        },
-      ],
+      errors: [{ messageId: 'noDomImport' }],
     },
     {
-      settings: {
-        'testing-library/utils-module': 'test-utils',
-      },
+      settings: { 'testing-library/utils-module': 'test-utils' },
       code: `
       // case: dom-testing-library required with custom module setting
       const { fireEvent } = require("dom-testing-library")`,
-      errors: [
-        {
-          line: 3,
-          messageId: 'noDomImport',
-        },
-      ],
+      errors: [{ line: 3, messageId: 'noDomImport' }],
     },
     {
       code: 'const { fireEvent } = require("@testing-library/dom")',
-      errors: [
-        {
-          messageId: 'noDomImport',
-        },
-      ],
+      errors: [{ messageId: 'noDomImport' }],
     },
-    {
-      code: 'const { fireEvent } = require("@testing-library/dom")',
-      options: ['vue'],
-      errors: [
-        {
-          messageId: 'noDomImportFramework',
-          data: {
-            module: '@testing-library/vue',
-          },
-        },
-      ],
-      output: 'const { fireEvent } = require("@testing-library/vue")',
-    },
-    {
-      settings: {
-        'testing-library/utils-module': 'test-utils',
-      },
-      code: `
-      // case: @testing-library/dom required with custom module setting
-      const { fireEvent } = require("@testing-library/dom")`,
-      options: ['vue'],
-      errors: [
-        {
-          messageId: 'noDomImportFramework',
-          data: {
-            module: '@testing-library/vue',
-          },
-        },
-      ],
-      output: `
-      // case: @testing-library/dom required with custom module setting
-      const { fireEvent } = require("@testing-library/vue")`,
-    },
+    ...SUPPORTED_TESTING_FRAMEWORKS.flatMap(
+      ({ configOption, oldName, newName }) =>
+        [true, false].map(
+          (isOldImport) =>
+            ({
+              settings: { 'testing-library/utils-module': 'test-utils' },
+              code: `
+                // case: @testing-library/dom required with custom module setting
+                const { fireEvent } = require("${
+                  isOldImport ? 'dom-testing-library' : '@testing-library/dom'
+                }")
+              `,
+              options: [configOption],
+              errors: [
+                {
+                  data: { module: isOldImport ? oldName : newName },
+                  messageId: 'noDomImportFramework',
+                },
+              ],
+              output: `
+                // case: @testing-library/dom required with custom module setting
+                const { fireEvent } = require("${
+                  isOldImport ? oldName : newName
+                }")
+              `,
+            } as const)
+        )
+    ),
     {
       code: 'require("dom-testing-library")',
-      errors: [
-        {
-          messageId: 'noDomImport',
-        },
-      ],
+      errors: [{ messageId: 'noDomImport' }],
     },
     {
       code: 'require("@testing-library/dom")',
-      errors: [
-        {
-          messageId: 'noDomImport',
-        },
-      ],
+      errors: [{ messageId: 'noDomImport' }],
     },
   ],
 });

--- a/tests/lib/rules/no-node-access.test.ts
+++ b/tests/lib/rules/no-node-access.test.ts
@@ -4,6 +4,7 @@ import { createRuleTester } from '../test-utils';
 const ruleTester = createRuleTester();
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
+  '@testing-library/angular',
   '@testing-library/react',
   '@marko/testing-library',
 ];

--- a/tests/lib/rules/no-promise-in-fire-event.test.ts
+++ b/tests/lib/rules/no-promise-in-fire-event.test.ts
@@ -6,6 +6,7 @@ const ruleTester = createRuleTester();
 const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/foo',
   '@testing-library/dom',
+  '@testing-library/angular',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/no-render-in-setup.test.ts
+++ b/tests/lib/rules/no-render-in-setup.test.ts
@@ -6,6 +6,7 @@ const ruleTester = createRuleTester();
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/foo',
+  '@testing-library/angular',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/no-wait-for-empty-callback.test.ts
+++ b/tests/lib/rules/no-wait-for-empty-callback.test.ts
@@ -6,6 +6,7 @@ const ruleTester = createRuleTester();
 const ALL_WAIT_METHODS = ['waitFor', 'waitForElementToBeRemoved'];
 const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/dom',
+  '@testing-library/angular',
   '@testing-library/react',
   '@marko/testing-library',
 ];

--- a/tests/lib/rules/no-wait-for-multiple-assertions.test.ts
+++ b/tests/lib/rules/no-wait-for-multiple-assertions.test.ts
@@ -7,6 +7,7 @@ const ruleTester = createRuleTester();
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/dom',
+  '@testing-library/angular',
   '@testing-library/react',
   '@marko/testing-library',
 ];

--- a/tests/lib/rules/no-wait-for-side-effects.test.ts
+++ b/tests/lib/rules/no-wait-for-side-effects.test.ts
@@ -5,6 +5,7 @@ const ruleTester = createRuleTester();
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/dom',
+  '@testing-library/angular',
   '@testing-library/react',
   '@marko/testing-library',
 ];

--- a/tests/lib/rules/no-wait-for-snapshot.test.ts
+++ b/tests/lib/rules/no-wait-for-snapshot.test.ts
@@ -6,6 +6,7 @@ const ruleTester = createRuleTester();
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/dom',
+  '@testing-library/angular',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/prefer-find-by.test.ts
+++ b/tests/lib/rules/prefer-find-by.test.ts
@@ -17,6 +17,7 @@ const ruleTester = createRuleTester();
 const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/foo',
   '@testing-library/dom',
+  '@testing-library/angular',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/prefer-query-by-disappearance.test.ts
+++ b/tests/lib/rules/prefer-query-by-disappearance.test.ts
@@ -7,6 +7,7 @@ const ruleTester = createRuleTester();
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/dom',
+  '@testing-library/angular',
   '@testing-library/react',
   '@marko/testing-library',
 ];

--- a/tests/lib/rules/prefer-screen-queries.test.ts
+++ b/tests/lib/rules/prefer-screen-queries.test.ts
@@ -10,6 +10,7 @@ const ruleTester = createRuleTester();
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/dom',
+  '@testing-library/angular',
   '@testing-library/react',
   '@marko/testing-library',
 ];

--- a/tests/lib/rules/render-result-naming-convention.test.ts
+++ b/tests/lib/rules/render-result-naming-convention.test.ts
@@ -6,6 +6,7 @@ import { createRuleTester } from '../test-utils';
 const ruleTester = createRuleTester();
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
+  '@testing-library/angular',
   '@testing-library/react',
   '@marko/testing-library',
 ];


### PR DESCRIPTION
Follow-up of #582 & #583

Added explicit tests for `@testing-library/angular`