### PR TITLE
test: refactor `@testing-library/react` tests

### DIFF
--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -7,6 +7,7 @@ const ruleTester = createRuleTester();
 const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/dom',
   '@testing-library/angular',
+  '@testing-library/react',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/no-promise-in-fire-event.test.ts
+++ b/tests/lib/rules/no-promise-in-fire-event.test.ts
@@ -7,6 +7,7 @@ const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/foo',
   '@testing-library/dom',
   '@testing-library/angular',
+  '@testing-library/react',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/no-render-in-setup.test.ts
+++ b/tests/lib/rules/no-render-in-setup.test.ts
@@ -7,6 +7,7 @@ const ruleTester = createRuleTester();
 const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/foo',
   '@testing-library/angular',
+  '@testing-library/react',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/no-wait-for-snapshot.test.ts
+++ b/tests/lib/rules/no-wait-for-snapshot.test.ts
@@ -7,6 +7,7 @@ const ruleTester = createRuleTester();
 const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/dom',
   '@testing-library/angular',
+  '@testing-library/react',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/prefer-find-by.test.ts
+++ b/tests/lib/rules/prefer-find-by.test.ts
@@ -18,6 +18,7 @@ const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/foo',
   '@testing-library/dom',
   '@testing-library/angular',
+  '@testing-library/react',
   '@marko/testing-library',
 ];
 


### PR DESCRIPTION
Follow-up of #582, #583 & #584

Added explicit tests for `@testing-library/react`