### PR TITLE
test: refactor `@testing-library/vue` tests

### DIFF
--- a/tests/lib/rules/await-async-query.test.ts
+++ b/tests/lib/rules/await-async-query.test.ts
@@ -15,6 +15,7 @@ const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/dom',
   '@testing-library/angular',
   '@testing-library/react',
+  '@testing-library/vue',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -8,6 +8,7 @@ const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/dom',
   '@testing-library/angular',
   '@testing-library/react',
+  '@testing-library/vue',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/no-await-sync-query.test.ts
+++ b/tests/lib/rules/no-await-sync-query.test.ts
@@ -11,6 +11,7 @@ const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/dom',
   '@testing-library/angular',
   '@testing-library/react',
+  '@testing-library/vue',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/no-container.test.ts
+++ b/tests/lib/rules/no-container.test.ts
@@ -6,6 +6,7 @@ const ruleTester = createRuleTester();
 const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/angular',
   '@testing-library/react',
+  '@testing-library/vue',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/no-debugging-utils.test.ts
+++ b/tests/lib/rules/no-debugging-utils.test.ts
@@ -6,6 +6,7 @@ const ruleTester = createRuleTester();
 const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/angular',
   '@testing-library/react',
+  '@testing-library/vue',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/no-node-access.test.ts
+++ b/tests/lib/rules/no-node-access.test.ts
@@ -6,6 +6,7 @@ const ruleTester = createRuleTester();
 const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/angular',
   '@testing-library/react',
+  '@testing-library/vue',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/no-promise-in-fire-event.test.ts
+++ b/tests/lib/rules/no-promise-in-fire-event.test.ts
@@ -8,6 +8,7 @@ const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/dom',
   '@testing-library/angular',
   '@testing-library/react',
+  '@testing-library/vue',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/no-render-in-setup.test.ts
+++ b/tests/lib/rules/no-render-in-setup.test.ts
@@ -8,6 +8,7 @@ const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/foo',
   '@testing-library/angular',
   '@testing-library/react',
+  '@testing-library/vue',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/no-wait-for-empty-callback.test.ts
+++ b/tests/lib/rules/no-wait-for-empty-callback.test.ts
@@ -8,6 +8,7 @@ const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/dom',
   '@testing-library/angular',
   '@testing-library/react',
+  '@testing-library/vue',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/no-wait-for-multiple-assertions.test.ts
+++ b/tests/lib/rules/no-wait-for-multiple-assertions.test.ts
@@ -9,6 +9,7 @@ const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/dom',
   '@testing-library/angular',
   '@testing-library/react',
+  '@testing-library/vue',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/no-wait-for-side-effects.test.ts
+++ b/tests/lib/rules/no-wait-for-side-effects.test.ts
@@ -7,6 +7,7 @@ const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/dom',
   '@testing-library/angular',
   '@testing-library/react',
+  '@testing-library/vue',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/no-wait-for-snapshot.test.ts
+++ b/tests/lib/rules/no-wait-for-snapshot.test.ts
@@ -8,6 +8,7 @@ const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/dom',
   '@testing-library/angular',
   '@testing-library/react',
+  '@testing-library/vue',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/prefer-find-by.test.ts
+++ b/tests/lib/rules/prefer-find-by.test.ts
@@ -19,6 +19,7 @@ const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/dom',
   '@testing-library/angular',
   '@testing-library/react',
+  '@testing-library/vue',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/prefer-query-by-disappearance.test.ts
+++ b/tests/lib/rules/prefer-query-by-disappearance.test.ts
@@ -9,6 +9,7 @@ const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/dom',
   '@testing-library/angular',
   '@testing-library/react',
+  '@testing-library/vue',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/prefer-screen-queries.test.ts
+++ b/tests/lib/rules/prefer-screen-queries.test.ts
@@ -12,6 +12,7 @@ const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/dom',
   '@testing-library/angular',
   '@testing-library/react',
+  '@testing-library/vue',
   '@marko/testing-library',
 ];
 

--- a/tests/lib/rules/render-result-naming-convention.test.ts
+++ b/tests/lib/rules/render-result-naming-convention.test.ts
@@ -8,6 +8,7 @@ const ruleTester = createRuleTester();
 const SUPPORTED_TESTING_FRAMEWORKS = [
   '@testing-library/angular',
   '@testing-library/react',
+  '@testing-library/vue',
   '@marko/testing-library',
 ];
 


### PR DESCRIPTION
Follow-up of #582, #583, #584 & #585

Added explicit tests for `@testing-library/vue`