### PR TITLE
[ISSUE-509] show wait-fire-event correctly

### DIFF
--- a/lib/rules/await-fire-event.ts
+++ b/lib/rules/await-fire-event.ts
@@ -29,7 +29,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
     },
     messages: {
       awaitFireEvent:
-        'Promise returned from `fireEvent.{{ methodName }}` must be handled',
+        'Promise returned from `fireEvent.{{ name }}` must be handled',
       fireEventWrapper:
         'Promise returned from `fireEvent.{{ wrapperName }}` wrapper over fire event method must be handled',
     },


### PR DESCRIPTION
## Checks

- [ ] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [ ] If some rule is added/updated/removed, I've regenerated the rules list (`npm run generate:rules-list`)
- [ ] If some rule meta info is changed, I've regenerated the plugin shared configs (`npm run generate:configs`)

## Changes

<!-- List the changes you're making with this pull request. -->
Issue link: https://github.com/testing-library/eslint-plugin-testing-library/issues/590

- I changed the waitFireEvent prop from "methodName" to "name"

![image](https://user-images.githubusercontent.com/54630721/169611306-3c31a483-2946-487e-8bf1-f55acb049556.png)
I am showing the error with gitLens

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->
