### PR TITLE
docs(prefer-presence-queries): add a note to discourage usage of options

### DIFF
--- a/docs/rules/prefer-presence-queries.md
+++ b/docs/rules/prefer-presence-queries.md
@@ -61,10 +61,10 @@ test('some test', async () => {
 
 ## Options
 
-| Option     | Required | Default | Details                                                                                                                                                      |
-| ---------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `presence` | No       | `true`  | If enabled, this rule will ensure `getBy*` is used to validate whether an element is present. If disabled, `queryBy*` will be accepted for presence queries. |
-| `absence`  | No       | `true`  | If enabled, this rule will ensure `queryBy*` is used to validate whether an element is absent. If disabled, `getBy*` will be accepted for absence queries.   |
+| Option     | Required | Default | Details                                                                                                                                                                                                                                                                                                                                                                            |
+| ---------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `presence` | No       | `true`  | If enabled, this rule will ensure `getBy*` is used to validate whether an element is present. If disabled, `queryBy*` will be accepted for presence queries. _Note: using this option is not recommended. It is workaround for false positives that should eventually be [fixed](https://github.com/testing-library/eslint-plugin-testing-library/issues/518) in this repository._ |
+| `absence`  | No       | `true`  | If enabled, this rule will ensure `queryBy*` is used to validate whether an element is absent. If disabled, `getBy*` will be accepted for absence queries. _Note: using this option is not recommended. It is workaround for false positives that should eventually be [fixed](https://github.com/testing-library/eslint-plugin-testing-library/issues/518) in this repository._   |
 
 ## Example
 


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [ ] If some rule is added/updated/removed, I've regenerated the rules list (`npm run generate:rules-list`)
- [ ] If some rule meta info is changed, I've regenerated the plugin shared configs (`npm run generate:configs`)

## Changes

<!-- List the changes you're making with this pull request. -->

- Added a note in `prefer-presence-queries` that discourages the use of options

## Context

In https://github.com/testing-library/eslint-plugin-testing-library/pull/557 2 `prefer-presence-queries` options were added due to false positives described in https://github.com/testing-library/eslint-plugin-testing-library/issues/518.

As I understand, these options are a short-term workaround. They will be removed when false positives are fixed. If that's the case, I think it's worth outlining this in rule docs.