### PR TITLE
feat(no-node-access): add `allowContainerFirstChild` option

### DIFF
--- a/docs/rules/no-node-access.md
+++ b/docs/rules/no-node-access.md
@@ -51,6 +51,25 @@ within(signinModal).getByPlaceholderText('Username');
 document.getElementById('submit-btn').closest('button');
 ```
 
+## Options
+
+This rule has one option:
+
+- `allowContainerFirstChild`: **disabled by default**. When we have container
+  with rendered content then the easiest way to access content itself is [by using
+  `firstChild` property](https://testing-library.com/docs/react-testing-library/api/#container-1). Use this option in cases when this is hardly avoidable.
+
+  ```js
+  "testing-library/no-node-access": ["error", {"allowContainerFirstChild": true}]
+  ```
+
+Correct:
+
+```jsx
+const { container } = render(<MyComponent />);
+expect(container.firstChild).toMatchSnapshot();
+```
+
 ## Further Reading
 
 ### Properties / methods that return another Node


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [ ] If some rule is added/updated/removed, I've regenerated the rules list (`npm run generate:rules-list`)
- [ ] If some rule meta info is changed, I've regenerated the plugin shared configs (`npm run generate:configs`)

## Changes

- Add `allowContainerFirstChild` option to `no-node-access` rule

## Context

Fixes #593
