### PR TITLE
fix: `prefer-query-by-disappearance` error line and column to the beginning of `get` or `find` queries

### DIFF
--- a/lib/rules/prefer-query-by-disappearance.ts
+++ b/lib/rules/prefer-query-by-disappearance.ts
@@ -51,14 +51,12 @@ export default createTestingLibraryRule<Options, MessageIds>({
 		}
 
 		/**
-		 * Checks if a node is a query node and starts with "get" or "find".
+		 * Checks if node is reportable (starts with "get" or "find") and if it is, reports it with `context.report()`.
 		 *
 		 * @param {TSESTree.LeftHandSideExpression} node - Node to be tested
-		 * @returns {Boolean} True if node should be reported and reports it with `context.report()`. False if node should not be reported.
+		 * @returns {Boolean} Boolean indicating if expression was reported
 		 */
-		function isReportableExpression(
-			node: TSESTree.LeftHandSideExpression
-		): boolean {
+		function reportExpression(node: TSESTree.LeftHandSideExpression): boolean {
 			const argumentProperty = isMemberExpression(node)
 				? getPropertyIdentifierNode(node.property)
 				: getPropertyIdentifierNode(node);
@@ -92,7 +90,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 				return false;
 			}
 
-			return isReportableExpression(node.callee);
+			return reportExpression(node.callee);
 		}
 
 		function isReturnViolation(node: TSESTree.Statement) {
@@ -100,7 +98,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 				return false;
 			}
 
-			return isReportableExpression(node.argument.callee);
+			return reportExpression(node.argument.callee);
 		}
 
 		function isNonReturnViolation(node: TSESTree.Statement) {
@@ -115,7 +113,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 				return false;
 			}
 
-			return isReportableExpression(node.expression.callee);
+			return reportExpression(node.expression.callee);
 		}
 
 		function isStatementViolation(statement: TSESTree.Statement) {
@@ -160,7 +158,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 				return false;
 			}
 
-			return isReportableExpression(node.body.callee);
+			return reportExpression(node.body.callee);
 		}
 
 		function checkArrowFunctionViolation(

--- a/tests/lib/rules/prefer-query-by-disappearance.test.ts
+++ b/tests/lib/rules/prefer-query-by-disappearance.test.ts
@@ -225,7 +225,7 @@ ruleTester.run(RULE_NAME, rule, {
 				{
 					messageId: 'preferQueryByDisappearance',
 					line: 4,
-					column: 41,
+					column: 54,
 				},
 			],
 		},
@@ -239,7 +239,7 @@ ruleTester.run(RULE_NAME, rule, {
 				{
 					messageId: 'preferQueryByDisappearance',
 					line: 4,
-					column: 41,
+					column: 54,
 				},
 			],
 		},
@@ -253,7 +253,7 @@ ruleTester.run(RULE_NAME, rule, {
 				{
 					messageId: 'preferQueryByDisappearance',
 					line: 4,
-					column: 41,
+					column: 54,
 				},
 			],
 		},
@@ -268,8 +268,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 4,
-					column: 41,
+					line: 5,
+					column: 18,
 				},
 			],
 		},
@@ -284,8 +284,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 4,
-					column: 41,
+					line: 5,
+					column: 18,
 				},
 			],
 		},
@@ -300,8 +300,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 4,
-					column: 41,
+					line: 5,
+					column: 25,
 				},
 			],
 		},
@@ -316,8 +316,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 4,
-					column: 41,
+					line: 5,
+					column: 25,
 				},
 			],
 		},
@@ -331,7 +331,7 @@ ruleTester.run(RULE_NAME, rule, {
 				{
 					messageId: 'preferQueryByDisappearance',
 					line: 4,
-					column: 41,
+					column: 48,
 				},
 			],
 		},
@@ -345,7 +345,7 @@ ruleTester.run(RULE_NAME, rule, {
 				{
 					messageId: 'preferQueryByDisappearance',
 					line: 4,
-					column: 41,
+					column: 48,
 				},
 			],
 		},
@@ -360,8 +360,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 4,
-					column: 41,
+					line: 5,
+					column: 25,
 				},
 			],
 		},
@@ -376,8 +376,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 4,
-					column: 41,
+					line: 5,
+					column: 25,
 				},
 			],
 		},
@@ -392,8 +392,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 4,
-					column: 41,
+					line: 5,
+					column: 18,
 				},
 			],
 		},
@@ -408,8 +408,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 4,
-					column: 41,
+					line: 5,
+					column: 18,
 				},
 			],
 		},
@@ -425,8 +425,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 5,
-					column: 41,
+					line: 6,
+					column: 11,
 				},
 			],
 		},
@@ -442,8 +442,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 5,
-					column: 41,
+					line: 6,
+					column: 11,
 				},
 			],
 		},
@@ -459,8 +459,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 5,
-					column: 41,
+					line: 6,
+					column: 11,
 				},
 			],
 		},
@@ -476,8 +476,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 5,
-					column: 41,
+					line: 6,
+					column: 11,
 				},
 			],
 		},
@@ -493,8 +493,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 5,
-					column: 41,
+					line: 6,
+					column: 18,
 				},
 			],
 		},
@@ -510,8 +510,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 5,
-					column: 41,
+					line: 6,
+					column: 18,
 				},
 			],
 		},
@@ -527,8 +527,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 5,
-					column: 41,
+					line: 6,
+					column: 18,
 				},
 			],
 		},
@@ -544,8 +544,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 5,
-					column: 41,
+					line: 6,
+					column: 18,
 				},
 			],
 		},
@@ -561,8 +561,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 5,
-					column: 41,
+					line: 6,
+					column: 18,
 				},
 			],
 		},
@@ -578,8 +578,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 5,
-					column: 41,
+					line: 6,
+					column: 18,
 				},
 			],
 		},
@@ -595,8 +595,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 5,
-					column: 41,
+					line: 6,
+					column: 18,
 				},
 			],
 		},
@@ -612,8 +612,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 5,
-					column: 41,
+					line: 6,
+					column: 18,
 				},
 			],
 		},
@@ -629,8 +629,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 5,
-					column: 41,
+					line: 6,
+					column: 11,
 				},
 			],
 		},
@@ -646,8 +646,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 5,
-					column: 41,
+					line: 6,
+					column: 11,
 				},
 			],
 		},
@@ -663,8 +663,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 5,
-					column: 41,
+					line: 6,
+					column: 11,
 				},
 			],
 		},
@@ -680,8 +680,8 @@ ruleTester.run(RULE_NAME, rule, {
 			errors: [
 				{
 					messageId: 'preferQueryByDisappearance',
-					line: 5,
-					column: 41,
+					line: 6,
+					column: 11,
 				},
 			],
 		},
@@ -696,7 +696,7 @@ ruleTester.run(RULE_NAME, rule, {
 				{
 					messageId: 'preferQueryByDisappearance',
 					line: 5,
-					column: 41,
+					column: 47,
 				},
 			],
 		},
@@ -711,7 +711,7 @@ ruleTester.run(RULE_NAME, rule, {
 				{
 					messageId: 'preferQueryByDisappearance',
 					line: 5,
-					column: 41,
+					column: 47,
 				},
 			],
 		},


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [ ] If some rule is added/updated/removed, I've regenerated the rules list (`npm run generate:rules-list`)
- [ ] If some rule meta info is changed, I've regenerated the plugin shared configs (`npm run generate:configs`)

## Changes
- refactor reporting an error deeper, where the `get` or `find` query variants are found
- refactor some function names to convey that they also check/report the error, not just return boolean based on if an error should be reported
- update unit tests to have correct error line and column

## Context
Closes #600 