### PR TITLE
fix: `no-await-sync-events` false positive

### DIFF
--- a/tests/lib/rules/no-await-sync-events.test.ts
+++ b/tests/lib/rules/no-await-sync-events.test.ts
@@ -151,6 +151,28 @@ ruleTester.run(RULE_NAME, rule, {
       `,
 		},
 		{
+			code: `async() => {
+		const delay = 10
+        await userEvent.keyboard('foo', {delay})
+      }
+      `,
+		},
+		{
+			code: `async() => {
+		const delay = 10
+        await userEvent.type(element, text, {delay})
+      }
+      `,
+		},
+		{
+			code: `async() => {
+		let delay = 0
+        delay = 10
+        await userEvent.type(element, text, {delay})
+      }
+      `,
+		},
+		{
 			settings: { 'testing-library/utils-module': 'test-utils' },
 			code: `
         import { fireEvent } from 'somewhere-else';
@@ -366,6 +388,57 @@ ruleTester.run(RULE_NAME, rule, {
 					column: 17,
 					messageId: 'noAwaitSyncEvents',
 					data: { name: 'renamedUserEvent.keyboard' },
+				},
+			],
+		},
+		{
+			code: `async() => {
+          const delay = 0
+          await userEvent.type('foo', { delay });
+        }
+      `,
+			errors: [
+				{
+					line: 3,
+					column: 17,
+					messageId: 'noAwaitSyncEvents',
+					data: { name: 'userEvent.type' },
+				},
+			],
+		},
+		{
+			code: `async() => {
+          const delay = 0
+		  const somethingElse = true
+		  const skipHover = true
+          await userEvent.type('foo', { delay, skipHover });
+        }
+      `,
+			errors: [
+				{
+					line: 5,
+					column: 17,
+					messageId: 'noAwaitSyncEvents',
+					data: { name: 'userEvent.type' },
+				},
+			],
+		},
+		{
+			code: `async() => {
+		  let delay = 0
+		  const somethingElse = true
+		  const skipHover = true
+		  delay = 15
+		  delay = 0
+          await userEvent.type('foo', { delay, skipHover });
+        }
+      `,
+			errors: [
+				{
+					line: 7,
+					column: 17,
+					messageId: 'noAwaitSyncEvents',
+					data: { name: 'userEvent.type' },
 				},
 			],
 		},


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [ ] If some rule is added/updated/removed, I've regenerated the rules list (`npm run generate:rules-list`)
- [ ] If some rule meta info is changed, I've regenerated the plugin shared configs (`npm run generate:configs`)

## Changes

- Check if `delay` is declared or assigned a value elsewhere than in the call expression's arguments
- Add test cases that have declarations and assignments

## Context

Closes #403
