### PR TITLE
fix(consistent-data-testid): avoid crash for filename with square brackets

### DIFF
--- a/docs/rules/consistent-data-testid.md
+++ b/docs/rules/consistent-data-testid.md
@@ -28,10 +28,10 @@ const baz = (props) => <div>...</div>;
 
 ## Options
 
-| Option            | Required | Default       | Details                                                                                                                                                                                                                                                                       | Example                                               |
-| ----------------- | -------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| `testIdPattern`   | Yes      | None          | A regex used to validate the format of the `data-testid` value. `{fileName}` can optionally be used as a placeholder and will be substituted with the name of the file OR the name of the files parent directory in the case when the file name is `index.js`                 | `^{fileName}(\_\_([A-Z]+[a-z]_?)+)_\$`                |
-| `testIdAttribute` | No       | `data-testid` | A string (or array of strings) used to specify the attribute used for querying by ID. This is only required if data-testid has been explicitly overridden in the [RTL configuration](https://testing-library.com/docs/dom-testing-library/api-queries#overriding-data-testid) | `data-my-test-attribute`, `["data-testid", "testId"]` |
+| Option            | Required | Default       | Details                                                                                                                                                                                                                                                                                                                                                                               | Example                                               |
+| ----------------- | -------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `testIdPattern`   | Yes      | None          | A regex used to validate the format of the `data-testid` value. `{fileName}` can optionally be used as a placeholder and will be substituted with the name of the file OR the name of the files parent directory in the case when the file name is `index.js` OR empty string in the case of dynamically changing routes (that contain square brackets) with `Gatsby.js` or `Next.js` | `^{fileName}(\_\_([A-Z]+[a-z]_?)+)_\$`                |
+| `testIdAttribute` | No       | `data-testid` | A string (or array of strings) used to specify the attribute used for querying by ID. This is only required if data-testid has been explicitly overridden in the [RTL configuration](https://testing-library.com/docs/dom-testing-library/api-queries#overriding-data-testid)                                                                                                         | `data-my-test-attribute`, `["data-testid", "testId"]` |
 
 ## Example
 
@@ -56,3 +56,7 @@ const baz = (props) => <div>...</div>;
 	]
 }
 ```
+
+## Notes
+
+- If you are using Gatsby.js's [client-only routes](https://www.gatsbyjs.com/docs/reference/routing/file-system-route-api/#syntax-client-only-routes) or Next.js's [dynamic routes](https://nextjs.org/docs/routing/dynamic-routes) and therefore have square brackets (`[]`) in the filename (e.g. `../path/to/[component].js`), the `{fileName}` placeholder will be replaced with an empty string. This is because a linter cannot know what the dynamic content will be at run time.

--- a/lib/rules/consistent-data-testid.ts
+++ b/lib/rules/consistent-data-testid.ts
@@ -74,6 +74,12 @@ export default createTestingLibraryRule<Options, MessageIds>({
 		function getFileNameData() {
 			const splitPath = getFilename().split('/');
 			const fileNameWithExtension = splitPath.pop() ?? '';
+			if (
+				fileNameWithExtension.includes('[') ||
+				fileNameWithExtension.includes(']')
+			) {
+				return { fileName: undefined };
+			}
 			const parent = splitPath.pop();
 			const fileName = fileNameWithExtension.split('.').shift();
 

--- a/tests/lib/rules/consistent-data-testid.test.ts
+++ b/tests/lib/rules/consistent-data-testid.test.ts
@@ -200,6 +200,67 @@ const validTestCases: ValidTestCase[] = [
         `,
 		options: [{ testIdPattern: 'somethingElse' }],
 	},
+	// To fix issue 509, https://github.com/testing-library/eslint-plugin-testing-library/issues/509
+	// Gatsby.js ja Next.js use square brackets in filenames to create dynamic routes
+	{
+		code: `
+            import React from 'react';
+            
+            const TestComponent = props => {
+              return (
+                <div data-testid="__CoolStuff">
+                  Hello
+                </div>
+              )
+            };
+          `,
+		options: [
+			{
+				testIdPattern: '^{fileName}(__([A-Z]+[a-z]*?)+)*$',
+			},
+		],
+		filename: '/my/cool/file/path/[client-only].js',
+	},
+	{
+		code: `
+            import React from 'react';
+            
+            const TestComponent = props => {
+              return (
+                <div data-testid="__CoolStuff">
+                  Hello
+                </div>
+              )
+            };
+          `,
+		options: [
+			{
+				// should work if given the {fileName} placeholder
+				testIdPattern: '^{fileName}(__([A-Z]+[a-z]*?)+)*$',
+			},
+		],
+		filename: '/my/cool/file/path/[...wildcard].js',
+	},
+	{
+		code: `
+            import React from 'react';
+            
+            const TestComponent = props => {
+              return (
+                <div data-testid="__CoolStuff">
+                  Hello
+                </div>
+              )
+            };
+          `,
+		options: [
+			{
+				// should work also if not given the {fileName} placeholder
+				testIdPattern: '^(__([A-Z]+[a-z]*?)+)*$',
+			},
+		],
+		filename: '/my/cool/file/path/[...wildcard].js',
+	},
 ];
 const invalidTestCases: InvalidTestCase[] = [
 	{


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [ ] If some rule is added/updated/removed, I've regenerated the rules list (`npm run generate:rules-list`)
- [ ] If some rule meta info is changed, I've regenerated the plugin shared configs (`npm run generate:configs`)

## Changes

In the discussion of the issue #509 there hasn't been a consensus how to fix the issue, and this is my suggestion.

It seems that the crash in 509 is caused by several repos using static site generators and their dynamic routing.
- `gatsbyjs/gatsby` uses Gatsby.js
- [`vickev/howdypix`](https://github.com/vickev/howdypix/tree/master/apps/webapp) [uses Next.js](https://github.com/vickev/howdypix/blob/master/apps/webapp/package.json#L71)

Both [Gatsby.js](https://www.gatsbyjs.com/docs/reference/routing/file-system-route-api/#syntax-client-only-routes) and [Next.js](https://nextjs.org/docs/routing/dynamic-routes) support square brackets and three periods in filename. However, since the three periods is optional, it makes sense to catch this edge case by looking only at the presence of square brackets.

This PR:
- makes the `consistent-data-testid` rule replace `{fileName}` placeholder with an empty string if the filename gotten from path contains square brackets
- updates the unit tests to include some edge cases with square brackets
- updates the rule documentation to mention this edge case

## Context

Closes #509.

Comments and thoughts about this PR are welcome.
