### PR TITLE
fix(no-wait-for-side-effects): false positive inside `.then()`

### DIFF
--- a/docs/rules/no-wait-for-side-effects.md
+++ b/docs/rules/no-wait-for-side-effects.md
@@ -74,6 +74,15 @@ Examples of **correct** code for this rule:
   });
 
   // or
+  userEvent.click(button);
+  await waitFor(function() {
+    expect(b).toEqual('b');
+  }).then(() => {
+    // Outside of waitFor, e.g. inside a .then() side effects are allowed
+    fireEvent.click(button);
+  });
+
+  // or
   render(<App />)
   await waitFor(() => {
     expect(b).toEqual('b');

--- a/docs/rules/no-wait-for-side-effects.md
+++ b/docs/rules/no-wait-for-side-effects.md
@@ -75,7 +75,7 @@ Examples of **correct** code for this rule:
 
   // or
   userEvent.click(button);
-  await waitFor(function() {
+  waitFor(function() {
     expect(b).toEqual('b');
   }).then(() => {
     // Outside of waitFor, e.g. inside a .then() side effects are allowed

--- a/lib/rules/no-wait-for-side-effects.ts
+++ b/lib/rules/no-wait-for-side-effects.ts
@@ -1,4 +1,4 @@
-import { ASTUtils, TSESTree } from '@typescript-eslint/utils';
+import { TSESTree } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {
@@ -8,7 +8,7 @@ import {
 	isAssignmentExpression,
 	isCallExpression,
 	isSequenceExpression,
-	isMemberExpression,
+	hasThenProperty,
 } from '../node-utils';
 
 export const RULE_NAME = 'no-wait-for-side-effects';
@@ -70,12 +70,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 
 			const callExpressionNode = node.parent.parent as TSESTree.CallExpression;
 
-			const test =
-				isMemberExpression(callExpressionNode.callee) &&
-				ASTUtils.isIdentifier(callExpressionNode.callee.property) &&
-				callExpressionNode.callee.property.name === 'then';
-
-			return test;
+			return hasThenProperty(callExpressionNode.callee);
 		}
 
 		function isRenderInVariableDeclaration(node: TSESTree.Node) {

--- a/tests/lib/rules/no-wait-for-side-effects.test.ts
+++ b/tests/lib/rules/no-wait-for-side-effects.test.ts
@@ -106,7 +106,7 @@ ruleTester.run(RULE_NAME, rule, {
 				code: `
           import { waitFor } from '${testingFramework}';
           userEvent.click(button)
-          await waitFor(function() {
+          waitFor(function() {
             expect(b).toEqual('b')
           }).then(() => {
             // Side effects are allowed inside .then()
@@ -753,7 +753,7 @@ ruleTester.run(RULE_NAME, rule, {
 				// Issue #500, https://github.com/testing-library/eslint-plugin-testing-library/issues/500
 				code: `
         import { waitFor } from '${testingFramework}';
-        await waitFor(function() {
+        waitFor(function() {
           userEvent.click(button)
           expect(b).toEqual('b')
         }).then(() => {

--- a/tests/lib/rules/no-wait-for-side-effects.test.ts
+++ b/tests/lib/rules/no-wait-for-side-effects.test.ts
@@ -739,7 +739,7 @@ ruleTester.run(RULE_NAME, rule, {
 				// Issue #500, https://github.com/testing-library/eslint-plugin-testing-library/issues/500
 				code: `
         import { waitFor } from '${testingFramework}';
-        await waitFor(function() {
+        waitFor(function() {
           userEvent.click(button)
           expect(b).toEqual('b')
         }).then(() => {

--- a/tests/lib/rules/no-wait-for-side-effects.test.ts
+++ b/tests/lib/rules/no-wait-for-side-effects.test.ts
@@ -101,6 +101,19 @@ ruleTester.run(RULE_NAME, rule, {
           })
         `,
 			},
+			{
+				// Issue #500, https://github.com/testing-library/eslint-plugin-testing-library/issues/500
+				code: `
+          import { waitFor } from '${testingFramework}';
+          userEvent.click(button)
+          await waitFor(function() {
+            expect(b).toEqual('b')
+          }).then(() => {
+            // Side effects are allowed inside .then()
+            userEvent.click(button);
+          })
+        `,
+			},
 		]),
 		{
 			settings: { 'testing-library/utils-module': 'test-utils' },
@@ -721,6 +734,41 @@ ruleTester.run(RULE_NAME, rule, {
         })
       `,
 				errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+			} as const,
+			{
+				// Issue #500, https://github.com/testing-library/eslint-plugin-testing-library/issues/500
+				code: `
+        import { waitFor } from '${testingFramework}';
+        await waitFor(function() {
+          userEvent.click(button)
+          expect(b).toEqual('b')
+        }).then(() => {
+          userEvent.click(button) // Side effects are allowed inside .then()
+          expect(b).toEqual('b') 
+        })
+      `,
+				errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+			} as const,
+			{
+				// Issue #500, https://github.com/testing-library/eslint-plugin-testing-library/issues/500
+				code: `
+        import { waitFor } from '${testingFramework}';
+        await waitFor(function() {
+          userEvent.click(button)
+          expect(b).toEqual('b')
+        }).then(() => {
+          userEvent.click(button) // Side effects are allowed inside .then()
+          expect(b).toEqual('b')
+          await waitFor(() => {
+            fireEvent.keyDown(input, {key: 'ArrowDown'}) // But not if there is a another waitFor with side effects inside the .then()
+            expect(b).toEqual('b')
+          })
+        })
+      `,
+				errors: [
+					{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' },
+					{ line: 10, column: 13, messageId: 'noSideEffectsWaitFor' },
+				],
 			} as const,
 		]),
 


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [ ] If some rule is added/updated/removed, I've regenerated the rules list (`npm run generate:rules-list`)
- [ ] If some rule meta info is changed, I've regenerated the plugin shared configs (`npm run generate:configs`)

## Changes

- when reporting side efdects, check if the node is a `.then()`, and if it is, not report it
- added unit tests
- adds a mention of edge case to rule documentation

## Context

Closes: #500