### PR TITLE
feat(no-node-access): report childElementCount prop

### DIFF
--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -83,6 +83,7 @@ const TESTING_FRAMEWORK_SETUP_HOOKS = ['beforeEach', 'beforeAll'];
 const PROPERTIES_RETURNING_NODES = [
 	'activeElement',
 	'children',
+	'childElementCount',
 	'firstChild',
 	'firstElementChild',
 	'fullscreenElement',

--- a/tests/lib/rules/no-node-access.test.ts
+++ b/tests/lib/rules/no-node-access.test.ts
@@ -324,5 +324,22 @@ ruleTester.run(RULE_NAME, rule, {
 				},
 			],
 		},
+		{
+			code: `
+        import { render } from '${testingFramework}';
+
+        const { container } = render(<ul><li>item</li><li>item</li></ul>)
+
+        expect(container.childElementCount).toBe(2)
+      `,
+			errors: [
+				{
+					// error points to `childElementCount`
+					line: 6,
+					column: 26,
+					messageId: 'noNodeAccess',
+				},
+			],
+		},
 	]),
 });


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [x] If some rule is added/updated/removed, I've regenerated the rules list (`npm run generate:rules-list`)
- [x] If some rule meta info is changed, I've regenerated the plugin shared configs (`npm run generate:configs`)

## Changes

- This PR adds childElementCount in no-node-access rule

## Context

```js
render(
  <ul>
     <li>item 1</li>
     <li>item 1</li>
  </ul>
);

expect(screen.getByRole('list').childElementCount).toBe(2);
```
