### PR TITLE
fix(no-dom-imports): false negatives with several testing library imports

### DIFF
--- a/docs/rules/no-dom-import.md
+++ b/docs/rules/no-dom-import.md
@@ -32,6 +32,11 @@ import { fireEvent } from '@testing-library/dom';
 ```
 
 ```js
+import { render } from '@testing-library/react'; // Okay, no error
+import { screen } from '@testing-library/dom'; // Error, unnecessary import from @testing-library/dom
+```
+
+```js
 const { fireEvent } = require('dom-testing-library');
 ```
 

--- a/lib/rules/no-dom-import.ts
+++ b/lib/rules/no-dom-import.ts
@@ -1,7 +1,7 @@
 import { TSESTree } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
-import { isCallExpression } from '../node-utils';
+import { isCallExpression, getImportModuleName } from '../node-utils';
 
 export const RULE_NAME = 'no-dom-import';
 export type MessageIds = 'noDomImport' | 'noDomImportFramework';
@@ -84,22 +84,22 @@ export default createTestingLibraryRule<Options, MessageIds>({
 
 		return {
 			'Program:exit'() {
-				const importName = helpers.getTestingLibraryImportName();
-				const importNode = helpers.getTestingLibraryImportNode();
+				let importName: string | undefined;
+				const allImportNodes = helpers.getAllTestingLibraryImportNodes();
 
-				if (!importNode) {
-					return;
-				}
+				allImportNodes.forEach((importNode) => {
+					importName = getImportModuleName(importNode);
 
-				const domModuleName = DOM_TESTING_LIBRARY_MODULES.find(
-					(module) => module === importName
-				);
+					const domModuleName = DOM_TESTING_LIBRARY_MODULES.find(
+						(module) => module === importName
+					);
 
-				if (!domModuleName) {
-					return;
-				}
+					if (!domModuleName) {
+						return;
+					}
 
-				report(importNode, domModuleName);
+					report(importNode, domModuleName);
+				});
 			},
 		};
 	},

--- a/tests/lib/rules/no-dom-import.test.ts
+++ b/tests/lib/rules/no-dom-import.test.ts
@@ -203,5 +203,17 @@ ruleTester.run(RULE_NAME, rule, {
 			code: 'require("@testing-library/dom")',
 			errors: [{ messageId: 'noDomImport' }],
 		},
+		{
+			code: `
+			require("@testing-library/dom");
+			require("@testing-library/react");`,
+			errors: [{ line: 2, messageId: 'noDomImport' }],
+		},
+		{
+			code: `
+			import { render } from '@testing-library/react';
+			import { screen } from '@testing-library/dom';`,
+			errors: [{ line: 3, messageId: 'noDomImport' }],
+		},
 	],
 });


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [ ] If some rule is added/updated/removed, I've regenerated the rules list (`npm run generate:rules-list`)
- [ ] If some rule meta info is changed, I've regenerated the plugin shared configs (`npm run generate:configs`)

## Changes
- adds a new util function `getAllTestingLibraryImportNodes` to get all `testing-library` related imports
- in `no-dom-import` loop through all the `testing-library` imports, and report an error on that import(s) that imports from `testing-library/dom`

## Context

Closes #586 

P.S. If you feel that this PR is following the rules of [Hactoberfest](https://hacktoberfest.com/) and this gets merged, it would be wonderful if this PR would be tagged with a `hacktoberfest-accepted` tag/label. Thanks!