### PR TITLE
fix(no-node-access): false positives with `props.children`

### DIFF
--- a/docs/rules/no-node-access.md
+++ b/docs/rules/no-node-access.md
@@ -46,7 +46,7 @@ within(signinModal).getByPlaceholderText('Username');
 ```
 
 ```js
-import { screen } from '${testingFramework}';
+import { screen } from '@testing-library/react';
 
 function ComponentA(props) {
 	// props.children is not reported

--- a/docs/rules/no-node-access.md
+++ b/docs/rules/no-node-access.md
@@ -46,6 +46,17 @@ within(signinModal).getByPlaceholderText('Username');
 ```
 
 ```js
+import { screen } from '${testingFramework}';
+
+function ComponentA(props) {
+	// props.children is not reported
+	return <div>{props.children}</div>;
+}
+
+render(<ComponentA />);
+```
+
+```js
 // If is not importing a testing-library package
 
 document.getElementById('submit-btn').closest('button');

--- a/lib/rules/no-node-access.ts
+++ b/lib/rules/no-node-access.ts
@@ -59,6 +59,13 @@ export default createTestingLibraryRule<Options, MessageIds>({
 					return;
 				}
 
+				if (
+					ASTUtils.isIdentifier(node.object) &&
+					node.object.name === 'props'
+				) {
+					return;
+				}
+
 				context.report({
 					node,
 					loc: node.property.loc.start,

--- a/tests/lib/rules/no-node-access.test.ts
+++ b/tests/lib/rules/no-node-access.test.ts
@@ -77,6 +77,41 @@ ruleTester.run(RULE_NAME, rule, {
       `,
 			},
 			{
+				code: `// issue #386 examples, props.children should not be reported
+				import { screen } from '${testingFramework}';
+				jest.mock('@/some/path', () => ({
+					someProperty: jest.fn((props) => props.children),
+				  }));
+				`,
+			},
+			{
+				code: `// issue #386 examples
+				import { screen } from '${testingFramework}';
+				function ComponentA(props) {
+					if (props.children) {
+					  // ...
+					}
+
+					return <div>{props.children}</div>
+				  }
+				`,
+			},
+			{
+				code: `/* related to issue #386 fix
+				* now all node accessing properties (listed in lib/utils/index.ts, in PROPERTIES_RETURNING_NODES)
+				* will not be reported by this rule because anything props.something won't be reported.
+				*/ 
+				import { screen } from '${testingFramework}';
+				function ComponentA(props) {
+					if (props.firstChild) {
+					  // ...
+					}
+
+					return <div>{props.nextSibling}</div>
+				  }
+				`,
+			},
+			{
 				settings: {
 					'testing-library/utils-module': 'test-utils',
 				},


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [ ] If some rule is added/updated/removed, I've regenerated the rules list (`npm run generate:rules-list`)
- [ ] If some rule meta info is changed, I've regenerated the plugin shared configs (`npm run generate:configs`)

## Changes
- checks if the node accessing property (e.g. `children`, `firstChild` or `previousSibling`) is called by `props`, so if there's a `props.children`, `props.firstChild` or `props.previousSibling`, then that code won't be reported as an error

## Context
Closes #386 (at least the most common case, not all of the examples given in that issue).
This PR does not close/fix the deconstructed props case (mentioned by @Belco90 in #386):

```
function ComponentB({ children }) {
  // this should NOT be reported
  if (children) {
    // ...
  }

  // this should NOT be reported
  return <div>{children}</div>
}
```

But I am happy to make another PR about this case too (I just haven't figured out how to identify with AST).

P.S. If you feel that this PR is following the rules of [Hactoberfest](https://hacktoberfest.com/) and this gets merged, it would be wonderful if this PR would be tagged with a hacktoberfest-accepted tag/label. Thanks!
