### PR TITLE
feat(no-debugging-utils): default to warn instead of error

### DIFF
--- a/lib/configs/angular.ts
+++ b/lib/configs/angular.ts
@@ -13,7 +13,7 @@ export = {
 		'testing-library/await-async-utils': 'error',
 		'testing-library/no-await-sync-query': 'error',
 		'testing-library/no-container': 'error',
-		'testing-library/no-debugging-utils': 'error',
+		'testing-library/no-debugging-utils': 'warn',
 		'testing-library/no-dom-import': ['error', 'angular'],
 		'testing-library/no-global-regexp-flag-in-query': 'error',
 		'testing-library/no-node-access': 'error',

--- a/lib/configs/marko.ts
+++ b/lib/configs/marko.ts
@@ -13,7 +13,7 @@ export = {
 		'testing-library/await-async-utils': 'error',
 		'testing-library/no-await-sync-query': 'error',
 		'testing-library/no-container': 'error',
-		'testing-library/no-debugging-utils': 'error',
+		'testing-library/no-debugging-utils': 'warn',
 		'testing-library/no-dom-import': ['error', 'marko'],
 		'testing-library/no-global-regexp-flag-in-query': 'error',
 		'testing-library/no-node-access': 'error',

--- a/lib/configs/react.ts
+++ b/lib/configs/react.ts
@@ -13,7 +13,7 @@ export = {
 		'testing-library/await-async-utils': 'error',
 		'testing-library/no-await-sync-query': 'error',
 		'testing-library/no-container': 'error',
-		'testing-library/no-debugging-utils': 'error',
+		'testing-library/no-debugging-utils': 'warn',
 		'testing-library/no-dom-import': ['error', 'react'],
 		'testing-library/no-global-regexp-flag-in-query': 'error',
 		'testing-library/no-manual-cleanup': 'error',

--- a/lib/configs/vue.ts
+++ b/lib/configs/vue.ts
@@ -13,7 +13,7 @@ export = {
 		'testing-library/await-async-utils': 'error',
 		'testing-library/no-await-sync-query': 'error',
 		'testing-library/no-container': 'error',
-		'testing-library/no-debugging-utils': 'error',
+		'testing-library/no-debugging-utils': 'warn',
 		'testing-library/no-dom-import': ['error', 'vue'],
 		'testing-library/no-global-regexp-flag-in-query': 'error',
 		'testing-library/no-manual-cleanup': 'error',

--- a/lib/rules/no-debugging-utils.ts
+++ b/lib/rules/no-debugging-utils.ts
@@ -29,10 +29,10 @@ export default createTestingLibraryRule<Options, MessageIds>({
 			description: 'Disallow the use of debugging utilities like `debug`',
 			recommendedConfig: {
 				dom: false,
-				angular: 'error',
-				react: 'error',
-				vue: 'error',
-				marko: 'error',
+				angular: 'warn',
+				react: 'warn',
+				vue: 'warn',
+				marko: 'warn',
 			},
 		},
 		messages: {

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -17,7 +17,7 @@ Object {
       "testing-library/await-async-utils": "error",
       "testing-library/no-await-sync-query": "error",
       "testing-library/no-container": "error",
-      "testing-library/no-debugging-utils": "error",
+      "testing-library/no-debugging-utils": "warn",
       "testing-library/no-dom-import": Array [
         "error",
         "angular",
@@ -82,7 +82,7 @@ Object {
       "testing-library/await-async-utils": "error",
       "testing-library/no-await-sync-query": "error",
       "testing-library/no-container": "error",
-      "testing-library/no-debugging-utils": "error",
+      "testing-library/no-debugging-utils": "warn",
       "testing-library/no-dom-import": Array [
         "error",
         "marko",
@@ -118,7 +118,7 @@ Object {
       "testing-library/await-async-utils": "error",
       "testing-library/no-await-sync-query": "error",
       "testing-library/no-container": "error",
-      "testing-library/no-debugging-utils": "error",
+      "testing-library/no-debugging-utils": "warn",
       "testing-library/no-dom-import": Array [
         "error",
         "react",
@@ -158,7 +158,7 @@ Object {
       "testing-library/await-async-utils": "error",
       "testing-library/no-await-sync-query": "error",
       "testing-library/no-container": "error",
-      "testing-library/no-debugging-utils": "error",
+      "testing-library/no-debugging-utils": "warn",
       "testing-library/no-dom-import": Array [
         "error",
         "vue",


### PR DESCRIPTION
BREAKING CHANGE: `no-debugging-utils` defaults to `warn` instead of `error`

## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [x] If some rule is added/updated/removed, I've regenerated the rules list (`npm run generate:rules-list`)
- [x] If some rule meta info is changed, I've regenerated the plugin shared configs (`npm run generate:configs`)

## Changes

<!-- List the changes you're making with this pull request. -->

- Change `no-debugging-utils` default to `warn` in shared configs instead of `error`

## Context

Resolves https://github.com/testing-library/eslint-plugin-testing-library/issues/622.
