### PR TITLE
feat(no-debugging-utils): enable all methods

### DIFF
--- a/docs/rules/no-debugging-utils.md
+++ b/docs/rules/no-debugging-utils.md
@@ -13,7 +13,7 @@ This rule supports disallowing the following debugging utilities:
 - `logDOM`
 - `prettyFormat`
 
-By default, only `debug` and `logTestingPlaygroundURL` are disallowed.
+By default, all are disallowed.
 
 Examples of **incorrect** code for this rule:
 

--- a/lib/rules/no-debugging-utils.ts
+++ b/lib/rules/no-debugging-utils.ts
@@ -13,13 +13,21 @@ import {
 } from '../node-utils';
 import { DEBUG_UTILS } from '../utils';
 
-type DebugUtilsToCheckFor = Partial<
-	Record<typeof DEBUG_UTILS[number], boolean>
->;
+type DebugUtilsToCheckForConfig = Record<typeof DEBUG_UTILS[number], boolean>;
+type DebugUtilsToCheckFor = Partial<DebugUtilsToCheckForConfig>;
 
 export const RULE_NAME = 'no-debugging-utils';
 export type MessageIds = 'noDebug';
 type Options = [{ utilsToCheckFor?: DebugUtilsToCheckFor }];
+
+const defaultUtilsToCheckFor: DebugUtilsToCheckForConfig = {
+	debug: true,
+	logTestingPlaygroundURL: true,
+	prettyDOM: true,
+	logRoles: true,
+	logDOM: true,
+	prettyFormat: true,
+};
 
 export default createTestingLibraryRule<Options, MessageIds>({
 	name: RULE_NAME,
@@ -60,9 +68,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 			},
 		],
 	},
-	defaultOptions: [
-		{ utilsToCheckFor: { debug: true, logTestingPlaygroundURL: true } },
-	],
+	defaultOptions: [{ utilsToCheckFor: defaultUtilsToCheckFor }],
 
 	create(context, [{ utilsToCheckFor = {} }], helpers) {
 		const suspiciousDebugVariableNames: string[] = [];

--- a/tests/lib/rules/no-debugging-utils.test.ts
+++ b/tests/lib/rules/no-debugging-utils.test.ts
@@ -448,7 +448,6 @@ ruleTester.run(RULE_NAME, rule, {
         import { screen } from '@testing-library/dom'
         screen.logTestingPlaygroundURL()
       `,
-			options: [{ utilsToCheckFor: { logTestingPlaygroundURL: true } }],
 			errors: [
 				{
 					line: 3,
@@ -462,7 +461,6 @@ ruleTester.run(RULE_NAME, rule, {
         import { logRoles } from '@testing-library/dom'
         logRoles(document.createElement('nav'))
       `,
-			options: [{ utilsToCheckFor: { logRoles: true } }],
 			errors: [
 				{
 					line: 3,
@@ -476,7 +474,6 @@ ruleTester.run(RULE_NAME, rule, {
         import { screen } from '@testing-library/dom'
         screen.logTestingPlaygroundURL()
       `,
-			options: [{ utilsToCheckFor: { logRoles: true } }],
 			errors: [
 				{
 					line: 3,
@@ -490,7 +487,6 @@ ruleTester.run(RULE_NAME, rule, {
         import { screen } from '@testing-library/dom'
         screen.logTestingPlaygroundURL()
       `,
-			options: [{ utilsToCheckFor: { debug: false } }],
 			errors: [
 				{
 					line: 3,


### PR DESCRIPTION
BREAKING CHANGE: enable all debug methods by default for `no-debugging-utils`

## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [x] If some rule is added/updated/removed, I've regenerated the rules list (`npm run generate:rules-list`)
- [x] If some rule meta info is changed, I've regenerated the plugin shared configs (`npm run generate:configs`)

## Changes

<!-- List the changes you're making with this pull request. -->

- Enable all of the debug methods by default in the `no-debugging-utils` rule

## Context

Resolves https://github.com/testing-library/eslint-plugin-testing-library/issues/621