### PR TITLE
feat(no-await-sync-query): rename to `no-await-sync-queries`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Then configure the rules you want to use within `rules` property of your `.eslin
 {
 	"rules": {
 		"testing-library/await-async-query": "error",
-		"testing-library/no-await-sync-query": "error",
+		"testing-library/no-await-sync-queries": "error",
 		"testing-library/no-debugging-utils": "warn",
 		"testing-library/no-dom-import": "off"
 	}
@@ -211,7 +211,7 @@ To enable this configuration use the `extends` property in your
 | [`await-async-utils`](./docs/rules/await-async-utils.md)                             | Enforce promises from async utils to be awaited properly                                     |     | ![dom-badge][] ![angular-badge][] ![react-badge][] ![vue-badge][] ![marko-badge][] |
 | [`consistent-data-testid`](./docs/rules/consistent-data-testid.md)                   | Ensures consistent usage of `data-testid`                                                    |     |                                                                                    |
 | [`no-await-sync-events`](./docs/rules/no-await-sync-events.md)                       | Disallow unnecessary `await` for sync events                                                 |     |                                                                                    |
-| [`no-await-sync-query`](./docs/rules/no-await-sync-query.md)                         | Disallow unnecessary `await` for sync queries                                                |     | ![dom-badge][] ![angular-badge][] ![react-badge][] ![vue-badge][] ![marko-badge][] |
+| [`no-await-sync-queries`](./docs/rules/no-await-sync-queries.md)                     | Disallow unnecessary `await` for sync queries                                                |     | ![dom-badge][] ![angular-badge][] ![react-badge][] ![vue-badge][] ![marko-badge][] |
 | [`no-container`](./docs/rules/no-container.md)                                       | Disallow the use of `container` methods                                                      |     | ![angular-badge][] ![react-badge][] ![vue-badge][] ![marko-badge][]                |
 | [`no-debugging-utils`](./docs/rules/no-debugging-utils.md)                           | Disallow the use of debugging utilities like `debug`                                         |     | ![angular-badge][] ![react-badge][] ![vue-badge][] ![marko-badge][]                |
 | [`no-dom-import`](./docs/rules/no-dom-import.md)                                     | Disallow importing from DOM Testing Library                                                  | 🔧  | ![angular-badge][] ![react-badge][] ![vue-badge][] ![marko-badge][]                |

--- a/docs/rules/no-await-sync-queries.md
+++ b/docs/rules/no-await-sync-queries.md
@@ -1,4 +1,4 @@
-# Disallow unnecessary `await` for sync queries (`testing-library/no-await-sync-query`)
+# Disallow unnecessary `await` for sync queries (`testing-library/no-await-sync-queries`)
 
 Ensure that sync queries are not awaited unnecessarily.
 

--- a/lib/configs/angular.ts
+++ b/lib/configs/angular.ts
@@ -11,7 +11,7 @@ export = {
 		],
 		'testing-library/await-async-query': 'error',
 		'testing-library/await-async-utils': 'error',
-		'testing-library/no-await-sync-query': 'error',
+		'testing-library/no-await-sync-queries': 'error',
 		'testing-library/no-container': 'error',
 		'testing-library/no-debugging-utils': 'warn',
 		'testing-library/no-dom-import': ['error', 'angular'],

--- a/lib/configs/dom.ts
+++ b/lib/configs/dom.ts
@@ -11,7 +11,7 @@ export = {
 		],
 		'testing-library/await-async-query': 'error',
 		'testing-library/await-async-utils': 'error',
-		'testing-library/no-await-sync-query': 'error',
+		'testing-library/no-await-sync-queries': 'error',
 		'testing-library/no-global-regexp-flag-in-query': 'error',
 		'testing-library/no-node-access': 'error',
 		'testing-library/no-promise-in-fire-event': 'error',

--- a/lib/configs/marko.ts
+++ b/lib/configs/marko.ts
@@ -11,7 +11,7 @@ export = {
 		],
 		'testing-library/await-async-query': 'error',
 		'testing-library/await-async-utils': 'error',
-		'testing-library/no-await-sync-query': 'error',
+		'testing-library/no-await-sync-queries': 'error',
 		'testing-library/no-container': 'error',
 		'testing-library/no-debugging-utils': 'warn',
 		'testing-library/no-dom-import': ['error', 'marko'],

--- a/lib/configs/react.ts
+++ b/lib/configs/react.ts
@@ -11,7 +11,7 @@ export = {
 		],
 		'testing-library/await-async-query': 'error',
 		'testing-library/await-async-utils': 'error',
-		'testing-library/no-await-sync-query': 'error',
+		'testing-library/no-await-sync-queries': 'error',
 		'testing-library/no-container': 'error',
 		'testing-library/no-debugging-utils': 'warn',
 		'testing-library/no-dom-import': ['error', 'react'],

--- a/lib/configs/vue.ts
+++ b/lib/configs/vue.ts
@@ -11,7 +11,7 @@ export = {
 		],
 		'testing-library/await-async-query': 'error',
 		'testing-library/await-async-utils': 'error',
-		'testing-library/no-await-sync-query': 'error',
+		'testing-library/no-await-sync-queries': 'error',
 		'testing-library/no-container': 'error',
 		'testing-library/no-debugging-utils': 'warn',
 		'testing-library/no-dom-import': ['error', 'vue'],

--- a/lib/rules/no-await-sync-queries.ts
+++ b/lib/rules/no-await-sync-queries.ts
@@ -3,7 +3,7 @@ import { TSESTree } from '@typescript-eslint/utils';
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import { getDeepestIdentifierNode } from '../node-utils';
 
-export const RULE_NAME = 'no-await-sync-query';
+export const RULE_NAME = 'no-await-sync-queries';
 export type MessageIds = 'noAwaitSyncQuery';
 type Options = [];
 

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -15,7 +15,7 @@ Object {
       ],
       "testing-library/await-async-query": "error",
       "testing-library/await-async-utils": "error",
-      "testing-library/no-await-sync-query": "error",
+      "testing-library/no-await-sync-queries": "error",
       "testing-library/no-container": "error",
       "testing-library/no-debugging-utils": "warn",
       "testing-library/no-dom-import": Array [
@@ -50,7 +50,7 @@ Object {
       ],
       "testing-library/await-async-query": "error",
       "testing-library/await-async-utils": "error",
-      "testing-library/no-await-sync-query": "error",
+      "testing-library/no-await-sync-queries": "error",
       "testing-library/no-global-regexp-flag-in-query": "error",
       "testing-library/no-node-access": "error",
       "testing-library/no-promise-in-fire-event": "error",
@@ -80,7 +80,7 @@ Object {
       ],
       "testing-library/await-async-query": "error",
       "testing-library/await-async-utils": "error",
-      "testing-library/no-await-sync-query": "error",
+      "testing-library/no-await-sync-queries": "error",
       "testing-library/no-container": "error",
       "testing-library/no-debugging-utils": "warn",
       "testing-library/no-dom-import": Array [
@@ -116,7 +116,7 @@ Object {
       ],
       "testing-library/await-async-query": "error",
       "testing-library/await-async-utils": "error",
-      "testing-library/no-await-sync-query": "error",
+      "testing-library/no-await-sync-queries": "error",
       "testing-library/no-container": "error",
       "testing-library/no-debugging-utils": "warn",
       "testing-library/no-dom-import": Array [
@@ -156,7 +156,7 @@ Object {
       ],
       "testing-library/await-async-query": "error",
       "testing-library/await-async-utils": "error",
-      "testing-library/no-await-sync-query": "error",
+      "testing-library/no-await-sync-queries": "error",
       "testing-library/no-container": "error",
       "testing-library/no-debugging-utils": "warn",
       "testing-library/no-dom-import": Array [

--- a/tests/lib/rules/no-await-sync-queries.test.ts
+++ b/tests/lib/rules/no-await-sync-queries.test.ts
@@ -1,4 +1,4 @@
-import rule, { RULE_NAME } from '../../../lib/rules/no-await-sync-query';
+import rule, { RULE_NAME } from '../../../lib/rules/no-await-sync-queries';
 import {
 	SYNC_QUERIES_COMBINATIONS,
 	ASYNC_QUERIES_COMBINATIONS,


### PR DESCRIPTION
BREAKING CHANGE: `no-await-sync-query` is now called `no-await-sync-queries`

---

Partially resolves #478 & #623