### PR TITLE
fix: filtered out queries ending with 'ByType'

### DIFF
--- a/lib/rules/await-async-query.ts
+++ b/lib/rules/await-async-query.ts
@@ -52,7 +52,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 			CallExpression(node) {
 				const identifierNode = getDeepestIdentifierNode(node);
 
-				if (!identifierNode || identifierNode.name.endsWith('Type')) {
+				if (!identifierNode || identifierNode.name.endsWith('ByType')) {
 					return;
 				}
 

--- a/lib/rules/await-async-query.ts
+++ b/lib/rules/await-async-query.ts
@@ -52,7 +52,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 			CallExpression(node) {
 				const identifierNode = getDeepestIdentifierNode(node);
 
-				if (!identifierNode) {
+				if (!identifierNode || identifierNode.name.endsWith('Type')) {
 					return;
 				}
 

--- a/tests/lib/rules/await-async-query.test.ts
+++ b/tests/lib/rules/await-async-query.test.ts
@@ -330,6 +330,11 @@ ruleTester.run(RULE_NAME, rule, {
 		// valid async query usage without any function defined
 		// so there is no innermost function scope found
 		`const element = await findByRole('button')`,
+
+		// edge case for files using
+		// findByType or findAllByType
+		// from react-test-renderer
+		`const example = findByType('div')`,
 	],
 
 	invalid: [


### PR DESCRIPTION
from await-async-query rule.

## Checks

- [X] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [X] If some rule is added/updated/removed, I've regenerated the rules list (`npm run generate:rules-list`)
- [ ] If some rule meta info is changed, I've regenerated the plugin shared configs (`npm run generate:configs`)

## Changes
Added a test case, based on personal usage.
Added a check for early return in the identifier name of the call ends with 'ByType' in await-async-query.ts file.


## Context
Fixes #671 
