### PR TITLE
fix(await-async-events): improve fixer

### DIFF
--- a/lib/node-utils/index.ts
+++ b/lib/node-utils/index.ts
@@ -13,6 +13,8 @@ import {
 	isBlockStatement,
 	isCallExpression,
 	isExpressionStatement,
+	isFunctionExpression,
+	isFunctionDeclaration,
 	isImportDeclaration,
 	isImportNamespaceSpecifier,
 	isImportSpecifier,
@@ -93,6 +95,28 @@ export function findClosestVariableDeclaratorNode(
 	}
 
 	return findClosestVariableDeclaratorNode(node.parent);
+}
+
+export function findClosestFunctionExpressionNode(
+	node: TSESTree.Node | undefined
+):
+	| TSESTree.ArrowFunctionExpression
+	| TSESTree.FunctionExpression
+	| TSESTree.FunctionDeclaration
+	| null {
+	if (!node) {
+		return null;
+	}
+
+	if (
+		isArrowFunctionExpression(node) ||
+		isFunctionExpression(node) ||
+		isFunctionDeclaration(node)
+	) {
+		return node;
+	}
+
+	return findClosestFunctionExpressionNode(node.parent);
 }
 
 /**

--- a/lib/node-utils/is-node-of-type.ts
+++ b/lib/node-utils/is-node-of-type.ts
@@ -59,3 +59,6 @@ export const isReturnStatement = ASTUtils.isNodeOfType(
 export const isFunctionExpression = ASTUtils.isNodeOfType(
 	AST_NODE_TYPES.FunctionExpression
 );
+export const isFunctionDeclaration = ASTUtils.isNodeOfType(
+	AST_NODE_TYPES.FunctionDeclaration
+);


### PR DESCRIPTION
## Changes

<!-- List the changes you're making with this pull request. -->

- Improve the fixer for `await-async-events` to also add missing `async` keyword to wrapping function expression

## Context

Resolves https://github.com/testing-library/eslint-plugin-testing-library/issues/674
