### PR TITLE
fix(no-wait-for-side-effects): false negatives in variables declarations

### DIFF
--- a/tests/lib/rules/no-wait-for-side-effects.test.ts
+++ b/tests/lib/rules/no-wait-for-side-effects.test.ts
@@ -795,5 +795,25 @@ ruleTester.run(RULE_NAME, rule, {
 				{ line: 12, column: 13, messageId: 'noSideEffectsWaitFor' },
 			],
 		},
+		// side effects (userEvent, fireEvent or render) in variable declarations
+		...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
+			{
+				// Issue #368, https://github.com/testing-library/eslint-plugin-testing-library/issues/368
+				code: `
+        import { waitFor } from '${testingFramework}';
+        import userEvent from '@testing-library/user-event'
+        await waitFor(() => {
+          const a = userEvent.click(button);
+          const b = fireEvent.click(button);
+          const wrapper = render(<App />);
+        })
+        `,
+				errors: [
+					{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' },
+					{ line: 6, column: 11, messageId: 'noSideEffectsWaitFor' },
+					{ line: 7, column: 11, messageId: 'noSideEffectsWaitFor' },
+				],
+			} as const,
+		]),
 	],
 });


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [ ] If some rule is added/updated/removed, I've regenerated the rules list (`npm run generate:rules-list`)
- [ ] If some rule meta info is changed, I've regenerated the plugin shared configs (`npm run generate:configs`)

## Changes

- adds a new helper function that checks if there are side effects (`userEvent`, `fireEvent` or `render`) in variable declarations
- adds a new invalid unit test

## Context
Closes #368 

P.S. If you feel that this PR is following the rules of [Hactoberfest](https://hacktoberfest.com/) and this gets merged, it would be wonderful if this PR would be tagged with a hacktoberfest-accepted tag/label. Thanks!