### PR TITLE
feat(no-global-regexp-flag-in-query): Detect global RegExp in variable declarations

### DIFF
--- a/lib/rules/no-global-regexp-flag-in-query.ts
+++ b/lib/rules/no-global-regexp-flag-in-query.ts
@@ -37,7 +37,13 @@ export default createTestingLibraryRule<Options, MessageIds>({
 	},
 	defaultOptions: [],
 	create(context, _, helpers) {
-		function report(literalNode: TSESTree.Node) {
+		/**
+		 * Checks if node is reportable (has a regex that contains 'g') and if it is, reports it with `context.report()`.
+		 *
+		 * @param literalNode Literal node under to be
+		 * @returns {Boolean} indicatinf if literal was reported
+		 */
+		function reportLiteralWithRegex(literalNode: TSESTree.Node) {
 			if (
 				isLiteral(literalNode) &&
 				'regex' in literalNode &&
@@ -85,7 +91,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 
 				const [firstArg, secondArg] = getArguments(identifierNode);
 
-				const firstArgumentHasError = report(firstArg);
+				const firstArgumentHasError = reportLiteralWithRegex(firstArg);
 				if (firstArgumentHasError) {
 					return;
 				}
@@ -100,7 +106,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 					) as TSESTree.Property | undefined;
 
 					if (namePropertyNode) {
-						report(namePropertyNode.value);
+						reportLiteralWithRegex(namePropertyNode.value);
 					}
 				}
 			},

--- a/tests/lib/rules/no-global-regexp-flag-in-query.test.ts
+++ b/tests/lib/rules/no-global-regexp-flag-in-query.test.ts
@@ -196,5 +196,29 @@ ruleTester.run(RULE_NAME, rule, {
         import { within } from '@testing-library/dom'
         within(element).queryAllByText(/hello/i)`,
 		},
+		{
+			code: `
+			const countRegExp = /count/gm
+			const anotherRegExp = /something/mgi
+			expect(screen.getByText(countRegExp)).toBeInTheDocument()
+			expect(screen.getByAllText(anotherRegExp)).toBeInTheDocument()`,
+			errors: [
+				{
+					messageId: 'noGlobalRegExpFlagInQuery',
+					line: 4,
+					column: 28,
+				},
+				{
+					messageId: 'noGlobalRegExpFlagInQuery',
+					line: 5,
+					column: 31,
+				},
+			],
+			output: `
+			const countRegExp = /count/m
+			const anotherRegExp = /something/mi
+			expect(screen.getByText(countRegExp)).toBeInTheDocument()
+			expect(screen.getByAllText(anotherRegExp)).toBeInTheDocument()`,
+		},
 	],
 });


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [ ] If some rule is added/updated/removed, I've regenerated the rules list (`npm run generate:rules-list`)
- [ ] If some rule meta info is changed, I've regenerated the plugin shared configs (`npm run generate:configs`)

## Changes
- rename one rule-specific helper function
- add a rule-specific helper array to keep tab of variable declarations that have a global RegExp
- add detecting if the argument that is passed to a testing-library query has a global RegExp in its variable declaration
- add unit test with this scenario

## Context
Closes #592

P.S. If you feel that this PR is following the rules of [Hactoberfest](https://hacktoberfest.com/) and this gets merged, it would be wonderful if this PR would be tagged with a hacktoberfest-accepted tag/label. Thanks!