### PR TITLE
test(no-node-access): add more valid test cases

### DIFF
--- a/tests/lib/rules/no-node-access.test.ts
+++ b/tests/lib/rules/no-node-access.test.ts
@@ -143,25 +143,6 @@ ruleTester.run(RULE_NAME, rule, {
 				code: `
 				import { render } from '@testing-library/react';
 				
-				function Wrapper(props) {
-					// this should NOT be reported
-					if (props.children) {
-					  // ...
-					}
-				  
-					// this should NOT be reported
-					return <div className="wrapper-class">{props.children}</div>
-				  };
-	
-				render(<Wrapper><SomeComponent /></Wrapper>);
-				expect(screen.getByText('SomeComponent')).toBeInTheDocument();
-				`,
-			},
-			{
-				// Example from discussions in issue #386
-				code: `
-				import { render } from '@testing-library/react';
-				
 				function Wrapper({ children }) {
 					// this should NOT be reported
 					if (children) {

--- a/tests/lib/rules/no-node-access.test.ts
+++ b/tests/lib/rules/no-node-access.test.ts
@@ -138,6 +138,44 @@ ruleTester.run(RULE_NAME, rule, {
         expect(container.firstChild).toMatchSnapshot()
       `,
 			},
+			{
+				// Example from discussions in issue #386
+				code: `
+				import { render } from '@testing-library/react';
+				
+				function Wrapper(props) {
+					// this should NOT be reported
+					if (props.children) {
+					  // ...
+					}
+				  
+					// this should NOT be reported
+					return <div className="wrapper-class">{props.children}</div>
+				  };
+	
+				render(<Wrapper><SomeComponent /></Wrapper>);
+				expect(screen.getByText('SomeComponent')).toBeInTheDocument();
+				`,
+			},
+			{
+				// Example from discussions in issue #386
+				code: `
+				import { render } from '@testing-library/react';
+				
+				function Wrapper({ children }) {
+					// this should NOT be reported
+					if (children) {
+					  // ...
+					}
+				  
+					// this should NOT be reported
+					return <div className="wrapper-class">{children}</div>
+				  };
+	
+				render(<Wrapper><SomeComponent /></Wrapper>);
+				expect(screen.getByText('SomeComponent')).toBeInTheDocument();
+				`,
+			},
 		]
 	),
 	invalid: SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [


### PR DESCRIPTION
These examples were gotten from discussions in issue #386

## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).
- [ ] If some rule is added/updated/removed, I've regenerated the rules list (`npm run generate:rules-list`)
- [ ] If some rule meta info is changed, I've regenerated the plugin shared configs (`npm run generate:configs`)

## Changes

- add a valid test case to `no-node-access`

## Context
Not closing an existing issue, just adding one test that should have been added in #658. I commented in that PR that it wouldn't be fixing an error from a code like this (component with destructured props), but turns out, that this code hasn't produced an error, it is totally valid from this rule's perspective.