### PR TITLE
fix: avoid reporting `react-test-renderer` utils as queries

### DIFF
--- a/lib/create-testing-library-rule/detect-testing-library-utils.ts
+++ b/lib/create-testing-library-rule/detect-testing-library-utils.ts
@@ -419,7 +419,11 @@ export function detectTestingLibraryUtils<
 		};
 
 		const isCustomQuery: IsCustomQueryFn = (node) => {
-			return isQuery(node) && !ALL_QUERIES_COMBINATIONS.includes(node.name);
+			return (
+				isQuery(node) &&
+				!ALL_QUERIES_COMBINATIONS.includes(node.name) &&
+				!EXCLUDED_FIND_BY_QUERIES.includes(node.name)
+			);
 		};
 
 		const isBuiltInQuery = (node: TSESTree.Identifier): boolean => {

--- a/lib/create-testing-library-rule/detect-testing-library-utils.ts
+++ b/lib/create-testing-library-rule/detect-testing-library-utils.ts
@@ -133,6 +133,14 @@ const FIRE_EVENT_NAME = 'fireEvent';
 const CREATE_EVENT_NAME = 'createEvent';
 const USER_EVENT_NAME = 'userEvent';
 const RENDER_NAME = 'render';
+const EXCLUDED_FIND_BY_QUERIES = [
+	//react-test-renderer utils
+	'findByType',
+	'findByProps',
+	'findAll',
+	'findAllByType',
+	'findAllByProps',
+];
 
 export type DetectionOptions = {
 	/**
@@ -389,7 +397,11 @@ export function detectTestingLibraryUtils<
 		 * Determines whether a given node is `find*` query variant or not.
 		 */
 		const isFindQueryVariant: IsFindQueryVariantFn = (node) => {
-			return isQuery(node) && node.name.startsWith('find');
+			return (
+				isQuery(node) &&
+				node.name.startsWith('find') &&
+				!EXCLUDED_FIND_BY_QUERIES.includes(node.name)
+			);
 		};
 
 		/**

--- a/tests/create-testing-library-rule.test.ts
+++ b/tests/create-testing-library-rule.test.ts
@@ -401,6 +401,16 @@ ruleTester.run(RULE_NAME, rule, {
       `,
 		},
 
+		// `react-test-renderer` utils starting with "find" shouldn't be reported as queries
+		// https://github.com/testing-library/eslint-plugin-testing-library/issues/673
+		`// issue #673
+		findByType('foo');
+		findByProps('foo');
+		findAll('foo');
+		findAllByType('foo');
+		findAllByProps('foo');
+		`,
+
 		// Weird edge cases
 		`(window as any).__THING = false;`,
 		`thing.method.lastCall.args[0]();`,

--- a/tests/lib/rules/await-async-query.test.ts
+++ b/tests/lib/rules/await-async-query.test.ts
@@ -341,6 +341,12 @@ ruleTester.run(RULE_NAME, rule, {
       })
     `,
 
+		// https://github.com/testing-library/eslint-plugin-testing-library/issues/671
+		`// issue #671
+		
+		const elements = root.findAllByType('div')
+		`,
+
 		// edge case for coverage
 		// valid async query usage without any function defined
 		// so there is no innermost function scope found


### PR DESCRIPTION
## Checks

- [X] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- Avoid reporting `react-test-renderer` utils as `find*` queries
- Avoid reporting `react-test-renderer` utils as custom queries
- Add tests

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

Fixes #671
Fixes #673 
