### PR TITLE
ci: fix smoke test's npm setup

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -11,17 +11,23 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Use Node
+        uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
-          cache: 'npm'
+
       - run: |
           npm install
           npm run build
+
       - run: npm link
         working-directory: ./dist
+
       - run: npm link eslint-plugin-testing-library
+
       - uses: AriPerkkio/eslint-remote-tester-run-action@v3
         with:
           issue-title: 'Results of weekly scheduled smoke test'

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
 		"eslint-plugin-prettier": "^4.2.1",
 		"eslint-plugin-promise": "^6.1.1",
 		"eslint-remote-tester": "^3.0.0",
-		"eslint-remote-tester-repositories": "^0.0.8",
+		"eslint-remote-tester-repositories": "^1.0.0",
 		"husky": "^8.0.2",
 		"is-ci": "^3.0.1",
 		"jest": "^28.1.3",


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- chore(dev-deps): update eslint-remote-tester-repositories
  - Updates `eslint-remote-tester-repositories` to new major version. No breaking changes. API is now considered as stable
- ci: fix smoke test's npm setup
  - Workflow seemed to be crashing due to some Node/NPM setup issues. Copied setup steps from `pipeline.yml`

