### PR TITLE
fix: ignore getBy inside of within for prefer-presence-queries on absence queries

### DIFF
--- a/lib/rules/prefer-presence-queries.ts
+++ b/lib/rules/prefer-presence-queries.ts
@@ -59,6 +59,12 @@ export default createTestingLibraryRule<Options, MessageIds>({
 		return {
 			'CallExpression Identifier'(node: TSESTree.Identifier) {
 				const expectCallNode = findClosestCallNode(node, 'expect');
+				const withinCallNode = findClosestCallNode(node, 'within');
+
+				if (withinCallNode) {
+					//Ignore false-positives where our query is inside a within
+					return;
+				}
 
 				if (!expectCallNode || !isMemberExpression(expectCallNode.parent)) {
 					return;

--- a/tests/lib/rules/prefer-presence-queries.test.ts
+++ b/tests/lib/rules/prefer-presence-queries.test.ts
@@ -837,6 +837,9 @@ ruleTester.run(RULE_NAME, rule, {
      // right after clicking submit button it disappears
      expect(submitButton).not.toBeInTheDocument()
     `,
+		`// checking absence on getBy* inside a within with queryBy* outside the within
+	 expect(within(screen.getByRole("button")).queryByText("Hello")).not.toBeInTheDocument()
+	`,
 	],
 	invalid: [
 		// cases: asserting absence incorrectly with `getBy*` queries


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- Ignore getBy* nodes inside of within() for prefer-presence-queries when checking absence queries

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->
Fixes #518 [Well, partially fixes it.]