### PR TITLE
fix(await-async-utils): false positive when destructuring

### DIFF
--- a/lib/rules/await-async-utils.ts
+++ b/lib/rules/await-async-utils.ts
@@ -97,6 +97,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 			VariableDeclarator(node: TSESTree.VariableDeclarator) {
 				if (isObjectPattern(node.id)) {
 					detectDestructuredAsyncUtilWrapperAliases(node.id);
+					return;
 				}
 
 				const isAssigningKnownAsyncFunctionWrapper =

--- a/lib/rules/await-async-utils.ts
+++ b/lib/rules/await-async-utils.ts
@@ -50,6 +50,11 @@ export default createTestingLibraryRule<Options, MessageIds>({
 			}
 		}
 
+		/*
+			Example:
+			`const { myAsyncWrapper: myRenamedValue } = someObject`;
+			Detects `myRenamedValue` and adds it to the known async wrapper names.
+		 */
 		function detectDestructuredAsyncUtilWrapperAliases(
 			node: TSESTree.ObjectPattern
 		) {

--- a/lib/rules/await-async-utils.ts
+++ b/lib/rules/await-async-utils.ts
@@ -66,7 +66,10 @@ export default createTestingLibraryRule<Options, MessageIds>({
 				}
 
 				if (functionWrappersNames.includes(property.key.name)) {
-					if (property.value.name !== property.key.name) {
+					const isDestructuredAsyncWrapperPropertyRenamed =
+						property.key.name !== property.value.name;
+
+					if (isDestructuredAsyncWrapperPropertyRenamed) {
 						functionWrappersNames.push(property.value.name);
 					}
 				}

--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -266,7 +266,7 @@ ruleTester.run(RULE_NAME, rule, {
           const utils = render(<MyComponent />);
         
           const waitForLoadComplete = () => {
-            return waitForElementToBeRemoved(screen.queryByRole('progressbar'));
+            return waitForElementToBeRemoved(screen.queryByTestId('my-test-id'));
           };
         
           return { waitForLoadComplete, ...utils };
@@ -277,13 +277,18 @@ ruleTester.run(RULE_NAME, rule, {
           await waitForLoadComplete();
 
           const myAlias = waitForLoadComplete;
+          const myOtherAlias = myAlias;
           await myAlias();
+          await myOtherAlias();
 
           const { ...clone } = setup();
           await clone.waitForLoadComplete();
 
-          const { waitForLoadComplete: myAlias } = setup();
-          await myAlias();
+          const { waitForLoadComplete: myDestructuredAlias } = setup();
+          await myDestructuredAlias();
+          
+          const { user, ...rest } = setup();
+          await rest.waitForLoadComplete();
 
           await setup().waitForLoadComplete();
         });
@@ -296,7 +301,7 @@ ruleTester.run(RULE_NAME, rule, {
           const utils = render(<MyComponent />);
         
           const waitForLoadComplete = () => {
-            return waitForElementToBeRemoved(screen.queryByRole('progressbar'));
+            return waitForElementToBeRemoved(screen.queryByTestId('my-test-id'));
           };
         
           return { waitForLoadComplete, ...utils };
@@ -519,13 +524,13 @@ ruleTester.run(RULE_NAME, rule, {
           const utils = render(<MyComponent />);
         
           const waitForLoadComplete = () => {
-            return waitForElementToBeRemoved(screen.queryByRole('progressbar'));
+            return waitForElementToBeRemoved(screen.queryByTestId('my-test-id'));
           };
         
           return { waitForLoadComplete, ...utils };
         }
 
-        test('destructuring an async function wrapper & handling it later is valid', () => {
+        test('unhandled promise from destructed property of async function wrapper is invalid', () => {
           const { user, waitForLoadComplete } = setup();
           waitForLoadComplete();
         });
@@ -546,13 +551,13 @@ ruleTester.run(RULE_NAME, rule, {
           const utils = render(<MyComponent />);
         
           const waitForLoadComplete = () => {
-            return waitForElementToBeRemoved(screen.queryByRole('progressbar'));
+            return waitForElementToBeRemoved(screen.queryByTestId('my-test-id'));
           };
         
           return { waitForLoadComplete, ...utils };
         }
 
-        test('destructuring an async function wrapper & handling it later is valid', () => {
+        test('unhandled promise from assigning async function wrapper is invalid', () => {
           const { user, waitForLoadComplete } = setup();
           const myAlias = waitForLoadComplete;
           myAlias();
@@ -574,13 +579,13 @@ ruleTester.run(RULE_NAME, rule, {
           const utils = render(<MyComponent />);
         
           const waitForLoadComplete = () => {
-            return waitForElementToBeRemoved(screen.queryByRole('progressbar'));
+            return waitForElementToBeRemoved(screen.queryByTestId('my-test-id'));
           };
         
           return { waitForLoadComplete, ...utils };
         }
 
-        test('destructuring an async function wrapper & handling it later is valid', () => {
+        test('unhandled promise from rest element with async wrapper function member is invalid', () => {
           const { ...clone } = setup();
           clone.waitForLoadComplete();
         });
@@ -601,13 +606,13 @@ ruleTester.run(RULE_NAME, rule, {
           const utils = render(<MyComponent />);
         
           const waitForLoadComplete = () => {
-            return waitForElementToBeRemoved(screen.queryByRole('progressbar'));
+            return waitForElementToBeRemoved(screen.queryByTestId('my-test-id'));
           };
         
           return { waitForLoadComplete, ...utils };
         }
 
-        test('destructuring an async function wrapper & handling it later is valid', () => {
+        test('unhandled promise from destructured property alias is invalid', () => {
           const { waitForLoadComplete: myAlias } = setup();
           myAlias();
         });
@@ -628,13 +633,13 @@ ruleTester.run(RULE_NAME, rule, {
           const utils = render(<MyComponent />);
         
           const waitForLoadComplete = () => {
-            return waitForElementToBeRemoved(screen.queryByRole('progressbar'));
+            return waitForElementToBeRemoved(screen.queryByTestId('my-test-id'));
           };
         
           return { waitForLoadComplete, ...utils };
         }
 
-        test('destructuring an async function wrapper & handling it later is valid', () => {
+        test('unhandled promise from object member with async wrapper value is invalid', () => {
           setup().waitForLoadComplete();
         });
       `,
@@ -644,6 +649,33 @@ ruleTester.run(RULE_NAME, rule, {
 					column: 19,
 					messageId: 'asyncUtilWrapper',
 					data: { name: 'waitForLoadComplete' },
+				},
+			],
+		},
+
+		{
+			code: `
+        function setup() {
+          const utils = render(<MyComponent />);
+        
+          const waitForLoadComplete = () => {
+            return waitForElementToBeRemoved(screen.queryByTestId('my-test-id'));
+          };
+        
+          return { waitForLoadComplete, ...utils };
+        }
+
+        test('unhandled promise from object member with async wrapper value is invalid', () => {
+          const myAlias = setup().waitForLoadComplete;
+          myAlias();
+        });
+      `,
+			errors: [
+				{
+					line: 14,
+					column: 11,
+					messageId: 'asyncUtilWrapper',
+					data: { name: 'myAlias' },
 				},
 			],
 		},

--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -294,25 +294,6 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		},
-
-		{
-			code: `
-        function setup() {
-          const utils = render(<MyComponent />);
-        
-          const waitForLoadComplete = () => {
-            return waitForElementToBeRemoved(screen.queryByTestId('my-test-id'));
-          };
-        
-          return { waitForLoadComplete, ...utils };
-        }
-
-        test('destructuring an async function wrapper & handling it later is valid', () => {
-          const { user, ...rest } = setup();
-          await rest.waitForLoadComplete();
-        });
-      `,
-		},
 	]),
 	invalid: SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
 		...ASYNC_UTILS.map(

--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -260,40 +260,40 @@ ruleTester.run(RULE_NAME, rule, {
         })
       `,
 		},
-		{
+		...ASYNC_UTILS.map((asyncUtil) => ({
 			code: `
         function setup() {
           const utils = render(<MyComponent />);
         
-          const waitForLoadComplete = () => {
-            return waitForElementToBeRemoved(screen.queryByTestId('my-test-id'));
+          const waitForAsyncUtil = () => {
+            return ${asyncUtil}(screen.queryByTestId('my-test-id'));
           };
         
-          return { waitForLoadComplete, ...utils };
+          return { waitForAsyncUtil, ...utils };
         }
 
         test('destructuring an async function wrapper & handling it later is valid', () => {
-          const { user, waitForLoadComplete } = setup();
-          await waitForLoadComplete();
+          const { user, waitForAsyncUtil } = setup();
+          await waitForAsyncUtil();
 
-          const myAlias = waitForLoadComplete;
+          const myAlias = waitForAsyncUtil;
           const myOtherAlias = myAlias;
           await myAlias();
           await myOtherAlias();
 
           const { ...clone } = setup();
-          await clone.waitForLoadComplete();
+          await clone.waitForAsyncUtil();
 
-          const { waitForLoadComplete: myDestructuredAlias } = setup();
+          const { waitForAsyncUtil: myDestructuredAlias } = setup();
           await myDestructuredAlias();
           
           const { user, ...rest } = setup();
-          await rest.waitForLoadComplete();
+          await rest.waitForAsyncUtil();
 
-          await setup().waitForLoadComplete();
+          await setup().waitForAsyncUtil();
         });
       `,
-		},
+		})),
 	]),
 	invalid: SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
 		...ASYNC_UTILS.map(
@@ -498,167 +498,179 @@ ruleTester.run(RULE_NAME, rule, {
 					],
 				} as const)
 		),
-
-		{
-			code: `
+		...ASYNC_UTILS.map(
+			(asyncUtil) =>
+				({
+					code: `
         function setup() {
           const utils = render(<MyComponent />);
         
-          const waitForLoadComplete = () => {
-            return waitForElementToBeRemoved(screen.queryByTestId('my-test-id'));
+          const waitForAsyncUtil = () => {
+            return ${asyncUtil}(screen.queryByTestId('my-test-id'));
           };
         
-          return { waitForLoadComplete, ...utils };
+          return { waitForAsyncUtil, ...utils };
         }
 
         test('unhandled promise from destructed property of async function wrapper is invalid', () => {
-          const { user, waitForLoadComplete } = setup();
-          waitForLoadComplete();
+          const { user, waitForAsyncUtil } = setup();
+          waitForAsyncUtil();
         });
       `,
-			errors: [
-				{
-					line: 14,
-					column: 11,
-					messageId: 'asyncUtilWrapper',
-					data: { name: 'waitForLoadComplete' },
-				},
-			],
-		},
-
-		{
-			code: `
+					errors: [
+						{
+							line: 14,
+							column: 11,
+							messageId: 'asyncUtilWrapper',
+							data: { name: 'waitForAsyncUtil' },
+						},
+					],
+				} as const)
+		),
+		...ASYNC_UTILS.map(
+			(asyncUtil) =>
+				({
+					code: `
         function setup() {
           const utils = render(<MyComponent />);
         
-          const waitForLoadComplete = () => {
-            return waitForElementToBeRemoved(screen.queryByTestId('my-test-id'));
+          const waitForAsyncUtil = () => {
+            return ${asyncUtil}(screen.queryByTestId('my-test-id'));
           };
         
-          return { waitForLoadComplete, ...utils };
+          return { waitForAsyncUtil, ...utils };
         }
 
-        test('unhandled promise from assigning async function wrapper is invalid', () => {
-          const { user, waitForLoadComplete } = setup();
-          const myAlias = waitForLoadComplete;
+        test('unhandled promise from destructed property of async function wrapper is invalid', () => {
+          const { user, waitForAsyncUtil } = setup();
+          const myAlias = waitForAsyncUtil;
           myAlias();
         });
       `,
-			errors: [
-				{
-					line: 15,
-					column: 11,
-					messageId: 'asyncUtilWrapper',
-					data: { name: 'myAlias' },
-				},
-			],
-		},
-
-		{
-			code: `
+					errors: [
+						{
+							line: 15,
+							column: 11,
+							messageId: 'asyncUtilWrapper',
+							data: { name: 'myAlias' },
+						},
+					],
+				} as const)
+		),
+		...ASYNC_UTILS.map(
+			(asyncUtil) =>
+				({
+					code: `
         function setup() {
           const utils = render(<MyComponent />);
         
-          const waitForLoadComplete = () => {
-            return waitForElementToBeRemoved(screen.queryByTestId('my-test-id'));
+          const waitForAsyncUtil = () => {
+            return ${asyncUtil}(screen.queryByTestId('my-test-id'));
           };
         
-          return { waitForLoadComplete, ...utils };
+          return { waitForAsyncUtil, ...utils };
         }
 
-        test('unhandled promise from rest element with async wrapper function member is invalid', () => {
+        test('unhandled promise from destructed property of async function wrapper is invalid', () => {
           const { ...clone } = setup();
-          clone.waitForLoadComplete();
+          clone.waitForAsyncUtil();
         });
       `,
-			errors: [
-				{
-					line: 14,
-					column: 17,
-					messageId: 'asyncUtilWrapper',
-					data: { name: 'waitForLoadComplete' },
-				},
-			],
-		},
-
-		{
-			code: `
+					errors: [
+						{
+							line: 14,
+							column: 17,
+							messageId: 'asyncUtilWrapper',
+							data: { name: 'waitForAsyncUtil' },
+						},
+					],
+				} as const)
+		),
+		...ASYNC_UTILS.map(
+			(asyncUtil) =>
+				({
+					code: `
         function setup() {
           const utils = render(<MyComponent />);
         
-          const waitForLoadComplete = () => {
-            return waitForElementToBeRemoved(screen.queryByTestId('my-test-id'));
+          const waitForAsyncUtil = () => {
+            return ${asyncUtil}(screen.queryByTestId('my-test-id'));
           };
         
-          return { waitForLoadComplete, ...utils };
+          return { waitForAsyncUtil, ...utils };
         }
 
-        test('unhandled promise from destructured property alias is invalid', () => {
-          const { waitForLoadComplete: myAlias } = setup();
+        test('unhandled promise from destructed property of async function wrapper is invalid', () => {
+          const { waitForAsyncUtil: myAlias } = setup();
           myAlias();
         });
       `,
-			errors: [
-				{
-					line: 14,
-					column: 11,
-					messageId: 'asyncUtilWrapper',
-					data: { name: 'myAlias' },
-				},
-			],
-		},
-
-		{
-			code: `
+					errors: [
+						{
+							line: 14,
+							column: 11,
+							messageId: 'asyncUtilWrapper',
+							data: { name: 'myAlias' },
+						},
+					],
+				} as const)
+		),
+		...ASYNC_UTILS.map(
+			(asyncUtil) =>
+				({
+					code: `
         function setup() {
           const utils = render(<MyComponent />);
         
-          const waitForLoadComplete = () => {
-            return waitForElementToBeRemoved(screen.queryByTestId('my-test-id'));
+          const waitForAsyncUtil = () => {
+            return ${asyncUtil}(screen.queryByTestId('my-test-id'));
           };
         
-          return { waitForLoadComplete, ...utils };
+          return { waitForAsyncUtil, ...utils };
         }
 
-        test('unhandled promise from object member with async wrapper value is invalid', () => {
-          setup().waitForLoadComplete();
+        test('unhandled promise from destructed property of async function wrapper is invalid', () => {
+          setup().waitForAsyncUtil();
         });
       `,
-			errors: [
-				{
-					line: 13,
-					column: 19,
-					messageId: 'asyncUtilWrapper',
-					data: { name: 'waitForLoadComplete' },
-				},
-			],
-		},
-
-		{
-			code: `
+					errors: [
+						{
+							line: 13,
+							column: 19,
+							messageId: 'asyncUtilWrapper',
+							data: { name: 'waitForAsyncUtil' },
+						},
+					],
+				} as const)
+		),
+		...ASYNC_UTILS.map(
+			(asyncUtil) =>
+				({
+					code: `
         function setup() {
           const utils = render(<MyComponent />);
         
-          const waitForLoadComplete = () => {
-            return waitForElementToBeRemoved(screen.queryByTestId('my-test-id'));
+          const waitForAsyncUtil = () => {
+            return ${asyncUtil}(screen.queryByTestId('my-test-id'));
           };
         
-          return { waitForLoadComplete, ...utils };
+          return { waitForAsyncUtil, ...utils };
         }
 
-        test('unhandled promise from object member with async wrapper value is invalid', () => {
-          const myAlias = setup().waitForLoadComplete;
+        test('unhandled promise from destructed property of async function wrapper is invalid', () => {
+          const myAlias = setup().waitForAsyncUtil;
           myAlias();
         });
       `,
-			errors: [
-				{
-					line: 14,
-					column: 11,
-					messageId: 'asyncUtilWrapper',
-					data: { name: 'myAlias' },
-				},
-			],
-		},
+					errors: [
+						{
+							line: 14,
+							column: 11,
+							messageId: 'asyncUtilWrapper',
+							data: { name: 'myAlias' },
+						},
+					],
+				} as const)
+		),
 	]),
 });

--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -260,6 +260,54 @@ ruleTester.run(RULE_NAME, rule, {
         })
       `,
 		},
+		{
+			code: `
+        function setup() {
+          const utils = render(<MyComponent />);
+        
+          const waitForLoadComplete = () => {
+            return waitForElementToBeRemoved(screen.queryByRole('progressbar'));
+          };
+        
+          return { waitForLoadComplete, ...utils };
+        }
+
+        test('destructuring an async function wrapper & handling it later is valid', () => {
+          const { user, waitForLoadComplete } = setup();
+          await waitForLoadComplete();
+
+          const myAlias = waitForLoadComplete;
+          await myAlias();
+
+          const { ...clone } = setup();
+          await clone.waitForLoadComplete();
+
+          const { waitForLoadComplete: myAlias } = setup();
+          await myAlias();
+
+          await setup().waitForLoadComplete();
+        });
+      `,
+		},
+
+		{
+			code: `
+        function setup() {
+          const utils = render(<MyComponent />);
+        
+          const waitForLoadComplete = () => {
+            return waitForElementToBeRemoved(screen.queryByRole('progressbar'));
+          };
+        
+          return { waitForLoadComplete, ...utils };
+        }
+
+        test('destructuring an async function wrapper & handling it later is valid', () => {
+          const { user, ...rest } = setup();
+          await rest.waitForLoadComplete();
+        });
+      `,
+		},
 	]),
 	invalid: SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
 		...ASYNC_UTILS.map(
@@ -441,6 +489,7 @@ ruleTester.run(RULE_NAME, rule, {
 					],
 				} as const)
 		),
+
 		...ASYNC_UTILS.map(
 			(asyncUtil) =>
 				({
@@ -463,5 +512,140 @@ ruleTester.run(RULE_NAME, rule, {
 					],
 				} as const)
 		),
+
+		{
+			code: `
+        function setup() {
+          const utils = render(<MyComponent />);
+        
+          const waitForLoadComplete = () => {
+            return waitForElementToBeRemoved(screen.queryByRole('progressbar'));
+          };
+        
+          return { waitForLoadComplete, ...utils };
+        }
+
+        test('destructuring an async function wrapper & handling it later is valid', () => {
+          const { user, waitForLoadComplete } = setup();
+          waitForLoadComplete();
+        });
+      `,
+			errors: [
+				{
+					line: 14,
+					column: 11,
+					messageId: 'asyncUtilWrapper',
+					data: { name: 'waitForLoadComplete' },
+				},
+			],
+		},
+
+		{
+			code: `
+        function setup() {
+          const utils = render(<MyComponent />);
+        
+          const waitForLoadComplete = () => {
+            return waitForElementToBeRemoved(screen.queryByRole('progressbar'));
+          };
+        
+          return { waitForLoadComplete, ...utils };
+        }
+
+        test('destructuring an async function wrapper & handling it later is valid', () => {
+          const { user, waitForLoadComplete } = setup();
+          const myAlias = waitForLoadComplete;
+          myAlias();
+        });
+      `,
+			errors: [
+				{
+					line: 15,
+					column: 11,
+					messageId: 'asyncUtilWrapper',
+					data: { name: 'myAlias' },
+				},
+			],
+		},
+
+		{
+			code: `
+        function setup() {
+          const utils = render(<MyComponent />);
+        
+          const waitForLoadComplete = () => {
+            return waitForElementToBeRemoved(screen.queryByRole('progressbar'));
+          };
+        
+          return { waitForLoadComplete, ...utils };
+        }
+
+        test('destructuring an async function wrapper & handling it later is valid', () => {
+          const { ...clone } = setup();
+          clone.waitForLoadComplete();
+        });
+      `,
+			errors: [
+				{
+					line: 14,
+					column: 17,
+					messageId: 'asyncUtilWrapper',
+					data: { name: 'waitForLoadComplete' },
+				},
+			],
+		},
+
+		{
+			code: `
+        function setup() {
+          const utils = render(<MyComponent />);
+        
+          const waitForLoadComplete = () => {
+            return waitForElementToBeRemoved(screen.queryByRole('progressbar'));
+          };
+        
+          return { waitForLoadComplete, ...utils };
+        }
+
+        test('destructuring an async function wrapper & handling it later is valid', () => {
+          const { waitForLoadComplete: myAlias } = setup();
+          myAlias();
+        });
+      `,
+			errors: [
+				{
+					line: 14,
+					column: 11,
+					messageId: 'asyncUtilWrapper',
+					data: { name: 'myAlias' },
+				},
+			],
+		},
+
+		{
+			code: `
+        function setup() {
+          const utils = render(<MyComponent />);
+        
+          const waitForLoadComplete = () => {
+            return waitForElementToBeRemoved(screen.queryByRole('progressbar'));
+          };
+        
+          return { waitForLoadComplete, ...utils };
+        }
+
+        test('destructuring an async function wrapper & handling it later is valid', () => {
+          setup().waitForLoadComplete();
+        });
+      `,
+			errors: [
+				{
+					line: 13,
+					column: 19,
+					messageId: 'asyncUtilWrapper',
+					data: { name: 'waitForLoadComplete' },
+				},
+			],
+		},
 	]),
 });


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

- Use early return via a condition `isAsyncUtilOrKnownAliasAroundIt` to reduce indentation
- Upon visiting `VariableDeclarator` nodes, detect destructured property aliases and assignments of known async wrapper functions
- Add `getMessageId` function
- Add test cases

## Context

Fixes #715 
