### PR TITLE
chore: fix new linting errors reported

### DIFF
--- a/lib/configs/index.ts
+++ b/lib/configs/index.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 
-import type { TSESLint } from '@typescript-eslint/utils';
+import { type TSESLint } from '@typescript-eslint/utils';
 
 import {
 	importDefault,

--- a/lib/utils/types.ts
+++ b/lib/utils/types.ts
@@ -1,4 +1,4 @@
-import type { TSESLint } from '@typescript-eslint/utils';
+import { type TSESLint } from '@typescript-eslint/utils';
 
 type RecommendedConfig<TOptions extends readonly unknown[]> =
 	| TSESLint.RuleMetaDataDocs['recommended']

--- a/tests/lib/rules/consistent-data-testid.test.ts
+++ b/tests/lib/rules/consistent-data-testid.test.ts
@@ -1,4 +1,4 @@
-import type { TSESLint } from '@typescript-eslint/utils';
+import { type TSESLint } from '@typescript-eslint/utils';
 
 import rule, {
 	MessageIds,

--- a/tests/lib/rules/no-node-access.test.ts
+++ b/tests/lib/rules/no-node-access.test.ts
@@ -1,4 +1,4 @@
-import type { TSESLint } from '@typescript-eslint/utils';
+import { type TSESLint } from '@typescript-eslint/utils';
 
 import rule, { RULE_NAME, Options } from '../../../lib/rules/no-node-access';
 import { createRuleTester } from '../test-utils';

--- a/tests/lib/rules/no-unnecessary-act.test.ts
+++ b/tests/lib/rules/no-unnecessary-act.test.ts
@@ -1,4 +1,4 @@
-import type { TSESLint } from '@typescript-eslint/utils';
+import { type TSESLint } from '@typescript-eslint/utils';
 
 import rule, {
 	MessageIds,

--- a/tools/generate-configs/index.ts
+++ b/tools/generate-configs/index.ts
@@ -1,4 +1,4 @@
-import type { LinterConfigRules } from '../../lib/configs';
+import { type LinterConfigRules } from '../../lib/configs';
 import rules from '../../lib/rules';
 import {
 	SUPPORTED_TESTING_FRAMEWORKS,

--- a/tools/generate-configs/utils.ts
+++ b/tools/generate-configs/utils.ts
@@ -1,7 +1,7 @@
 import { writeFileSync } from 'fs';
 import { resolve } from 'path';
 
-import type { TSESLint } from '@typescript-eslint/utils';
+import { type TSESLint } from '@typescript-eslint/utils';
 import { format, resolveConfig } from 'prettier';
 
 const prettierConfig = resolveConfig.sync(__dirname);


### PR DESCRIPTION
## Checks

- [X] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- Fix new linting errors reported by eslint-plugin-import

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

Since we don't have our dependencies pinned, some ESLint plugin/config got updated and started reporting new errors in #722. I'm tired of this behavior, already happened many times. I'm pinning the dependencies in another PR and setting up Renovatebot.