### PR TITLE
fix(await-async-util): false positives due to empty strings

### DIFF
--- a/lib/rules/await-async-utils.ts
+++ b/lib/rules/await-async-utils.ts
@@ -44,10 +44,16 @@ export default createTestingLibraryRule<Options, MessageIds>({
 
 		function detectAsyncUtilWrapper(node: TSESTree.Identifier) {
 			const innerFunction = getInnermostReturningFunction(context, node);
-
-			if (innerFunction) {
-				functionWrappersNames.push(getFunctionName(innerFunction));
+			if (!innerFunction) {
+				return;
 			}
+
+			const functionName = getFunctionName(innerFunction);
+			if (functionName.length === 0) {
+				return;
+			}
+
+			functionWrappersNames.push(functionName);
 		}
 
 		/*

--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -294,6 +294,38 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
+		...ASYNC_UTILS.map((asyncUtil) => ({
+			code: `
+          import React from 'react';
+          import { render, act } from '@testing-library/react';
+          
+          const doWithAct = async (timeout) => {
+            await act(async () => await ${asyncUtil}(screen.getByTestId('my-test')));
+          };
+          
+          describe('Component', () => {
+            const mock = jest.fn();
+          
+            it('test', async () => {
+              let Component = () => {
+                mock(1);
+                return <div />;
+              };
+              render(<Component />);
+          
+              await doWithAct(500);
+          
+              const myNumberTestVar = 1;
+              const myBooleanTestVar = false;
+              const myArrayTestVar = [1, 2];
+              const myStringTestVar = 'hello world';
+              const myObjectTestVar = { hello: 'world' };
+
+              expect(mock).toHaveBeenCalledWith(myNumberTestVar);
+            });
+          });
+      `,
+		})),
 	]),
 	invalid: SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
 		...ASYNC_UTILS.map(


### PR DESCRIPTION
## Checks

- [x ] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

- In `detectAsyncUtilWrapper`, adapt code to not push empty strings into `functionWrapperNames`.

## Context

Partially fixes #732 : Addresses the first example, but not the latter one.
