### PR TITLE
chore(semantic-release): change package root

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,4 @@
 {
-	"pkgRoot": "dist",
 	"branches": [
 		"+([0-9])?(.{+([0-9]),x}).x",
 		"main",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
 				"@types/node": "^16.18.23",
 				"@typescript-eslint/eslint-plugin": "^5.58.0",
 				"@typescript-eslint/parser": "^5.58.0",
-				"cpy-cli": "^4.2.0",
 				"del-cli": "^5.0.0",
 				"eslint": "^8.38.0",
 				"eslint-config-kentcdodds": "^20.5.0",
@@ -3450,17 +3449,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/arrify": {
-			"version": "3.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/ast-types-flow": {
 			"version": "0.0.7",
 			"dev": true,
@@ -4210,250 +4198,6 @@
 				"cosmiconfig": ">=7",
 				"ts-node": ">=10",
 				"typescript": ">=4"
-			}
-		},
-		"node_modules/cp-file": {
-			"version": "9.1.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.1.2",
-				"make-dir": "^3.0.0",
-				"nested-error-stacks": "^2.0.0",
-				"p-event": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/cpy": {
-			"version": "9.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"arrify": "^3.0.0",
-				"cp-file": "^9.1.0",
-				"globby": "^13.1.1",
-				"junk": "^4.0.0",
-				"micromatch": "^4.0.4",
-				"nested-error-stacks": "^2.1.0",
-				"p-filter": "^3.0.0",
-				"p-map": "^5.3.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/cpy-cli": {
-			"version": "4.2.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cpy": "^9.0.0",
-				"meow": "^10.1.2"
-			},
-			"bin": {
-				"cpy": "cli.js"
-			},
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/cpy-cli/node_modules/camelcase": {
-			"version": "6.3.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/cpy-cli/node_modules/camelcase-keys": {
-			"version": "7.0.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"camelcase": "^6.3.0",
-				"map-obj": "^4.1.0",
-				"quick-lru": "^5.1.1",
-				"type-fest": "^1.2.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/cpy-cli/node_modules/decamelize": {
-			"version": "5.0.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/cpy-cli/node_modules/indent-string": {
-			"version": "5.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/cpy-cli/node_modules/meow": {
-			"version": "10.1.5",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/minimist": "^1.2.2",
-				"camelcase-keys": "^7.0.0",
-				"decamelize": "^5.0.0",
-				"decamelize-keys": "^1.1.0",
-				"hard-rejection": "^2.1.0",
-				"minimist-options": "4.1.0",
-				"normalize-package-data": "^3.0.2",
-				"read-pkg-up": "^8.0.0",
-				"redent": "^4.0.0",
-				"trim-newlines": "^4.0.2",
-				"type-fest": "^1.2.2",
-				"yargs-parser": "^20.2.9"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/cpy-cli/node_modules/quick-lru": {
-			"version": "5.1.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/cpy-cli/node_modules/read-pkg": {
-			"version": "6.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/normalize-package-data": "^2.4.0",
-				"normalize-package-data": "^3.0.2",
-				"parse-json": "^5.2.0",
-				"type-fest": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/cpy-cli/node_modules/read-pkg-up": {
-			"version": "8.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"find-up": "^5.0.0",
-				"read-pkg": "^6.0.0",
-				"type-fest": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/cpy-cli/node_modules/redent": {
-			"version": "4.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"indent-string": "^5.0.0",
-				"strip-indent": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/cpy-cli/node_modules/strip-indent": {
-			"version": "4.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"min-indent": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/cpy-cli/node_modules/trim-newlines": {
-			"version": "4.0.2",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/cpy-cli/node_modules/type-fest": {
-			"version": "1.4.0",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/cpy/node_modules/globby": {
-			"version": "13.1.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.2.11",
-				"ignore": "^5.2.0",
-				"merge2": "^1.4.1",
-				"slash": "^4.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/create-require": {
@@ -9530,17 +9274,6 @@
 				"node": ">=4.0"
 			}
 		},
-		"node_modules/junk": {
-			"version": "4.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/kind-of": {
 			"version": "6.0.3",
 			"dev": true,
@@ -10463,11 +10196,6 @@
 		},
 		"node_modules/nerf-dart": {
 			"version": "1.0.0",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/nested-error-stacks": {
-			"version": "2.1.1",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -13443,42 +13171,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/p-event": {
-			"version": "4.2.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-timeout": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/p-filter": {
-			"version": "3.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-map": "^5.1.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/p-finally": {
-			"version": "1.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/p-is-promise": {
 			"version": "3.0.0",
 			"dev": true,
@@ -13542,17 +13234,6 @@
 			"dependencies": {
 				"@types/retry": "0.12.0",
 				"retry": "^0.13.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/p-timeout": {
-			"version": "3.2.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-finally": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=8"
@@ -18388,10 +18069,6 @@
 				"is-shared-array-buffer": "^1.0.2"
 			}
 		},
-		"arrify": {
-			"version": "3.0.0",
-			"dev": true
-		},
 		"ast-types-flow": {
 			"version": "0.0.7",
 			"dev": true
@@ -18852,139 +18529,6 @@
 			"integrity": "sha512-BabizFdC3wBHhbI4kJh0VkQP9GkBfoHPydD0COMce1nJ1kJAB3F2TmJ/I7diULBKtmEWSwEbuN/KDtgnmUUVmw==",
 			"dev": true,
 			"requires": {}
-		},
-		"cp-file": {
-			"version": "9.1.0",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"make-dir": "^3.0.0",
-				"nested-error-stacks": "^2.0.0",
-				"p-event": "^4.1.0"
-			}
-		},
-		"cpy": {
-			"version": "9.0.1",
-			"dev": true,
-			"requires": {
-				"arrify": "^3.0.0",
-				"cp-file": "^9.1.0",
-				"globby": "^13.1.1",
-				"junk": "^4.0.0",
-				"micromatch": "^4.0.4",
-				"nested-error-stacks": "^2.1.0",
-				"p-filter": "^3.0.0",
-				"p-map": "^5.3.0"
-			},
-			"dependencies": {
-				"globby": {
-					"version": "13.1.3",
-					"dev": true,
-					"requires": {
-						"dir-glob": "^3.0.1",
-						"fast-glob": "^3.2.11",
-						"ignore": "^5.2.0",
-						"merge2": "^1.4.1",
-						"slash": "^4.0.0"
-					}
-				}
-			}
-		},
-		"cpy-cli": {
-			"version": "4.2.0",
-			"dev": true,
-			"requires": {
-				"cpy": "^9.0.0",
-				"meow": "^10.1.2"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "6.3.0",
-					"dev": true
-				},
-				"camelcase-keys": {
-					"version": "7.0.2",
-					"dev": true,
-					"requires": {
-						"camelcase": "^6.3.0",
-						"map-obj": "^4.1.0",
-						"quick-lru": "^5.1.1",
-						"type-fest": "^1.2.1"
-					}
-				},
-				"decamelize": {
-					"version": "5.0.1",
-					"dev": true
-				},
-				"indent-string": {
-					"version": "5.0.0",
-					"dev": true
-				},
-				"meow": {
-					"version": "10.1.5",
-					"dev": true,
-					"requires": {
-						"@types/minimist": "^1.2.2",
-						"camelcase-keys": "^7.0.0",
-						"decamelize": "^5.0.0",
-						"decamelize-keys": "^1.1.0",
-						"hard-rejection": "^2.1.0",
-						"minimist-options": "4.1.0",
-						"normalize-package-data": "^3.0.2",
-						"read-pkg-up": "^8.0.0",
-						"redent": "^4.0.0",
-						"trim-newlines": "^4.0.2",
-						"type-fest": "^1.2.2",
-						"yargs-parser": "^20.2.9"
-					}
-				},
-				"quick-lru": {
-					"version": "5.1.1",
-					"dev": true
-				},
-				"read-pkg": {
-					"version": "6.0.0",
-					"dev": true,
-					"requires": {
-						"@types/normalize-package-data": "^2.4.0",
-						"normalize-package-data": "^3.0.2",
-						"parse-json": "^5.2.0",
-						"type-fest": "^1.0.1"
-					}
-				},
-				"read-pkg-up": {
-					"version": "8.0.0",
-					"dev": true,
-					"requires": {
-						"find-up": "^5.0.0",
-						"read-pkg": "^6.0.0",
-						"type-fest": "^1.0.1"
-					}
-				},
-				"redent": {
-					"version": "4.0.0",
-					"dev": true,
-					"requires": {
-						"indent-string": "^5.0.0",
-						"strip-indent": "^4.0.0"
-					}
-				},
-				"strip-indent": {
-					"version": "4.0.0",
-					"dev": true,
-					"requires": {
-						"min-indent": "^1.0.1"
-					}
-				},
-				"trim-newlines": {
-					"version": "4.0.2",
-					"dev": true
-				},
-				"type-fest": {
-					"version": "1.4.0",
-					"dev": true
-				}
-			}
 		},
 		"create-require": {
 			"version": "1.1.1",
@@ -22132,10 +21676,6 @@
 				"object.assign": "^4.1.3"
 			}
 		},
-		"junk": {
-			"version": "4.0.0",
-			"dev": true
-		},
 		"kind-of": {
 			"version": "6.0.3",
 			"dev": true
@@ -22710,10 +22250,6 @@
 		},
 		"nerf-dart": {
 			"version": "1.0.0",
-			"dev": true
-		},
-		"nested-error-stacks": {
-			"version": "2.1.1",
 			"dev": true
 		},
 		"nice-try": {
@@ -24751,24 +24287,6 @@
 			"version": "2.2.0",
 			"dev": true
 		},
-		"p-event": {
-			"version": "4.2.0",
-			"dev": true,
-			"requires": {
-				"p-timeout": "^3.1.0"
-			}
-		},
-		"p-filter": {
-			"version": "3.0.0",
-			"dev": true,
-			"requires": {
-				"p-map": "^5.1.0"
-			}
-		},
-		"p-finally": {
-			"version": "1.0.0",
-			"dev": true
-		},
 		"p-is-promise": {
 			"version": "3.0.0",
 			"dev": true
@@ -24802,13 +24320,6 @@
 			"requires": {
 				"@types/retry": "0.12.0",
 				"retry": "^0.13.1"
-			}
-		},
-		"p-timeout": {
-			"version": "3.2.0",
-			"dev": true,
-			"requires": {
-				"p-finally": "^1.0.0"
 			}
 		},
 		"p-try": {

--- a/package.json
+++ b/package.json
@@ -24,11 +24,15 @@
 		"email": "me@mario.dev",
 		"url": "https://mario.dev/"
 	},
-	"main": "index.js",
+	"files": [
+		"dist",
+		"README.md",
+		"LICENSE"
+	],
+	"main": "./dist/index.js",
 	"scripts": {
 		"prebuild": "del-cli dist",
 		"build": "tsc",
-		"postbuild": "cpy README.md ./dist && cpy package.json ./dist && cpy LICENSE ./dist",
 		"generate-all": "run-p \"generate:*\"",
 		"generate:configs": "ts-node tools/generate-configs",
 		"generate:rules-doc": "npm run build && npm run rule-doc-generator",
@@ -58,7 +62,6 @@
 		"@types/node": "^16.18.23",
 		"@typescript-eslint/eslint-plugin": "^5.58.0",
 		"@typescript-eslint/parser": "^5.58.0",
-		"cpy-cli": "^4.2.0",
 		"del-cli": "^5.0.0",
 		"eslint": "^8.38.0",
 		"eslint-config-kentcdodds": "^20.5.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"lint:fix": "npm run lint -- --fix",
 		"prepare": "is-ci || husky install",
 		"prettier-base": "prettier . --ignore-unknown --cache --loglevel warn",
-		"rule-doc-generator": "eslint-doc-generator --path-rule-list \"../README.md\" --path-rule-doc \"../docs/rules/{name}.md\" --url-rule-doc \"docs/rules/{name}.md\" dist/",
+		"rule-doc-generator": "eslint-doc-generator",
 		"semantic-release": "semantic-release",
 		"test": "jest",
 		"test:ci": "jest --ci --coverage",


### PR DESCRIPTION
## Checks

- [X] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- Remove the `pkgRoot` from semantic-release config, so it points directly to the root of the repo instead of `dist/` folder.

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

Pointing to the root of the repo is the correct behavior. It was incorrect before, that's why we had to copy the extra files after building. By setting the `pkgRoot` to the root of the repo, and setting the proper `files` in the `package.json`, npm CLI and semantic-release will bundle and publish it as expected.