### PR TITLE
chore(jest): replace `ts-jest` with `@swc/jest`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
 	testMatch: ['**/tests/**/*.test.ts'],
 	transform: {
-		'^.+\\.tsx?$': 'ts-jest',
+		'^.+\\.ts$': '@swc/jest',
 	},
 	coverageThreshold: {
 		global: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
 				"@babel/eslint-plugin": "^7.19.1",
 				"@commitlint/cli": "^17.5.1",
 				"@commitlint/config-conventional": "^17.4.4",
+				"@swc/core": "^1.3.75",
+				"@swc/jest": "^0.2.28",
 				"@types/jest": "^27.5.2",
 				"@types/node": "^16.18.23",
 				"@typescript-eslint/eslint-plugin": "^5.58.0",
@@ -42,7 +44,6 @@
 				"npm-run-all": "^4.1.5",
 				"prettier": "2.8.7",
 				"semantic-release": "^19.0.5",
-				"ts-jest": "^28.0.8",
 				"ts-node": "^10.9.1",
 				"typescript": "^4.9.5"
 			},
@@ -1557,6 +1558,113 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/@jest/create-cache-key-function": {
+			"version": "27.5.1",
+			"resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-27.5.1.tgz",
+			"integrity": "sha512-dmH1yW+makpTSURTy8VzdUwFnfQh1G8R+DxO2Ho2FFmBbKFEVm+3jWdvFhE2VqB/LATCTokkP0dotjyQyw5/AQ==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": "^27.5.1"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+			}
+		},
+		"node_modules/@jest/create-cache-key-function/node_modules/@jest/types": {
+			"version": "27.5.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
+			"integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
+			"dev": true,
+			"dependencies": {
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"@types/istanbul-reports": "^3.0.0",
+				"@types/node": "*",
+				"@types/yargs": "^16.0.0",
+				"chalk": "^4.0.0"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+			}
+		},
+		"node_modules/@jest/create-cache-key-function/node_modules/@types/yargs": {
+			"version": "16.0.5",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.5.tgz",
+			"integrity": "sha512-AxO/ADJOBFJScHbWhq2xAhlWP24rY4aCEG/NFaMvbT3X2MgRsLjhjQwsn0Zi5zn0LG9jUhCCZMeX9Dkuw6k+vQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"node_modules/@jest/create-cache-key-function/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@jest/create-cache-key-function/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@jest/create-cache-key-function/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/@jest/create-cache-key-function/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/@jest/create-cache-key-function/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@jest/create-cache-key-function/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/@jest/environment": {
 			"version": "28.1.3",
 			"dev": true,
@@ -2502,6 +2610,216 @@
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@sinonjs/commons": "^1.7.0"
+			}
+		},
+		"node_modules/@swc/core": {
+			"version": "1.3.75",
+			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.75.tgz",
+			"integrity": "sha512-YLqd5oZVnaOq/OzkjRSsJUQqAfKYiD0fzUyVUPVlNNCoQEfVfSMcXH80hLmYe9aDH0T/a7qEMjWyIr/0kWqy1A==",
+			"dev": true,
+			"hasInstallScript": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/swc"
+			},
+			"optionalDependencies": {
+				"@swc/core-darwin-arm64": "1.3.75",
+				"@swc/core-darwin-x64": "1.3.75",
+				"@swc/core-linux-arm-gnueabihf": "1.3.75",
+				"@swc/core-linux-arm64-gnu": "1.3.75",
+				"@swc/core-linux-arm64-musl": "1.3.75",
+				"@swc/core-linux-x64-gnu": "1.3.75",
+				"@swc/core-linux-x64-musl": "1.3.75",
+				"@swc/core-win32-arm64-msvc": "1.3.75",
+				"@swc/core-win32-ia32-msvc": "1.3.75",
+				"@swc/core-win32-x64-msvc": "1.3.75"
+			},
+			"peerDependencies": {
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependenciesMeta": {
+				"@swc/helpers": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@swc/core-darwin-arm64": {
+			"version": "1.3.75",
+			"resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.75.tgz",
+			"integrity": "sha512-anDnx9L465lGbjB2mvcV54NGHW6illr0IDvVV7JmkabYUVneaRdQvTr0tbHv3xjHnjrK1wuwVOHKV0LcQF2tnQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-darwin-x64": {
+			"version": "1.3.75",
+			"resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.75.tgz",
+			"integrity": "sha512-dIHDfrLmeZfr2xwi1whO7AmzdI3HdamgvxthaL+S8L1x8TeczAZEvsmZTjy3s8p3Va4rbGXcb3+uBhmfkqCbfw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-arm-gnueabihf": {
+			"version": "1.3.75",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.75.tgz",
+			"integrity": "sha512-qeJmvMGrjC6xt+G0R4kVqqxvlhxJx7tTzhcEoWgLJnfvGZiF6SJdsef4OSM7HuReXrlBoEtJbfGPrLJtbV+C0w==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-arm64-gnu": {
+			"version": "1.3.75",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.75.tgz",
+			"integrity": "sha512-sqA9JqHEJBF4AdNuwo5zRqq0HC3l31SPsG9zpRa4nRzG5daBBJ80H7fi6PZQud1rfNNq+Q08gjYrdrxwHstvjw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-arm64-musl": {
+			"version": "1.3.75",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.75.tgz",
+			"integrity": "sha512-95rQT5xTAL3eKhMJbJbLsZHHP9EUlh1rcrFoLf0gUApoVF8g94QjZ9hYZiI72mMP5WPjgTEXQVnVB9O2GxeaLw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-x64-gnu": {
+			"version": "1.3.75",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.75.tgz",
+			"integrity": "sha512-If7UpAhnPduMmtC+TSgPpZ1UXZfp2hIpjUFxpeCmHHYLS6Fn/2GZC5hpEiu+wvFJF0hzPh93eNAHa9gUxGUG+w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-linux-x64-musl": {
+			"version": "1.3.75",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.75.tgz",
+			"integrity": "sha512-HOhxX0YNHTElCZqIviquka3CGYTN8rSQ6BdFfSk/K0O+ZEHx3qGte0qr+gGLPF/237GxreUkp3OMaWKuURtuCg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-win32-arm64-msvc": {
+			"version": "1.3.75",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.75.tgz",
+			"integrity": "sha512-7QPI+mvBXAerVfWahrgBNe+g7fK8PuetxFnZSEmXUcDXvWcdJXAndD7GjAJzbDyjQpLKHbsDKMiHYvfNxZoN/A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-win32-ia32-msvc": {
+			"version": "1.3.75",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.75.tgz",
+			"integrity": "sha512-EfABCy4Wlq7O5ShWsm32FgDkSjyeyj/SQ4wnUIvWpkXhgfT1iNXky7KRU1HtX+SmnVk/k/NnabVZpIklYbjtZA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/core-win32-x64-msvc": {
+			"version": "1.3.75",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.75.tgz",
+			"integrity": "sha512-cTvP0pOD9C3pSp1cwtt85ZsrUkQz8RZfSPhM+jCGxKxmoowDCnInoOQ4Ica/ehyuUnQ4/IstSdYtYpO5yzPDJg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@swc/jest": {
+			"version": "0.2.28",
+			"resolved": "https://registry.npmjs.org/@swc/jest/-/jest-0.2.28.tgz",
+			"integrity": "sha512-iCB3lvngkQldLga35krb8LPa+6gmkVXnlpfCTXOAgMaEYFagLxOIFbIO8II7dhHa8ApOv5ap8iFRETI4lVY0vw==",
+			"dev": true,
+			"dependencies": {
+				"@jest/create-cache-key-function": "^27.4.2",
+				"jsonc-parser": "^3.2.0"
+			},
+			"engines": {
+				"npm": ">= 7.0.0"
+			},
+			"peerDependencies": {
+				"@swc/core": "*"
 			}
 		},
 		"node_modules/@testing-library/dom": {
@@ -3737,17 +4055,6 @@
 			},
 			"engines": {
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-			}
-		},
-		"node_modules/bs-logger": {
-			"version": "0.2.6",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-json-stable-stringify": "2.x"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/bser": {
@@ -9484,6 +9791,12 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/jsonc-parser": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+			"dev": true
+		},
 		"node_modules/jsonfile": {
 			"version": "6.1.0",
 			"dev": true,
@@ -10047,11 +10360,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
 			"integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
 			"dev": true
-		},
-		"node_modules/lodash.memoize": {
-			"version": "4.1.2",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
@@ -15391,86 +15699,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/ts-jest": {
-			"version": "28.0.8",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"bs-logger": "0.x",
-				"fast-json-stable-stringify": "2.x",
-				"jest-util": "^28.0.0",
-				"json5": "^2.2.1",
-				"lodash.memoize": "4.x",
-				"make-error": "1.x",
-				"semver": "7.x",
-				"yargs-parser": "^21.0.1"
-			},
-			"bin": {
-				"ts-jest": "cli.js"
-			},
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-			},
-			"peerDependencies": {
-				"@babel/core": ">=7.0.0-beta.0 <8",
-				"@jest/types": "^28.0.0",
-				"babel-jest": "^28.0.0",
-				"jest": "^28.0.0",
-				"typescript": ">=4.3"
-			},
-			"peerDependenciesMeta": {
-				"@babel/core": {
-					"optional": true
-				},
-				"@jest/types": {
-					"optional": true
-				},
-				"babel-jest": {
-					"optional": true
-				},
-				"esbuild": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/ts-jest/node_modules/lru-cache": {
-			"version": "6.0.0",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/ts-jest/node_modules/semver": {
-			"version": "7.3.8",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/ts-jest/node_modules/yallist": {
-			"version": "4.0.0",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/ts-jest/node_modules/yargs-parser": {
-			"version": "21.1.1",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/ts-node": {
 			"version": "10.9.1",
 			"dev": true,
@@ -17129,6 +17357,88 @@
 				}
 			}
 		},
+		"@jest/create-cache-key-function": {
+			"version": "27.5.1",
+			"resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-27.5.1.tgz",
+			"integrity": "sha512-dmH1yW+makpTSURTy8VzdUwFnfQh1G8R+DxO2Ho2FFmBbKFEVm+3jWdvFhE2VqB/LATCTokkP0dotjyQyw5/AQ==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^27.5.1"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "27.5.1",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
+					"integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^16.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/yargs": {
+					"version": "16.0.5",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.5.tgz",
+					"integrity": "sha512-AxO/ADJOBFJScHbWhq2xAhlWP24rY4aCEG/NFaMvbT3X2MgRsLjhjQwsn0Zi5zn0LG9jUhCCZMeX9Dkuw6k+vQ==",
+					"dev": true,
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"@jest/environment": {
 			"version": "28.1.3",
 			"dev": true,
@@ -17769,6 +18079,104 @@
 			"dev": true,
 			"requires": {
 				"@sinonjs/commons": "^1.7.0"
+			}
+		},
+		"@swc/core": {
+			"version": "1.3.75",
+			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.75.tgz",
+			"integrity": "sha512-YLqd5oZVnaOq/OzkjRSsJUQqAfKYiD0fzUyVUPVlNNCoQEfVfSMcXH80hLmYe9aDH0T/a7qEMjWyIr/0kWqy1A==",
+			"dev": true,
+			"requires": {
+				"@swc/core-darwin-arm64": "1.3.75",
+				"@swc/core-darwin-x64": "1.3.75",
+				"@swc/core-linux-arm-gnueabihf": "1.3.75",
+				"@swc/core-linux-arm64-gnu": "1.3.75",
+				"@swc/core-linux-arm64-musl": "1.3.75",
+				"@swc/core-linux-x64-gnu": "1.3.75",
+				"@swc/core-linux-x64-musl": "1.3.75",
+				"@swc/core-win32-arm64-msvc": "1.3.75",
+				"@swc/core-win32-ia32-msvc": "1.3.75",
+				"@swc/core-win32-x64-msvc": "1.3.75"
+			}
+		},
+		"@swc/core-darwin-arm64": {
+			"version": "1.3.75",
+			"resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.75.tgz",
+			"integrity": "sha512-anDnx9L465lGbjB2mvcV54NGHW6illr0IDvVV7JmkabYUVneaRdQvTr0tbHv3xjHnjrK1wuwVOHKV0LcQF2tnQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@swc/core-darwin-x64": {
+			"version": "1.3.75",
+			"resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.75.tgz",
+			"integrity": "sha512-dIHDfrLmeZfr2xwi1whO7AmzdI3HdamgvxthaL+S8L1x8TeczAZEvsmZTjy3s8p3Va4rbGXcb3+uBhmfkqCbfw==",
+			"dev": true,
+			"optional": true
+		},
+		"@swc/core-linux-arm-gnueabihf": {
+			"version": "1.3.75",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.75.tgz",
+			"integrity": "sha512-qeJmvMGrjC6xt+G0R4kVqqxvlhxJx7tTzhcEoWgLJnfvGZiF6SJdsef4OSM7HuReXrlBoEtJbfGPrLJtbV+C0w==",
+			"dev": true,
+			"optional": true
+		},
+		"@swc/core-linux-arm64-gnu": {
+			"version": "1.3.75",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.75.tgz",
+			"integrity": "sha512-sqA9JqHEJBF4AdNuwo5zRqq0HC3l31SPsG9zpRa4nRzG5daBBJ80H7fi6PZQud1rfNNq+Q08gjYrdrxwHstvjw==",
+			"dev": true,
+			"optional": true
+		},
+		"@swc/core-linux-arm64-musl": {
+			"version": "1.3.75",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.75.tgz",
+			"integrity": "sha512-95rQT5xTAL3eKhMJbJbLsZHHP9EUlh1rcrFoLf0gUApoVF8g94QjZ9hYZiI72mMP5WPjgTEXQVnVB9O2GxeaLw==",
+			"dev": true,
+			"optional": true
+		},
+		"@swc/core-linux-x64-gnu": {
+			"version": "1.3.75",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.75.tgz",
+			"integrity": "sha512-If7UpAhnPduMmtC+TSgPpZ1UXZfp2hIpjUFxpeCmHHYLS6Fn/2GZC5hpEiu+wvFJF0hzPh93eNAHa9gUxGUG+w==",
+			"dev": true,
+			"optional": true
+		},
+		"@swc/core-linux-x64-musl": {
+			"version": "1.3.75",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.75.tgz",
+			"integrity": "sha512-HOhxX0YNHTElCZqIviquka3CGYTN8rSQ6BdFfSk/K0O+ZEHx3qGte0qr+gGLPF/237GxreUkp3OMaWKuURtuCg==",
+			"dev": true,
+			"optional": true
+		},
+		"@swc/core-win32-arm64-msvc": {
+			"version": "1.3.75",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.75.tgz",
+			"integrity": "sha512-7QPI+mvBXAerVfWahrgBNe+g7fK8PuetxFnZSEmXUcDXvWcdJXAndD7GjAJzbDyjQpLKHbsDKMiHYvfNxZoN/A==",
+			"dev": true,
+			"optional": true
+		},
+		"@swc/core-win32-ia32-msvc": {
+			"version": "1.3.75",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.75.tgz",
+			"integrity": "sha512-EfABCy4Wlq7O5ShWsm32FgDkSjyeyj/SQ4wnUIvWpkXhgfT1iNXky7KRU1HtX+SmnVk/k/NnabVZpIklYbjtZA==",
+			"dev": true,
+			"optional": true
+		},
+		"@swc/core-win32-x64-msvc": {
+			"version": "1.3.75",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.75.tgz",
+			"integrity": "sha512-cTvP0pOD9C3pSp1cwtt85ZsrUkQz8RZfSPhM+jCGxKxmoowDCnInoOQ4Ica/ehyuUnQ4/IstSdYtYpO5yzPDJg==",
+			"dev": true,
+			"optional": true
+		},
+		"@swc/jest": {
+			"version": "0.2.28",
+			"resolved": "https://registry.npmjs.org/@swc/jest/-/jest-0.2.28.tgz",
+			"integrity": "sha512-iCB3lvngkQldLga35krb8LPa+6gmkVXnlpfCTXOAgMaEYFagLxOIFbIO8II7dhHa8ApOv5ap8iFRETI4lVY0vw==",
+			"dev": true,
+			"requires": {
+				"@jest/create-cache-key-function": "^27.4.2",
+				"jsonc-parser": "^3.2.0"
 			}
 		},
 		"@testing-library/dom": {
@@ -18560,13 +18968,6 @@
 				"electron-to-chromium": "^1.4.477",
 				"node-releases": "^2.0.13",
 				"update-browserslist-db": "^1.0.11"
-			}
-		},
-		"bs-logger": {
-			"version": "0.2.6",
-			"dev": true,
-			"requires": {
-				"fast-json-stable-stringify": "2.x"
 			}
 		},
 		"bser": {
@@ -22104,6 +22505,12 @@
 			"version": "2.2.3",
 			"dev": true
 		},
+		"jsonc-parser": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+			"dev": true
+		},
 		"jsonfile": {
 			"version": "6.1.0",
 			"dev": true,
@@ -22444,10 +22851,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
 			"integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
-			"dev": true
-		},
-		"lodash.memoize": {
-			"version": "4.1.2",
 			"dev": true
 		},
 		"lodash.merge": {
@@ -25983,44 +26386,6 @@
 		"trim-newlines": {
 			"version": "3.0.1",
 			"dev": true
-		},
-		"ts-jest": {
-			"version": "28.0.8",
-			"dev": true,
-			"requires": {
-				"bs-logger": "0.x",
-				"fast-json-stable-stringify": "2.x",
-				"jest-util": "^28.0.0",
-				"json5": "^2.2.1",
-				"lodash.memoize": "4.x",
-				"make-error": "1.x",
-				"semver": "7.x",
-				"yargs-parser": "^21.0.1"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "6.0.0",
-					"dev": true,
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"semver": {
-					"version": "7.3.8",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"dev": true
-				},
-				"yargs-parser": {
-					"version": "21.1.1",
-					"dev": true
-				}
-			}
 		},
 		"ts-node": {
 			"version": "10.9.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
 		"@babel/eslint-plugin": "^7.19.1",
 		"@commitlint/cli": "^17.5.1",
 		"@commitlint/config-conventional": "^17.4.4",
+		"@swc/core": "^1.3.75",
+		"@swc/jest": "^0.2.28",
 		"@types/jest": "^27.5.2",
 		"@types/node": "^16.18.23",
 		"@typescript-eslint/eslint-plugin": "^5.58.0",
@@ -79,7 +81,6 @@
 		"npm-run-all": "^4.1.5",
 		"prettier": "2.8.7",
 		"semantic-release": "^19.0.5",
-		"ts-jest": "^28.0.8",
 		"ts-node": "^10.9.1",
 		"typescript": "^4.9.5"
 	},


### PR DESCRIPTION
## Checks

- [X] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- replace `ts-jest` with `@swc/jest`

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

Making our Jest tests faster with [`@swc/jest`](https://swc.rs/docs/usage/jest). A comparison running all the tests in an Intel MacBook Pro:

![Running tests with ts-jest takes around 55 seconds](https://github.com/testing-library/eslint-plugin-testing-library/assets/2677072/3e2cda96-b3ae-44eb-b916-88d2a83a5e01)

![Running tests with @swc/jest takes around 40 seconds](https://github.com/testing-library/eslint-plugin-testing-library/assets/2677072/0fc5c599-8f5e-49c0-9044-cbeb2293b61e)
