### PR TITLE
fix(no-await-sync-events): stop reporting `user-event` by default

### DIFF
--- a/docs/rules/no-await-sync-events.md
+++ b/docs/rules/no-await-sync-events.md
@@ -4,7 +4,7 @@
 
 <!-- end auto-generated rule header -->
 
-Ensure that sync simulated events are not awaited unnecessarily.
+Ensure that sync events are not awaited unnecessarily.
 
 ## Rule Details
 
@@ -21,6 +21,12 @@ Some examples of simulating events not returning any Promise are:
 - `userEvent.hover` (prior to `user-event` v14)
 
 This rule aims to prevent users from waiting for those function calls.
+
+> ⚠️ `fire-event` methods are async only on following Testing Library packages:
+>
+> - `@testing-library/vue` (supported by this plugin)
+> - `@testing-library/svelte` (not supported yet by this plugin)
+> - `@marko/testing-library` (supported by this plugin)
 
 Examples of **incorrect** code for this rule:
 
@@ -87,13 +93,9 @@ const qux = async () => {
 
 This rule provides the following options:
 
-- `eventModules`: array of strings. The possibilities are: `"fire-event"` and `"user-event"`. Defaults to `["fire-event", "user-event"]`
+- `eventModules`: string, or array of strings. Defines which event module should be linted for sync event methods. The possibilities are: `"fire-event"` and `"user-event"`. Defaults to `"fire-event"`.
 
-### `eventModules`
-
-This option gives you more granular control of which event modules you want to report, so you can choose to only report methods from either `fire-event`, `user-event` or both.
-
-Example:
+### Example:
 
 ```js
 module.exports = {
@@ -106,7 +108,11 @@ module.exports = {
 };
 ```
 
+## When Not To Use It
+
+- `"fire-event"` option: should be disabled only for those Testing Library packages where fire-event methods are async.
+- `"user-event"` option: should be disabled only if using v14 or greater.
+
 ## Notes
 
-- Since `user-event` v14 all its methods are async, so you should disable reporting them by setting the `eventModules` to just `"fire-event"` so `user-event` methods are not reported.
-- There is another rule `await-async-events`, which is for awaiting async events for `user-event` v14 or `fire-event` only in Vue Testing Library. Please do not confuse with this rule.
+There is another rule `await-async-events`, which is for awaiting async events for `user-event` v14 or `fire-event` only in Testing Library packages with async methods. Please do not confuse with this rule.

--- a/tests/lib/rules/no-await-sync-events.test.ts
+++ b/tests/lib/rules/no-await-sync-events.test.ts
@@ -219,6 +219,16 @@ ruleTester.run(RULE_NAME, rule, {
       `,
 			options: [{ eventModules: ['fire-event'] }],
 		})),
+
+		// valid tests for user-event with default options (user-event disabled)
+		...USER_EVENT_SYNC_FUNCTIONS.map((func) => ({
+			code: `
+        import userEvent from '@testing-library/user-event';
+        test('should not report userEvent.${func} by default', async() => {
+          await userEvent.${func}('foo');
+        });
+      `,
+		})),
 	],
 
 	invalid: [
@@ -254,6 +264,7 @@ ruleTester.run(RULE_NAME, rule, {
           await userEvent.${func}('foo');
         });
       `,
+					options: [{ eventModules: 'user-event' }],
 					errors: [
 						{
 							line: 4,
@@ -277,7 +288,6 @@ ruleTester.run(RULE_NAME, rule, {
           await fireEvent.${func}('foo');
         });
       `,
-						options: [{ eventModules: ['fire-event'] }],
 						errors: [
 							{
 								line: 4,
@@ -289,8 +299,7 @@ ruleTester.run(RULE_NAME, rule, {
 					} as const)
 			)
 		),
-		// sync userEvent sync methods with await operator are not valid
-		// when only fire-event set in eventModules
+
 		...USER_EVENT_SYNC_FUNCTIONS.map(
 			(func) =>
 				({
@@ -320,6 +329,7 @@ ruleTester.run(RULE_NAME, rule, {
           await userEvent.keyboard('foo');
         });
       `,
+			options: [{ eventModules: ['user-event'] }],
 			errors: [
 				{
 					line: 4,
@@ -343,6 +353,7 @@ ruleTester.run(RULE_NAME, rule, {
           await userEvent.keyboard('foo', { delay: 0 });
         });
       `,
+			options: [{ eventModules: ['user-event'] }],
 			errors: [
 				{
 					line: 4,
@@ -370,6 +381,7 @@ ruleTester.run(RULE_NAME, rule, {
           await renamedUserEvent.keyboard('foo', { delay: 0 });
         });
       `,
+			options: [{ eventModules: ['user-event', 'fire-event'] }],
 			errors: [
 				{
 					line: 6,
@@ -397,6 +409,7 @@ ruleTester.run(RULE_NAME, rule, {
           await userEvent.type('foo', { delay });
         }
       `,
+			options: [{ eventModules: ['user-event'] }],
 			errors: [
 				{
 					line: 3,
@@ -414,6 +427,7 @@ ruleTester.run(RULE_NAME, rule, {
           await userEvent.type('foo', { delay, skipHover });
         }
       `,
+			options: [{ eventModules: ['user-event'] }],
 			errors: [
 				{
 					line: 5,
@@ -433,6 +447,7 @@ ruleTester.run(RULE_NAME, rule, {
           await userEvent.type('foo', { delay, skipHover });
         }
       `,
+			options: [{ eventModules: ['user-event'] }],
 			errors: [
 				{
 					line: 7,


### PR DESCRIPTION
## Checks

- [X] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- Stop reporting `user-event` methods by default, assuming v14 is the standard now.

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

Fixes #801
Fixes #669
