### PR TITLE
fix(await-async-events): sync userEvent.setup() should not be reported

### DIFF
--- a/lib/rules/await-async-events.ts
+++ b/lib/rules/await-async-events.ts
@@ -16,6 +16,7 @@ export const RULE_NAME = 'await-async-events';
 export type MessageIds = 'awaitAsyncEvent' | 'awaitAsyncEventWrapper';
 const FIRE_EVENT_NAME = 'fireEvent';
 const USER_EVENT_NAME = 'userEvent';
+const USER_EVENT_SETUP_FUNCTION_NAME = 'setup';
 type EventModules = (typeof EVENTS_SIMULATORS)[number];
 export type Options = [
 	{
@@ -90,6 +91,9 @@ export default createTestingLibraryRule<Options, MessageIds>({
 			messageId?: MessageIds;
 			fix?: TSESLint.ReportFixFunction;
 		}): void {
+			if (node.name === USER_EVENT_SETUP_FUNCTION_NAME) {
+				return;
+			}
 			if (!isPromiseHandled(node)) {
 				context.report({
 					node: closestCallExpression.callee,

--- a/tests/lib/rules/await-async-events.test.ts
+++ b/tests/lib/rules/await-async-events.test.ts
@@ -181,6 +181,29 @@ ruleTester.run(RULE_NAME, rule, {
 		]),
 
 		...USER_EVENT_ASYNC_FRAMEWORKS.flatMap((testingFramework) => [
+			{
+				code: `
+				import userEvent from '${testingFramework}'
+				test('setup method called is valid', () => {
+					userEvent.setup()
+				})
+				`,
+				options: [{ eventModule: 'userEvent' }] as const,
+			},
+			{
+				code: `
+				import userEvent from '${testingFramework}'
+				function customSetup() {
+					return {
+						user: userEvent.setup()
+					};
+				}
+				test('setup method called and returned is valid', () => {
+					const {user} = customSetup();
+				})
+				`,
+				options: [{ eventModule: 'userEvent' }] as const,
+			},
 			...USER_EVENT_ASYNC_FUNCTIONS.map((eventMethod) => ({
 				code: `
         import userEvent from '${testingFramework}'


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

* Skipping nodes named "setup" in the await-async-events rule

## Context

Fixes #800 

This is my first open source PR. I'd rather base the logic on the type of the call expression (is it a `Promise`?), but I don't believe that information is available in the AST so I just went off of the identifier name.
