### PR TITLE
docs: typo in v6 migration guide

### DIFF
--- a/docs/migration-guides/v6.md
+++ b/docs/migration-guides/v6.md
@@ -10,7 +10,7 @@ If you are not on v5 yet, we recommend first following the [v5 migration guide](
 - `await-async-events` is now enabled by default for `fireEvent` in Vue and Marko shared configs
 - `await-async-events` is now enabled by default for `userEvent` in all shared configs
 - `await-async-query` is now called `await-async-queries`
-- `no-await-async-query` is now called `no-await-async-queries`
+- `no-await-sync-query` is now called `no-await-sync-queries`
 - `no-render-in-setup` is now called `no-render-in-lifecycle`
 - `no-await-sync-events` is now enabled by default in React, Angular, and DOM shared configs
 - `no-manual-cleanup` is now enabled by default in React and Vue shared configs
@@ -25,6 +25,6 @@ If you are not on v5 yet, we recommend first following the [v5 migration guide](
 - Removing `testing-library/no-wait-for-empty-callback` if you were referencing it manually somewhere
 - Renaming `testing-library/await-fire-event` to `testing-library/await-async-events` if you were referencing it manually somewhere
 - Renaming `testing-library/await-async-query` to `testing-library/await-async-queries` if you were referencing it manually somewhere
-- Renaming `testing-library/no-await-async-query` to `testing-library/no-await-async-queries` if you were referencing it manually somewhere
+- Renaming `testing-library/no-await-sync-query` to `testing-library/no-await-sync-queries` if you were referencing it manually somewhere
 - Renaming `testing-library/no-render-in-setup` to `testing-library/no-render-in-lifecycle` if you were referencing it manually somewhere
 - Being aware of new rules enabled or changed above in shared configs which can lead to newly reported errors


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

Typo in the migration guide that's already fixed in the GitHub release.

The rules are called `no-await-sync-query` and `no-await-sync-queries`

## Context

https://github.com/testing-library/eslint-plugin-testing-library/releases/tag/v6.0.0
<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->
