### PR TITLE
feat(await-async-events): instance of userEvent is recognized as async

### DIFF
--- a/lib/node-utils/index.ts
+++ b/lib/node-utils/index.ts
@@ -679,3 +679,37 @@ export function findImportSpecifier(
 		return (property as TSESTree.Property).key as TSESTree.Identifier;
 	}
 }
+
+/**
+ * Finds if the userEvent is used as an instance
+ */
+
+export function getUserEventInstance(
+	context: TSESLint.RuleContext<string, unknown[]>,
+	userEventImport: TSESTree.Identifier | null
+): string | undefined {
+	const { tokensAndComments } = context.getSourceCode();
+	if (!userEventImport) {
+		return undefined;
+	}
+	/**
+	 * Check for the following pattern:
+	 * userEvent.setup(
+	 * For a line like this:
+	 * const user = userEvent.setup();
+	 * function will return 'user'
+	 */
+	for (const [index, token] of tokensAndComments.entries()) {
+		if (
+			token.type === 'Identifier' &&
+			token.value === userEventImport.name &&
+			tokensAndComments[index + 1].value === '.' &&
+			tokensAndComments[index + 2].value === 'setup' &&
+			tokensAndComments[index + 3].value === '(' &&
+			tokensAndComments[index - 1].value === '='
+		) {
+			return tokensAndComments[index - 2].value;
+		}
+	}
+	return undefined;
+}

--- a/lib/rules/await-async-events.ts
+++ b/lib/rules/await-async-events.ts
@@ -6,6 +6,7 @@ import {
 	findClosestFunctionExpressionNode,
 	getFunctionName,
 	getInnermostReturningFunction,
+	getUserEventInstance,
 	getVariableReferences,
 	isMemberExpression,
 	isPromiseHandled,
@@ -118,9 +119,20 @@ export default createTestingLibraryRule<Options, MessageIds>({
 
 		return {
 			'CallExpression Identifier'(node: TSESTree.Identifier) {
+				const importedUserEventLibraryNode =
+					helpers.getTestingLibraryImportNode();
+				const userEventImport = helpers.getUserEventImportIdentifier(
+					importedUserEventLibraryNode
+				);
+				// Check if userEvent is used as an instance, like const user = userEvent.setup()
+				const userEventInstance = getUserEventInstance(
+					context,
+					userEventImport
+				);
 				if (
 					(isFireEventEnabled && helpers.isFireEventMethod(node)) ||
-					(isUserEventEnabled && helpers.isUserEventMethod(node))
+					(isUserEventEnabled &&
+						helpers.isUserEventMethod(node, userEventInstance))
 				) {
 					detectEventMethodWrapper(node);
 


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

Adds a feature that events from the instance of userEvent are recognized as async events.

Example:
const user = userEvent.setup();
user.click(button);

The 'user' will be flagged in this case.


## Context

Closes #812

My first open source PR, and not used to GitHub that much, so there might be some errors with the process. Changes itself are quite simple, but I didn't find a more elegant way to do that.
