### PR TITLE
fix: handle multiple imports with `no-manual-cleanup`

### DIFF
--- a/lib/rules/no-manual-cleanup.ts
+++ b/lib/rules/no-manual-cleanup.ts
@@ -111,15 +111,12 @@ export default createTestingLibraryRule<Options, MessageIds>({
 		return {
 			'Program:exit'() {
 				const testingLibraryImportName = helpers.getTestingLibraryImportName();
-				const testingLibraryImportNode = helpers.getTestingLibraryImportNode();
 				const customModuleImportNode = helpers.getCustomModuleImportNode();
 
-				if (
-					testingLibraryImportName &&
-					testingLibraryImportNode &&
-					testingLibraryImportName.match(CLEANUP_LIBRARY_REGEXP)
-				) {
-					reportCandidateModule(testingLibraryImportNode);
+				if (testingLibraryImportName?.match(CLEANUP_LIBRARY_REGEXP)) {
+					for (const importNode of helpers.getAllTestingLibraryImportNodes()) {
+						reportCandidateModule(importNode);
+					}
 				}
 
 				if (customModuleImportNode) {

--- a/tests/lib/rules/no-manual-cleanup.test.ts
+++ b/tests/lib/rules/no-manual-cleanup.test.ts
@@ -235,5 +235,22 @@ ruleTester.run(RULE_NAME, rule, {
 					],
 				} as const)
 		),
+		...ALL_TESTING_LIBRARIES_WITH_CLEANUP.map(
+			(lib) =>
+				({
+					code: `
+        import { render } from "${lib}";
+        import { cleanup } from "${lib}";
+        afterEach(cleanup);
+      `,
+					errors: [
+						{
+							line: 3,
+							column: 18,
+							messageId: 'noManualCleanup',
+						},
+					],
+				} as const)
+		),
 	],
 });


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

Crawl all the import references when sniffing out `no-manual-cleanup` violations.

## Context

There is currently a bug with `no-manual-cleanup` where we only ever check the first import of any `testing-library` package. While duplicative imports of the _same_ package is very likely uncommon, there are many packages within the `testing-library` ecosystem that will trip up the package detection and break this rule when we only look at the first.