### PR TITLE
fix(await-async-events): setup() incorrectly reported from a wrapper

### DIFF
--- a/lib/rules/await-async-events.ts
+++ b/lib/rules/await-async-events.ts
@@ -91,9 +91,17 @@ export default createTestingLibraryRule<Options, MessageIds>({
 			messageId?: MessageIds;
 			fix?: TSESLint.ReportFixFunction;
 		}): void {
-			if (node.name === USER_EVENT_SETUP_FUNCTION_NAME) {
-				return;
+			if (isMemberExpression(closestCallExpression.callee)) {
+				if (
+					(closestCallExpression.callee.object as TSESTree.Identifier).name ===
+						USER_EVENT_NAME &&
+					(closestCallExpression.callee.property as TSESTree.Identifier)
+						.name === USER_EVENT_SETUP_FUNCTION_NAME
+				) {
+					return;
+				}
 			}
+
 			if (!isPromiseHandled(node)) {
 				context.report({
 					node: closestCallExpression.callee,

--- a/tests/lib/rules/await-async-events.test.ts
+++ b/tests/lib/rules/await-async-events.test.ts
@@ -204,6 +204,19 @@ ruleTester.run(RULE_NAME, rule, {
 				`,
 				options: [{ eventModule: 'userEvent' }] as const,
 			},
+			{
+				code: `
+				import userEvent from '${testingFramework}'
+				function customSetup() {
+					const user = userEvent.setup()
+					return {user}
+				}
+				test('setup method called and returned is valid', () => {
+					const {user} = customSetup();
+				})
+				`,
+				options: [{ eventModule: 'userEvent' }] as const,
+			},
 			...USER_EVENT_ASYNC_FUNCTIONS.map((eventMethod) => ({
 				code: `
         import userEvent from '${testingFramework}'


### PR DESCRIPTION

## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- `userEvent.setup()` is [sync](https://testing-library.com/docs/user-event/setup/#starting-a-session-per-setup). So we shouldn't report any async linting error on it

## Context

- Fix https://github.com/testing-library/eslint-plugin-testing-library/issues/818
- I'm not super familiar with the codebase, please let me know if anything goes wrong

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->
