### PR TITLE
docs: update eslint pattern matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ module.exports = {
 	overrides: [
 		{
 			// 3) Now we enable eslint-plugin-testing-library rules or preset only for matching testing files!
-			files: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
+			files: ['**/__tests__/**/*.[jt]sx?', '**/?(*.)+(spec|test).[jt]sx?'],
 			extends: ['plugin:testing-library/react'],
 		},
 	],


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

I believe there is a mistake in the README, where the `s` should not be optional, but the `x` should

    *.[jt]s?(x):
        [jt]: Matches a single character, either 'j' or 't'.
        s?: The 's' is optional.
        (x): This matches an `x`, however, parenthesis are not a standard syntax for file globbing.

    *.[jt]sx?:
        [jt]: Matches a single character, either 'j' or 't'.
        s: This 's' is required.
        x?: The 'x' is optional.
        

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

File matching in eslint configuration example in the README file.
