### PR TITLE
chore: upgrade TypeScript to v5.0

### DIFF
--- a/lib/rules/no-await-sync-events.ts
+++ b/lib/rules/no-await-sync-events.ts
@@ -76,6 +76,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 						property.id.name === 'delay' &&
 						isLiteral(property.init) &&
 						property.init.value &&
+						// @ts-expect-error -- TODO: fix me
 						property.init.value > 0
 				);
 			},
@@ -88,6 +89,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 					isLiteral(node.right) &&
 					node.right.value !== null
 				) {
+					// @ts-expect-error -- TODO: fix me
 					hasDelayDeclarationOrAssignmentGTZero = node.right.value > 0;
 				}
 			},
@@ -141,6 +143,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 							property.key.name === 'delay' &&
 							isLiteral(property.value) &&
 							!!property.value.value &&
+							// @ts-expect-error -- TODO: fix me
 							property.value.value > 0
 					);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
 				"prettier": "2.8.7",
 				"semantic-release": "^19.0.5",
 				"ts-node": "^10.9.1",
-				"typescript": "^5.3.2"
+				"typescript": "^5.0.4"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0",
@@ -15077,15 +15077,15 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
-			"integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+			"integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=14.17"
+				"node": ">=12.20"
 			}
 		},
 		"node_modules/uglify-js": {
@@ -25218,9 +25218,9 @@
 			}
 		},
 		"typescript": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
-			"integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ=="
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+			"integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw=="
 		},
 		"uglify-js": {
 			"version": "3.17.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
 				"prettier": "2.8.7",
 				"semantic-release": "^19.0.5",
 				"ts-node": "^10.9.1",
-				"typescript": "^4.9.5"
+				"typescript": "^5.3.2"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0",
@@ -15077,14 +15077,15 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.9.5",
-			"license": "Apache-2.0",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+			"integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/uglify-js": {
@@ -25217,7 +25218,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.9.5"
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+			"integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ=="
 		},
 		"uglify-js": {
 			"version": "3.17.4",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
 		"prettier": "2.8.7",
 		"semantic-release": "^19.0.5",
 		"ts-node": "^10.9.1",
-		"typescript": "^5.3.2"
+		"typescript": "^5.0.4"
 	},
 	"peerDependencies": {
 		"eslint": "^7.5.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
 		"prettier": "2.8.7",
 		"semantic-release": "^19.0.5",
 		"ts-node": "^10.9.1",
-		"typescript": "^4.9.5"
+		"typescript": "^5.3.2"
 	},
 	"peerDependencies": {
 		"eslint": "^7.5.0 || ^8.0.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,19 @@
 {
 	"compilerOptions": {
 		"strict": true,
-		"target": "es6",
-		"module": "commonjs",
-		"moduleResolution": "node",
+		"target": "ES2019",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"lib": ["ES2019"],
 		"esModuleInterop": true,
-		"resolveJsonModule": true,
-		"forceConsistentCasingInFileNames": true,
-		"noImplicitAny": true,
-		"outDir": "./dist",
-		"removeComments": true,
 		"skipLibCheck": true,
+		"resolveJsonModule": true,
+		"moduleDetection": "force",
+		"isolatedModules": true,
+		"removeComments": true,
+		// TODO: turn it on
+		"noUncheckedIndexedAccess": false,
+		"outDir": "dist",
 		"sourceMap": false
 	},
 	"include": ["./lib/**/*.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,7 @@
 		"outDir": "./dist",
 		"removeComments": true,
 		"skipLibCheck": true,
-		"sourceMap": false,
-		"suppressImplicitAnyIndexErrors": true
+		"sourceMap": false
 	},
 	"include": ["./lib/**/*.ts"]
 }


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

- Upgrades TypeScript from v4.9 to v5.0 (we can't use v5.1 and above in Node.js v12)
- Updates `tsconfig.json` based on https://www.totaltypescript.com/tsconfig-cheat-sheet and the requirements of the project

## Context

Based on https://github.com/testing-library/eslint-plugin-testing-library/pull/856. See 4c2871616bd70fc2a032556429686476ae1169e7...0f6fe962b2897d0cb000666db3fa20619db9204b for changes.

- https://node.green/#ES2019
