### PR TITLE
docs: add missing import

### DIFF
--- a/docs/rules/prefer-screen-queries.md
+++ b/docs/rules/prefer-screen-queries.md
@@ -38,7 +38,7 @@ getByText('foo');
 Examples of **correct** code for this rule:
 
 ```js
-import { screen } from '@testing-library/any-framework';
+import { render, screen } from '@testing-library/any-framework';
 
 // calling a query from the `screen` object
 render(<Component />);


### PR DESCRIPTION
## Checks

- [ X] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

I was going through this example to understand a failure I was getting. I noticed that the import methods from the testing-library was missing the `render` method. Not sure if that's intentional since the examples are for any testing library. Thanks!