### PR TITLE
chore(all-contributors): disable skipping ci

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -680,6 +680,6 @@
     }
   ],
   "contributorsPerLine": 7,
-  "skipCi": true,
+  "skipCi": false,
   "commitType": "docs"
 }


### PR DESCRIPTION
## Checks

- [X] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- Avoid skipping CI in all-contributors PRs.

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

Since we have required status checks before merging PRs, all-contributors can't skip CI. Otherwise, the status checks will hang forever waiting to be run, blocking the PR from being merged.