### PR TITLE
fix(await-async-events): false positive reports on awaited expressions evaluating to promise

### DIFF
--- a/lib/node-utils/index.ts
+++ b/lib/node-utils/index.ts
@@ -256,18 +256,22 @@ function getRootExpression(
 	switch (parent.type) {
 		case AST_NODE_TYPES.ConditionalExpression:
 			return getRootExpression(parent);
-		case AST_NODE_TYPES.LogicalExpression:
+		case AST_NODE_TYPES.LogicalExpression: {
+			let rootExpression;
 			switch (parent.operator) {
 				case '??':
 				case '||':
-					return getRootExpression(parent);
+					rootExpression = getRootExpression(parent);
+					break;
 				case '&&':
-					return parent.right === expression
-						? getRootExpression(parent)
-						: expression;
-				default:
-					return expression;
+					rootExpression =
+						parent.right === expression
+							? getRootExpression(parent)
+							: expression;
+					break;
 			}
+			return rootExpression ?? expression;
+		}
 		case AST_NODE_TYPES.SequenceExpression:
 			return parent.expressions[parent.expressions.length - 1] === expression
 				? getRootExpression(parent)

--- a/lib/node-utils/index.ts
+++ b/lib/node-utils/index.ts
@@ -255,8 +255,19 @@ function getRootExpression(
 	if (parent == null) return expression;
 	switch (parent.type) {
 		case AST_NODE_TYPES.ConditionalExpression:
-		case AST_NODE_TYPES.LogicalExpression:
 			return getRootExpression(parent);
+		case AST_NODE_TYPES.LogicalExpression:
+			switch (parent.operator) {
+				case '??':
+				case '||':
+					return getRootExpression(parent);
+				case '&&':
+					return parent.right === expression
+						? getRootExpression(parent)
+						: expression;
+				default:
+					return expression;
+			}
 		case AST_NODE_TYPES.SequenceExpression:
 			return parent.expressions[parent.expressions.length - 1] === expression
 				? getRootExpression(parent)

--- a/lib/node-utils/index.ts
+++ b/lib/node-utils/index.ts
@@ -258,6 +258,46 @@ export function isPromiseHandled(nodeIdentifier: TSESTree.Identifier): boolean {
 	return false;
 }
 
+/**
+ * For an expression in a parent expression that evaluates to the expression or another child returns the parent node recursively.
+ */
+function getRootExpression(
+	expression: TSESTree.Expression
+): TSESTree.Expression {
+	const { parent } = expression;
+	if (parent == null) return expression;
+	switch (parent.type) {
+		case AST_NODE_TYPES.ConditionalExpression:
+		case AST_NODE_TYPES.LogicalExpression:
+			return getRootExpression(parent);
+		case AST_NODE_TYPES.SequenceExpression:
+			return parent.expressions[parent.expressions.length - 1] === expression
+				? getRootExpression(parent)
+				: expression;
+		default:
+			return expression;
+	}
+}
+
+/**
+ * Determines whether a given promise expression is considered unhandled.
+ *
+ * It will be considered unhandled if an ancestor voids the expression.
+ */
+export function isPromiseUnhandled(expression: TSESTree.Expression): boolean {
+	const { parent } = getRootExpression(expression);
+	if (parent == null) return false;
+	switch (parent.type) {
+		case AST_NODE_TYPES.ExpressionStatement:
+		case AST_NODE_TYPES.SequenceExpression:
+		case AST_NODE_TYPES.UnaryExpression:
+		case AST_NODE_TYPES.VariableDeclarator:
+			return true;
+		default:
+			return false;
+	}
+}
+
 export function getVariableReferences(
 	context: TSESLint.RuleContext<string, unknown[]>,
 	node: TSESTree.Node

--- a/lib/rules/await-async-events.ts
+++ b/lib/rules/await-async-events.ts
@@ -8,7 +8,7 @@ import {
 	getInnermostReturningFunction,
 	getVariableReferences,
 	isMemberExpression,
-	isPromiseUnhandled,
+	isPromiseHandled,
 } from '../node-utils';
 import { EVENTS_SIMULATORS } from '../utils';
 
@@ -91,7 +91,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 			messageId?: MessageIds;
 			fix?: TSESLint.ReportFixFunction;
 		}): void {
-			if (isPromiseUnhandled(closestCallExpression)) {
+			if (!isPromiseHandled(node)) {
 				context.report({
 					node: closestCallExpression.callee,
 					messageId,
@@ -176,17 +176,13 @@ export default createTestingLibraryRule<Options, MessageIds>({
 							},
 						});
 					} else {
-						const referenceIdentifiers = references
-							.map(({ identifier }) => identifier)
-							.filter(ASTUtils.isIdentifier);
-						if (referenceIdentifiers.every(isPromiseUnhandled)) {
-							referenceIdentifiers.forEach(
-								(id) =>
-									void reportUnhandledNode({
-										node: id,
-										closestCallExpression,
-									})
-							);
+						for (const reference of references) {
+							if (ASTUtils.isIdentifier(reference.identifier)) {
+								reportUnhandledNode({
+									node: reference.identifier,
+									closestCallExpression,
+								});
+							}
 						}
 					}
 				} else if (functionWrappersNames.includes(node.name)) {

--- a/tests/lib/rules/await-async-events.test.ts
+++ b/tests/lib/rules/await-async-events.test.ts
@@ -315,6 +315,17 @@ ruleTester.run(RULE_NAME, rule, {
 				options: [{ eventModule: 'userEvent' }] as const,
 			})),
 			...USER_EVENT_ASYNC_FUNCTIONS.map((eventMethod) => ({
+				code: `
+        import userEvent from '${testingFramework}'
+        test('await expression that evaluates to promise is valid', async () => {
+          await (null, userEvent.${eventMethod}(getByLabelText('username')));
+		  await (condition ? null : userEvent.${eventMethod}(getByLabelText('username')));
+		  await (condition && userEvent.${eventMethod}(getByLabelText('username')));
+        })
+        `,
+				options: [{ eventModule: 'userEvent' }] as const,
+			})),
+			...USER_EVENT_ASYNC_FUNCTIONS.map((eventMethod) => ({
 				settings: {
 					'testing-library/utils-module': 'test-utils',
 				},
@@ -960,6 +971,66 @@ ruleTester.run(RULE_NAME, rule, {
       }
 
       triggerEvent()
+      `,
+					} as const)
+			),
+			...USER_EVENT_ASYNC_FUNCTIONS.map(
+				(eventMethod) =>
+					({
+						code: `
+		import userEvent from '${testingFramework}'
+		test('unhandled expression that evaluates to promise is invalid', () => {
+			condition ? null : (null, true && userEvent.${eventMethod}(getByLabelText('username')));
+		});
+      `,
+						errors: [
+							{
+								line: 4,
+								column: 38,
+								messageId: 'awaitAsyncEvent',
+								data: { name: eventMethod },
+							},
+						],
+						options: [{ eventModule: 'userEvent' }],
+						output: `
+		import userEvent from '${testingFramework}'
+		test('unhandled expression that evaluates to promise is invalid', async () => {
+			condition ? null : (null, true && await userEvent.${eventMethod}(getByLabelText('username')));
+		});
+      `,
+					} as const)
+			),
+			...USER_EVENT_ASYNC_FUNCTIONS.map(
+				(eventMethod) =>
+					({
+						code: `
+		import userEvent from '${testingFramework}'
+		test('voided promise is invalid', async () => {
+			await void userEvent.${eventMethod}(getByLabelText('username'));
+			await (userEvent.${eventMethod}(getByLabelText('username')), null);
+		});
+      `,
+						errors: [
+							{
+								line: 4,
+								column: 15,
+								messageId: 'awaitAsyncEvent',
+								data: { name: eventMethod },
+							},
+							{
+								line: 5,
+								column: 11,
+								messageId: 'awaitAsyncEvent',
+								data: { name: eventMethod },
+							},
+						],
+						options: [{ eventModule: 'userEvent' }],
+						output: `
+		import userEvent from '${testingFramework}'
+		test('voided promise is invalid', async () => {
+			await void await userEvent.${eventMethod}(getByLabelText('username'));
+			await (await userEvent.${eventMethod}(getByLabelText('username')), null);
+		});
       `,
 					} as const)
 			),

--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -439,6 +439,33 @@ ruleTester.run(RULE_NAME, rule, {
 			(asyncUtil) =>
 				({
 					code: `
+        import { ${asyncUtil} } from '${testingFramework}';
+        test('unhandled expression that evaluates to promise is invalid', () => {
+          const aPromise = ${asyncUtil}(() => getByLabelText('username'));
+          doSomethingElse(aPromise);
+          ${asyncUtil}(() => getByLabelText('email'));
+        });
+      `,
+					errors: [
+						{
+							line: 4,
+							column: 28,
+							messageId: 'awaitAsyncUtil',
+							data: { name: asyncUtil },
+						},
+						{
+							line: 6,
+							column: 11,
+							messageId: 'awaitAsyncUtil',
+							data: { name: asyncUtil },
+						},
+					],
+				} as const)
+		),
+		...ASYNC_UTILS.map(
+			(asyncUtil) =>
+				({
+					code: `
         import { ${asyncUtil}, render } from '${testingFramework}';
         
         function waitForSomethingAsync() {


### PR DESCRIPTION
## Checks

- [X] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

In `await-async-events`, `await-async-queries` and `await-async-utils` when determining whether a promise is handled the checks are performed on a parent expression that evaluates to the call expression returning a promise instead of always the call expression. In the following cases the parent expression is used instead.

```ts
// sequence expression
(sideEffect(), promise());
// conditional expression
condition ? promise() : otherPromise();
// logical expression
maybePromise() ?? promise();
maybePromise() || promise();
condition && promise();
```

This change does not eliminate false positives from the three `await-async-` rules. The rules are fundamentally written in a brittle way where they look for specific reasons not to report and default to reporting. This means the rules are not robust against changes to the language so even if we defined perfect behaviour for all cases in current JavaScript a new language feature could introduce false positives again.

For the rules to be robust and guaranteed not to report false positives they would have to default to not report unless they find a specific reason to report. In 4d878d1 I took this approach but I noticed the other two rules seem to have a requirement of reporting in some unsafe cases (e.g. `expect(query).toBeInTheDocument()`) so I reverted the changes and opted to carve out exceptions for specific cases instead. Whether the rules ought to be safe with regard to false positives or if they're intentionally opinionated is another conversation. I left the safer approach in the commit history in case we want to revisit that idea. Let me know if you prefer a neatly squashed commit history instead.

## Context


@sjarva invited me to contribute and I picked an issue off the top.

Fixes #887

Although the bug report was about conditional expressions the same bug could be reproduced with other expressions as well. This PR covers all the cases I could think of.