### PR TITLE
fix(await-async-events): false positives for userEvent.setup() returned

### DIFF
--- a/lib/rules/await-async-events.ts
+++ b/lib/rules/await-async-events.ts
@@ -122,6 +122,10 @@ export default createTestingLibraryRule<Options, MessageIds>({
 					(isFireEventEnabled && helpers.isFireEventMethod(node)) ||
 					(isUserEventEnabled && helpers.isUserEventMethod(node))
 				) {
+					if (node.name === USER_EVENT_SETUP_FUNCTION_NAME) {
+						return;
+					}
+
 					detectEventMethodWrapper(node);
 
 					const closestCallExpression = findClosestCallExpressionNode(
@@ -130,10 +134,6 @@ export default createTestingLibraryRule<Options, MessageIds>({
 					);
 
 					if (!closestCallExpression?.parent) {
-						return;
-					}
-
-					if (node.name === USER_EVENT_SETUP_FUNCTION_NAME) {
 						return;
 					}
 

--- a/tests/lib/rules/await-async-events.test.ts
+++ b/tests/lib/rules/await-async-events.test.ts
@@ -207,6 +207,16 @@ ruleTester.run(RULE_NAME, rule, {
 			{
 				code: `
 				import userEvent from '${testingFramework}'
+				const customSetup = () => userEvent.setup();
+				test('setup method called and returned as arrow function body is valid', () => {
+					const user = customSetup();
+				})
+				`,
+				options: [{ eventModule: 'userEvent' }] as const,
+			},
+			{
+				code: `
+				import userEvent from '${testingFramework}'
 				function customSetup() {
 					const user = userEvent.setup();
 					return { user };


### PR DESCRIPTION
## Checks

- [X] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

The circuit-breaker checking for `userEvent.setup()` was executed after `detectEventMethodWrapper` so the circuit-breaking only applied to cases where the expression is not returned. It's intended to be applied generally so this PR moves it to the top of its code block.

## Context

My last contribution was received well so I picked another open issue.

Fixes #881

This is another false-positive where the root problem is defaulting to report unless a reason not to report is found. If new methods are introduced to `userEvent` the rule will assume they return promises. I'd like to change the behaviour to check for an allow-list of method names instead of checking it's not specifically `setup` so future bugs would be false negatives instead of false positives. I didn't do that in this PR because maybe it's the way it is by design.
