### PR TITLE
fix: add plugin name and version metadata for ESLint v9

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,10 +1,12 @@
-import {
-	name as packageName,
-	version as packageVersion,
-} from '../package.json';
-
 import configs from './configs';
 import rules from './rules';
+
+// we can't natively import package.json as tsc will copy it into dist/
+const {
+	name: packageName,
+	version: packageVersion,
+	// eslint-disable-next-line @typescript-eslint/no-var-requires
+} = require('../package.json') as { name: string; version: string };
 
 export = {
 	meta: {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,16 @@
+import {
+	name as packageName,
+	version as packageVersion,
+} from '../package.json';
+
 import configs from './configs';
 import rules from './rules';
 
 export = {
+	meta: {
+		name: packageName,
+		version: packageVersion,
+	},
 	configs,
 	rules,
 };

--- a/tools/generate-configs/index.ts
+++ b/tools/generate-configs/index.ts
@@ -1,4 +1,5 @@
-import { type LinterConfigRules } from '../../lib/configs';
+import { type TSESLint } from '@typescript-eslint/utils';
+
 import rules from '../../lib/rules';
 import {
 	SUPPORTED_TESTING_FRAMEWORKS,
@@ -11,7 +12,7 @@ const RULE_NAME_PREFIX = 'testing-library/';
 
 const getRecommendedRulesForTestingFramework = (
 	framework: SupportedTestingFramework
-): LinterConfigRules =>
+): Record<string, TSESLint.Linter.RuleEntry> =>
 	Object.entries(rules)
 		.filter(
 			([


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- Add plugin name and version metadata

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

Relates to #902 - this metadata is technically not required but preferred for ESLint v9 to be able to work.. better? (iirc its used for cache busting).

I've not added any tests for now as I think it's a small enough change that we can verify it's fine with our eyes :)