### PR TITLE
chore: enable `eslint-plugin-prettier`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
 		'plugin:import/recommended',
 		'plugin:jest/recommended',
 		'plugin:jest-formatting/recommended',
-		'prettier',
+		'plugin:prettier/recommended',
 	],
 	rules: {
 		// Base


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- enables `eslint-plugin-prettier` via it's recommended ruleset

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

Extending `prettier` enables `eslint-config-prettier` which only disables ESLint rules that conflict with `prettier` - it's the `eslint-plugin-prettier` config that enables _both_ the `prettier/prettier` rule _and_ `eslint-config-prettier`.