### PR TITLE
feat: add support for flat config

### DIFF
--- a/.eslint-doc-generatorrc.js
+++ b/.eslint-doc-generatorrc.js
@@ -3,6 +3,13 @@ const prettierConfig = require('./.prettierrc.js');
 
 /** @type {import('eslint-doc-generator').GenerateOptions} */
 const config = {
+	ignoreConfig: [
+		'flat/angular',
+		'flat/dom',
+		'flat/marko',
+		'flat/react',
+		'flat/vue',
+	],
 	postprocess: (content) =>
 		prettier.format(content, { ...prettierConfig, parser: 'markdown' }),
 };

--- a/README.md
+++ b/README.md
@@ -108,6 +108,16 @@ Another approach for customizing ESLint config by paths is through [ESLint Casca
 
 ## Shareable configurations
 
+> [!NOTE]
+>
+> `eslint.config.js` compatible versions of configs are available prefixed with
+> `flat/`, though most of the plugin documentation still currently uses
+> `.eslintrc` syntax.
+>
+> Refer to the
+> [ESLint documentation on the new configuration file format](https://eslint.org/docs/latest/use/configure/configuration-files-new)
+> for more.
+
 This plugin exports several recommended configurations that enforce good practices for specific Testing Library packages.
 You can find more info about enabled rules in the [Supported Rules section](#supported-rules), under the `Configurations` column.
 
@@ -140,6 +150,22 @@ module.exports = {
 };
 ```
 
+To enable this configuration with `eslint.config.js`, use
+`testingLibrary.configs['flat/dom']`:
+
+```js
+const testingLibrary = require('eslint-plugin-testing-library');
+
+module.exports = [
+	{
+		files: [
+			/* glob matching your test files */
+		],
+		...testingLibrary.configs['flat/dom'],
+	},
+];
+```
+
 ### Angular
 
 Enforces recommended rules for Angular Testing Library.
@@ -151,6 +177,22 @@ To enable this configuration use the `extends` property in your
 module.exports = {
 	extends: ['plugin:testing-library/angular'],
 };
+```
+
+To enable this configuration with `eslint.config.js`, use
+`testingLibrary.configs['flat/angular']`:
+
+```js
+const testingLibrary = require('eslint-plugin-testing-library');
+
+module.exports = [
+	{
+		files: [
+			/* glob matching your test files */
+		],
+		...testingLibrary.configs['flat/angular'],
+	},
+];
 ```
 
 ### React
@@ -166,6 +208,22 @@ module.exports = {
 };
 ```
 
+To enable this configuration with `eslint.config.js`, use
+`testingLibrary.configs['flat/react']`:
+
+```js
+const testingLibrary = require('eslint-plugin-testing-library');
+
+module.exports = [
+	{
+		files: [
+			/* glob matching your test files */
+		],
+		...testingLibrary.configs['flat/react'],
+	},
+];
+```
+
 ### Vue
 
 Enforces recommended rules for Vue Testing Library.
@@ -179,6 +237,22 @@ module.exports = {
 };
 ```
 
+To enable this configuration with `eslint.config.js`, use
+`testingLibrary.configs['flat/vue']`:
+
+```js
+const testingLibrary = require('eslint-plugin-testing-library');
+
+module.exports = [
+	{
+		files: [
+			/* glob matching your test files */
+		],
+		...testingLibrary.configs['flat/vue'],
+	},
+];
+```
+
 ### Marko
 
 Enforces recommended rules for Marko Testing Library.
@@ -190,6 +264,22 @@ To enable this configuration use the `extends` property in your
 module.exports = {
 	extends: ['plugin:testing-library/marko'],
 };
+```
+
+To enable this configuration with `eslint.config.js`, use
+`testingLibrary.configs['flat/marko']`:
+
+```js
+const testingLibrary = require('eslint-plugin-testing-library');
+
+module.exports = [
+	{
+		files: [
+			/* glob matching your test files */
+		],
+		...testingLibrary.configs['flat/marko'],
+	},
+];
 ```
 
 ## Supported Rules

--- a/lib/configs/index.ts
+++ b/lib/configs/index.ts
@@ -8,7 +8,7 @@ import {
 	SupportedTestingFramework,
 } from '../utils';
 
-export type LinterConfigRules = Record<string, TSESLint.Linter.RuleEntry>;
+export type LinterConfigRules = Pick<Required<TSESLint.Linter.Config>, 'rules'>;
 
 const configsDir = __dirname;
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,10 +1,12 @@
-import {
-	name as packageName,
-	version as packageVersion,
-} from '../package.json';
-
 import configs from './configs';
 import rules from './rules';
+
+// we can't natively import package.json as tsc will copy it into dist/
+const {
+	name: packageName,
+	version: packageVersion,
+	// eslint-disable-next-line @typescript-eslint/no-var-requires
+} = require('../package.json') as { name: string; version: string };
 
 export = {
 	meta: {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,16 @@
+import {
+	name as packageName,
+	version as packageVersion,
+} from '../package.json';
+
 import configs from './configs';
 import rules from './rules';
 
 export = {
+	meta: {
+		name: packageName,
+		version: packageVersion,
+	},
 	configs,
 	rules,
 };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,8 @@
+import type { TSESLint } from '@typescript-eslint/utils';
+
 import configs from './configs';
 import rules from './rules';
+import { SupportedTestingFramework } from './utils';
 
 // we can't natively import package.json as tsc will copy it into dist/
 const {
@@ -8,11 +11,34 @@ const {
 	// eslint-disable-next-line @typescript-eslint/no-var-requires
 } = require('../package.json') as { name: string; version: string };
 
-export = {
+const plugin = {
 	meta: {
 		name: packageName,
 		version: packageVersion,
 	},
-	configs,
+	// ugly cast for now to keep TypeScript happy since
+	// we don't have types for flat config yet
+	configs: {} as Record<
+		SupportedTestingFramework | `flat/${SupportedTestingFramework}`,
+		Pick<Required<TSESLint.Linter.Config>, 'rules'>
+	>,
 	rules,
 };
+
+plugin.configs = {
+	...configs,
+	...(Object.fromEntries(
+		Object.entries(configs).map(([framework, config]) => [
+			`flat/${framework}`,
+			{
+				plugins: { 'testing-library': plugin },
+				rules: config.rules,
+			},
+		])
+	) as Record<
+		`flat/${SupportedTestingFramework}`,
+		Pick<Required<TSESLint.Linter.Config>, 'rules'> & { plugins: unknown }
+	>),
+};
+
+export = plugin;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -52,6 +52,11 @@ it('should export configs that refer to actual rules', () => {
 		'react',
 		'vue',
 		'marko',
+		'flat/dom',
+		'flat/angular',
+		'flat/react',
+		'flat/vue',
+		'flat/marko',
 	]);
 	const allConfigRules = Object.values(allConfigs)
 		.map((config) => Object.keys(config.rules))

--- a/tools/generate-configs/index.ts
+++ b/tools/generate-configs/index.ts
@@ -1,4 +1,5 @@
-import { type LinterConfigRules } from '../../lib/configs';
+import { type TSESLint } from '@typescript-eslint/utils';
+
 import rules from '../../lib/rules';
 import {
 	SUPPORTED_TESTING_FRAMEWORKS,
@@ -11,7 +12,7 @@ const RULE_NAME_PREFIX = 'testing-library/';
 
 const getRecommendedRulesForTestingFramework = (
 	framework: SupportedTestingFramework
-): LinterConfigRules =>
+): Record<string, TSESLint.Linter.RuleEntry> =>
 	Object.entries(rules)
 		.filter(
 			([


### PR DESCRIPTION
## Checks

- [ ] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- Adds plugin name and version metadata (aka #921)
- Adds flat versions of configs, for ESLint v9

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

Resolves #902
Resolves #853

This uses a very similar approach to what I'm using for `eslint-plugin-jest` - the types should actually be pretty much correct, but I've just gone straight to casting since things are a bit of a mess right now ecosystem wise, which'll improve once we have everyone on ESLint v9.

Similarly I've not worried about adding any particular tests since the output is pretty stable and easily validated manually (which I have already), and I've based the documentation off what we use in `eslint-plugin-jest` too