### PR TITLE
fix(no-manual-cleanup): properly check all `@testing-library` imports

### DIFF
--- a/lib/rules/no-manual-cleanup.ts
+++ b/lib/rules/no-manual-cleanup.ts
@@ -1,15 +1,16 @@
-import { ASTUtils, TSESTree, TSESLint } from '@typescript-eslint/utils';
+import { ASTUtils, TSESLint, TSESTree } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {
+	getImportModuleName,
 	getVariableReferences,
+	ImportModuleNode,
+	isImportDeclaration,
 	isImportDefaultSpecifier,
 	isImportSpecifier,
 	isMemberExpression,
 	isObjectPattern,
 	isProperty,
-	ImportModuleNode,
-	isImportDeclaration,
 } from '../node-utils';
 
 export const RULE_NAME = 'no-manual-cleanup';
@@ -110,12 +111,15 @@ export default createTestingLibraryRule<Options, MessageIds>({
 
 		return {
 			'Program:exit'() {
-				const testingLibraryImportName = helpers.getTestingLibraryImportName();
 				const customModuleImportNode = helpers.getCustomModuleImportNode();
 
-				if (testingLibraryImportName?.match(CLEANUP_LIBRARY_REGEXP)) {
-					for (const importNode of helpers.getAllTestingLibraryImportNodes()) {
-						reportCandidateModule(importNode);
+				for (const testingLibraryImportNode of helpers.getAllTestingLibraryImportNodes()) {
+					const testingLibraryImportName = getImportModuleName(
+						testingLibraryImportNode
+					);
+
+					if (testingLibraryImportName?.match(CLEANUP_LIBRARY_REGEXP)) {
+						reportCandidateModule(testingLibraryImportNode);
 					}
 				}
 

--- a/tests/lib/rules/no-manual-cleanup.test.ts
+++ b/tests/lib/rules/no-manual-cleanup.test.ts
@@ -72,6 +72,38 @@ ruleTester.run(RULE_NAME, rule, {
 		...ALL_TESTING_LIBRARIES_WITH_CLEANUP.map(
 			(lib) =>
 				({
+					code: `
+						import { render, cleanup } from "${lib}"
+						import userEvent from "@testing-library/user-event"
+					`,
+					errors: [
+						{
+							line: 2,
+							column: 24, // error points to `cleanup`
+							messageId: 'noManualCleanup',
+						},
+					],
+				} as const)
+		),
+		...ALL_TESTING_LIBRARIES_WITH_CLEANUP.map(
+			(lib) =>
+				({
+					code: `
+						import userEvent from "@testing-library/user-event"
+						import { render, cleanup } from "${lib}"
+					`,
+					errors: [
+						{
+							line: 3,
+							column: 24, // error points to `cleanup`
+							messageId: 'noManualCleanup',
+						},
+					],
+				} as const)
+		),
+		...ALL_TESTING_LIBRARIES_WITH_CLEANUP.map(
+			(lib) =>
+				({
 					// official testing-library packages should be reported with custom module setting
 					settings: {
 						'testing-library/utils-module': 'test-utils',
@@ -252,5 +284,24 @@ ruleTester.run(RULE_NAME, rule, {
 					],
 				} as const)
 		),
+		{
+			code: `
+				import { cleanup as cleanupVue } from "@testing-library/vue";
+				import { cleanup as cleanupReact } from "@testing-library/react";
+				afterEach(() => { cleanupVue(); cleanupReact(); });
+			`,
+			errors: [
+				{
+					line: 2,
+					column: 14,
+					messageId: 'noManualCleanup',
+				},
+				{
+					line: 3,
+					column: 14,
+					messageId: 'noManualCleanup',
+				},
+			],
+		},
 	],
 });


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- Changes `no-manual-cleanup` so it checks every import rather than just the first one

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

Currently the rule assumes the first `@testing-library` import will be one with a `cleanup`, which isn't true