### PR TITLE
fix(prefer-query-by-disappearance): allow get and find query variants when passed in directly

### DIFF
--- a/lib/rules/prefer-query-by-disappearance.ts
+++ b/lib/rules/prefer-query-by-disappearance.ts
@@ -78,21 +78,6 @@ export default createTestingLibraryRule<Options, MessageIds>({
 			return false;
 		}
 
-		function checkNonCallbackViolation(node: TSESTree.CallExpressionArgument) {
-			if (!isCallExpression(node)) {
-				return false;
-			}
-
-			if (
-				!isMemberExpression(node.callee) &&
-				!getPropertyIdentifierNode(node.callee)
-			) {
-				return false;
-			}
-
-			return reportExpression(node.callee);
-		}
-
 		function isReturnViolation(node: TSESTree.Statement) {
 			if (!isReturnStatement(node) || !isCallExpression(node.argument)) {
 				return false;
@@ -177,7 +162,6 @@ export default createTestingLibraryRule<Options, MessageIds>({
 
 			const argumentNode = node.arguments[0];
 
-			checkNonCallbackViolation(argumentNode);
 			checkArrowFunctionViolation(argumentNode);
 			checkFunctionExpressionViolation(argumentNode);
 		}

--- a/tests/lib/rules/prefer-query-by-disappearance.test.ts
+++ b/tests/lib/rules/prefer-query-by-disappearance.test.ts
@@ -25,6 +25,20 @@ ruleTester.run(RULE_NAME, rule, {
 		},
 		{
 			code: `
+        import { screen, waitForElementToBeRemoved } from '${testingFramework}';
+
+        await waitForElementToBeRemoved(screen.getByText("hello"))
+      `,
+		},
+		{
+			code: `
+        import { screen, waitForElementToBeRemoved } from '${testingFramework}';
+
+        await waitForElementToBeRemoved(screen.findByText("hello"))
+      `,
+		},
+		{
+			code: `
         import { screen } from '${testingFramework}';
 
         const callback = () => screen.getByRole('button')
@@ -213,6 +227,36 @@ ruleTester.run(RULE_NAME, rule, {
         })
       `,
 		},
+		{
+			code: `
+        import { screen } from '${testingFramework}';
+
+        const { getByText } = screen
+        await waitForElementToBeRemoved(getByText('hey'))
+      `,
+		},
+		{
+			code: `
+        import { render } from '${testingFramework}';
+
+        const { getByText } = render(<App />)
+        await waitForElementToBeRemoved(getByText('hey'))
+      `,
+		},
+		{
+			code: `
+        import { screen } from '${testingFramework}';
+        const { findByText } = screen
+        await waitForElementToBeRemoved(findByText('hey'))
+      `,
+		},
+		{
+			code: `
+        import { render } from '${testingFramework}';
+        const { findByText } = render(<App />)
+        await waitForElementToBeRemoved(findByText('hey'))
+      `,
+		},
 	]),
 	invalid: SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
 		{
@@ -318,34 +362,6 @@ ruleTester.run(RULE_NAME, rule, {
 					messageId: 'preferQueryByDisappearance',
 					line: 5,
 					column: 25,
-				},
-			],
-		},
-		{
-			code: `
-        import { screen, waitForElementToBeRemoved } from '${testingFramework}';
-
-        await waitForElementToBeRemoved(screen.getByText("hello"))
-      `,
-			errors: [
-				{
-					messageId: 'preferQueryByDisappearance',
-					line: 4,
-					column: 48,
-				},
-			],
-		},
-		{
-			code: `
-        import { screen, waitForElementToBeRemoved } from '${testingFramework}';
-
-        await waitForElementToBeRemoved(screen.findByText("hello"))
-      `,
-			errors: [
-				{
-					messageId: 'preferQueryByDisappearance',
-					line: 4,
-					column: 48,
 				},
 			],
 		},
@@ -712,66 +728,6 @@ ruleTester.run(RULE_NAME, rule, {
 					messageId: 'preferQueryByDisappearance',
 					line: 5,
 					column: 47,
-				},
-			],
-		},
-		{
-			code: `
-        import { screen } from '${testingFramework}';
-
-        const { getByText } = screen
-        await waitForElementToBeRemoved(getByText('hey'))
-      `,
-			errors: [
-				{
-					messageId: 'preferQueryByDisappearance',
-					line: 5,
-					column: 41,
-				},
-			],
-		},
-		{
-			code: `
-        import { render } from '${testingFramework}';
-
-        const { getByText } = render(<App />)
-        await waitForElementToBeRemoved(getByText('hey'))
-      `,
-			errors: [
-				{
-					messageId: 'preferQueryByDisappearance',
-					line: 5,
-					column: 41,
-				},
-			],
-		},
-		{
-			code: `
-        import { screen } from '${testingFramework}';
-
-        const { findByText } = screen
-        await waitForElementToBeRemoved(findByText('hey'))
-      `,
-			errors: [
-				{
-					messageId: 'preferQueryByDisappearance',
-					line: 5,
-					column: 41,
-				},
-			],
-		},
-		{
-			code: `
-        import { render } from '${testingFramework}';
-
-        const { findByText } = render(<App />)
-        await waitForElementToBeRemoved(findByText('hey'))
-      `,
-			errors: [
-				{
-					messageId: 'preferQueryByDisappearance',
-					line: 5,
-					column: 41,
 				},
 			],
 		},


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

Currently, the plugin reports

```ts
await waitForElementToBeRemoved(screen.getByText('abc'))
```

as a violation. 
This PR removes this check and also allows the `findBy` variants.

## Context

When passing in an element directly, `waitForElementToBeRemoved` actually checks whether the element is there initially. If it is not, it will throw an error. This corresponds with the `getBy` variants of the queries.

I figured to also remove the check for the `findBy` variants since this is really a problem to solve by typescript (and the type definitions of the "main" testing library).

If anything, we should report `waitForElementToBeRemoved(screen.queryByText('abc'))` as a violation. However, I also think that this is something that the typescript definitions of the "main" testing library should solve (by constraining what can and cannot be passed into `waitForElementToBeRemoved`). So I did not add this check here.
