### PR TITLE
chore: remove `bahmutov/npm-install` usage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,11 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
+          cache: npm
           node-version-file: '.nvmrc'
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
+        run: npm install
 
       - name: Build package
         run: npm run build

--- a/.github/workflows/verifications.yml
+++ b/.github/workflows/verifications.yml
@@ -19,10 +19,11 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
+          cache: npm
           node-version-file: '.nvmrc'
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
+        run: npm install
 
       - name: Run script
         run: npm run ${{ matrix.validation-script }}
@@ -43,10 +44,11 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
+          cache: npm
           node-version: ${{ matrix.node }}
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
+        run: npm install
 
       - name: Install ESLint v${{ matrix.eslint }}
         run: npm install --no-save --force eslint@${{ matrix.eslint }}


### PR DESCRIPTION
Caching is  now done easily with `actions/setup-node` v4