### PR TITLE
add `ByA11yState` to `ALL_QUERIES_METHODS` const

### DIFF
--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -43,6 +43,7 @@ const ALL_QUERIES_METHODS = [
 	'ByDisplayValue',
 	'ByRole',
 	'ByTestId',
+	'ByA11yState',
 ];
 
 const SYNC_QUERIES_COMBINATIONS = combineQueries(


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

- add accessibility queries to `ALL_QUERIES_METHODS` so we can successfully target those queries while pattern matching

## Context
- `prefer-screen-queries` was failing for destructured a11y queries
- this fixes that