### PR TITLE
feat: add TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,25 @@
+import type { Linter, Rule } from 'eslint';
+
+declare const plugin: {
+	meta: {
+		name: string;
+		version: string;
+	};
+	configs: {
+		angular: Linter.LegacyConfig;
+		dom: Linter.LegacyConfig;
+		marko: Linter.LegacyConfig;
+		react: Linter.LegacyConfig;
+		vue: Linter.LegacyConfig;
+		'flat/angular': Linter.FlatConfig;
+		'flat/dom': Linter.FlatConfig;
+		'flat/marko': Linter.FlatConfig;
+		'flat/react': Linter.FlatConfig;
+		'flat/vue': Linter.FlatConfig;
+	};
+	rules: {
+		[key: string]: Rule.RuleModule;
+	};
+};
+
+export = plugin;

--- a/package.json
+++ b/package.json
@@ -27,9 +27,11 @@
 	"files": [
 		"dist",
 		"README.md",
-		"LICENSE"
+		"LICENSE",
+		"index.d.ts"
 	],
 	"main": "./dist/index.js",
+	"types": "index.d.ts",
 	"scripts": {
 		"prebuild": "del-cli dist",
 		"build": "tsc",


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- adds types so that usage with `eslint.config.js` in TypeScript codebases don't result in errors

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

Now that plugins are imported "naturally" they can be type-checked by TypeScript so it's useful to ship types - for now I've just manually typed the plugin since primarily the only useful thing to have typed is the configs, as things like rules and settings are still not implicitly inferred and trying to automate this would be overkill.

These types match those that we've got in `eslint-plugin-jest`, `eslint-plugin-jest-dom`, and other places