### PR TITLE
fix: use valid config type for supporting both ESLint v8 and v9

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,12 +12,12 @@ declare const plugin: {
 		react: Linter.LegacyConfig;
 		svelte: Linter.LegacyConfig;
 		vue: Linter.LegacyConfig;
-		'flat/angular': Linter.Config<Linter.RulesRecord>;
-		'flat/dom': Linter.Config<Linter.RulesRecord>;
-		'flat/marko': Linter.Config<Linter.RulesRecord>;
-		'flat/react': Linter.Config<Linter.RulesRecord>;
-		'flat/svelte': Linter.Config<Linter.RulesRecord>;
-		'flat/vue': Linter.Config<Linter.RulesRecord>;
+		'flat/angular': Linter.FlatConfig;
+		'flat/dom': Linter.FlatConfig;
+		'flat/marko': Linter.FlatConfig;
+		'flat/react': Linter.FlatConfig;
+		'flat/svelte': Linter.FlatConfig;
+		'flat/vue': Linter.FlatConfig;
 	};
 	rules: {
 		[key: string]: Rule.RuleModule;


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- switches the types back to using the `Linter.FlatConfig` type to ensure compatibility with both ESLint v8 and v9

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

#973 incorrectly changed this probably because `Linter.FlatConfig` is marked as deprecated in v9, but it's the correct type to be using when supporting both v8 and v9 because `@types/eslint` (for v8) `Linter.Config`  maps to _legacy_ config - so right now the actual types for `flat/*` will change depending on the version of ESLint you've got installed.