### PR TITLE
chore: fix commitlint local setup

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,4 @@
 auto-install-peers=true
 enable-pre-post-scripts=true
+public-hoist-pattern[]=@commitlint*
+public-hoist-pattern[]=commitlint


### PR DESCRIPTION
## Checks

- [X] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- Add `commitlint` packages to the pnpm public hoist pattern

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

commitlint is currently broken for the `commit-msg` hook because pnpm can't find the right dependencies. This is caused by the private hoist mechanism from pnpm. For fixing it, I just made all the commitlint packages publicly hoisted. [More info in this issue](https://github.com/conventional-changelog/commitlint/issues/645).