### PR TITLE
docs: fix example in prefer-screen-queries.md

### DIFF
--- a/docs/rules/prefer-screen-queries.md
+++ b/docs/rules/prefer-screen-queries.md
@@ -38,7 +38,7 @@ getByText('foo');
 Examples of **correct** code for this rule:
 
 ```js
-import { render, screen } from '@testing-library/any-framework';
+import { render, screen, within } from '@testing-library/any-framework';
 
 // calling a query from the `screen` object
 render(<Component />);


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

- Add missing import of "within" in example code of `prefer-screen-queries`.

## Context
