### PR TITLE
refactor: Strengthen Type Safety and Fix Test File Compilation Errors

### DIFF
--- a/lib/create-testing-library-rule/detect-testing-library-utils.ts
+++ b/lib/create-testing-library-rule/detect-testing-library-utils.ts
@@ -802,8 +802,10 @@ export function detectTestingLibraryUtils<
 			}
 
 			return isNegated
-				? ABSENCE_MATCHERS.includes(matcher)
-				: PRESENCE_MATCHERS.includes(matcher);
+				? ABSENCE_MATCHERS.some((absenceMather) => absenceMather === matcher)
+				: PRESENCE_MATCHERS.some(
+						(presenceMather) => presenceMather === matcher
+					);
 		};
 
 		/**
@@ -821,8 +823,8 @@ export function detectTestingLibraryUtils<
 			}
 
 			return isNegated
-				? PRESENCE_MATCHERS.includes(matcher)
-				: ABSENCE_MATCHERS.includes(matcher);
+				? PRESENCE_MATCHERS.some((presenceMather) => presenceMather === matcher)
+				: ABSENCE_MATCHERS.some((absenceMather) => absenceMather === matcher);
 		};
 
 		const isMatchingAssert: IsMatchingAssertFn = (node, matcherName) => {

--- a/lib/create-testing-library-rule/index.ts
+++ b/lib/create-testing-library-rule/index.ts
@@ -1,6 +1,10 @@
 import { ESLintUtils } from '@typescript-eslint/utils';
 
-import { getDocsUrl, TestingLibraryPluginDocs } from '../utils';
+import {
+	getDocsUrl,
+	TestingLibraryPluginDocs,
+	TestingLibraryPluginRuleModule,
+} from '../utils';
 
 import {
 	DetectionOptions,
@@ -27,11 +31,20 @@ export const createTestingLibraryRule = <
 		create: EnhancedRuleCreate<TMessageIds, TOptions>;
 		detectionOptions?: Partial<DetectionOptions>;
 	}
->) =>
-	ESLintUtils.RuleCreator<TestingLibraryPluginDocs<TOptions>>(getDocsUrl)({
+>): TestingLibraryPluginRuleModule<TMessageIds, TOptions> => {
+	const rule = ESLintUtils.RuleCreator<TestingLibraryPluginDocs<TOptions>>(
+		getDocsUrl
+	)({
 		...remainingConfig,
 		create: detectTestingLibraryUtils<TMessageIds, TOptions>(
 			create,
 			detectionOptions
 		),
 	});
+	const { docs } = rule.meta;
+	if (docs === undefined) {
+		throw new Error('Rule metadata must contain `docs` property');
+	}
+
+	return { ...rule, meta: { ...rule.meta, docs } };
+};

--- a/lib/rules/no-node-access.ts
+++ b/lib/rules/no-node-access.ts
@@ -52,11 +52,16 @@ export default createTestingLibraryRule<Options, MessageIds>({
 				return;
 			}
 
+			const propertyName = ASTUtils.isIdentifier(node.property)
+				? node.property.name
+				: null;
+
 			if (
-				ASTUtils.isIdentifier(node.property) &&
-				ALL_RETURNING_NODES.includes(node.property.name)
+				ALL_RETURNING_NODES.some(
+					(allReturningNode) => allReturningNode === propertyName
+				)
 			) {
-				if (allowContainerFirstChild && node.property.name === 'firstChild') {
+				if (allowContainerFirstChild && propertyName === 'firstChild') {
 					return;
 				}
 

--- a/lib/rules/no-render-in-lifecycle.ts
+++ b/lib/rules/no-render-in-lifecycle.ts
@@ -68,7 +68,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 				type: 'object',
 				properties: {
 					allowTestingFrameworkSetupHook: {
-						enum: TESTING_FRAMEWORK_SETUP_HOOKS,
+						enum: [...TESTING_FRAMEWORK_SETUP_HOOKS],
 						type: 'string',
 					},
 				},

--- a/lib/rules/prefer-explicit-assert.ts
+++ b/lib/rules/prefer-explicit-assert.ts
@@ -92,7 +92,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 				properties: {
 					assertion: {
 						type: 'string',
-						enum: PRESENCE_MATCHERS,
+						enum: [...PRESENCE_MATCHERS],
 					},
 					includeFindQueries: { type: 'boolean' },
 				},
@@ -182,8 +182,14 @@ export default createTestingLibraryRule<Options, MessageIds>({
 						}
 
 						const shouldEnforceAssertion =
-							(!isNegatedMatcher && PRESENCE_MATCHERS.includes(matcher)) ||
-							(isNegatedMatcher && ABSENCE_MATCHERS.includes(matcher));
+							(!isNegatedMatcher &&
+								PRESENCE_MATCHERS.some(
+									(presenceMather) => presenceMather === matcher
+								)) ||
+							(isNegatedMatcher &&
+								ABSENCE_MATCHERS.some(
+									(absenceMather) => absenceMather === matcher
+								));
 
 						if (shouldEnforceAssertion && matcher !== assertion) {
 							context.report({

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -2,7 +2,10 @@ export * from './compat';
 export * from './file-import';
 export * from './types';
 
-const combineQueries = (variants: string[], methods: string[]): string[] => {
+const combineQueries = (
+	variants: readonly string[],
+	methods: readonly string[]
+): string[] => {
 	const combinedQueries: string[] = [];
 	variants.forEach((variant) => {
 		const variantPrefix = variant.replace('By', '');
@@ -25,14 +28,19 @@ const LIBRARY_MODULES = [
 	'@testing-library/vue',
 	'@testing-library/svelte',
 	'@marko/testing-library',
-];
+] as const;
 
-const SYNC_QUERIES_VARIANTS = ['getBy', 'getAllBy', 'queryBy', 'queryAllBy'];
-const ASYNC_QUERIES_VARIANTS = ['findBy', 'findAllBy'];
+const SYNC_QUERIES_VARIANTS = [
+	'getBy',
+	'getAllBy',
+	'queryBy',
+	'queryAllBy',
+] as const;
+const ASYNC_QUERIES_VARIANTS = ['findBy', 'findAllBy'] as const;
 const ALL_QUERIES_VARIANTS = [
 	...SYNC_QUERIES_VARIANTS,
 	...ASYNC_QUERIES_VARIANTS,
-];
+] as const;
 
 const ALL_QUERIES_METHODS = [
 	'ByLabelText',
@@ -43,7 +51,7 @@ const ALL_QUERIES_METHODS = [
 	'ByDisplayValue',
 	'ByRole',
 	'ByTestId',
-];
+] as const;
 
 const SYNC_QUERIES_COMBINATIONS = combineQueries(
 	SYNC_QUERIES_VARIANTS,
@@ -58,7 +66,7 @@ const ASYNC_QUERIES_COMBINATIONS = combineQueries(
 const ALL_QUERIES_COMBINATIONS = [
 	...SYNC_QUERIES_COMBINATIONS,
 	...ASYNC_QUERIES_COMBINATIONS,
-];
+] as const;
 
 const ASYNC_UTILS = ['waitFor', 'waitForElementToBeRemoved'] as const;
 
@@ -73,7 +81,7 @@ const DEBUG_UTILS = [
 
 const EVENTS_SIMULATORS = ['fireEvent', 'userEvent'] as const;
 
-const TESTING_FRAMEWORK_SETUP_HOOKS = ['beforeEach', 'beforeAll'];
+const TESTING_FRAMEWORK_SETUP_HOOKS = ['beforeEach', 'beforeAll'] as const;
 
 const PROPERTIES_RETURNING_NODES = [
 	'activeElement',
@@ -93,7 +101,7 @@ const PROPERTIES_RETURNING_NODES = [
 	'previousSibling',
 	'rootNode',
 	'scripts',
-];
+] as const;
 
 const METHODS_RETURNING_NODES = [
 	'closest',
@@ -104,20 +112,20 @@ const METHODS_RETURNING_NODES = [
 	'getElementsByTagNameNS',
 	'querySelector',
 	'querySelectorAll',
-];
+] as const;
 
 const ALL_RETURNING_NODES = [
 	...PROPERTIES_RETURNING_NODES,
 	...METHODS_RETURNING_NODES,
-];
+] as const;
 
 const PRESENCE_MATCHERS = [
 	'toBeOnTheScreen',
 	'toBeInTheDocument',
 	'toBeTruthy',
 	'toBeDefined',
-];
-const ABSENCE_MATCHERS = ['toBeNull', 'toBeFalsy'];
+] as const;
+const ABSENCE_MATCHERS = ['toBeNull', 'toBeFalsy'] as const;
 
 export {
 	combineQueries,

--- a/tests/lib/rules/consistent-data-testid.test.ts
+++ b/tests/lib/rules/consistent-data-testid.test.ts
@@ -1,4 +1,7 @@
-import { type TSESLint } from '@typescript-eslint/utils';
+import {
+	type InvalidTestCase,
+	type ValidTestCase,
+} from '@typescript-eslint/rule-tester';
 
 import rule, {
 	MessageIds,
@@ -9,9 +12,9 @@ import { createRuleTester } from '../test-utils';
 
 const ruleTester = createRuleTester();
 
-type ValidTestCase = TSESLint.ValidTestCase<Options>;
-type InvalidTestCase = TSESLint.InvalidTestCase<MessageIds, Options>;
-type TestCase = InvalidTestCase | ValidTestCase;
+type RuleValidTestCase = ValidTestCase<Options>;
+type RuleInvalidTestCase = InvalidTestCase<MessageIds, Options>;
+type TestCase = RuleValidTestCase | RuleInvalidTestCase;
 const disableAggressiveReporting = <T extends TestCase>(array: T[]): T[] =>
 	array.map((testCase) => ({
 		...testCase,
@@ -22,11 +25,11 @@ const disableAggressiveReporting = <T extends TestCase>(array: T[]): T[] =>
 		},
 	}));
 
-const validTestCases: ValidTestCase[] = [
+const validTestCases: RuleValidTestCase[] = [
 	{
 		code: `
           import React from 'react';
-          
+
           const TestComponent = props => {
             return (
               <div data-testid="cool">
@@ -40,7 +43,7 @@ const validTestCases: ValidTestCase[] = [
 	{
 		code: `
           import React from 'react';
-          
+
           const TestComponent = props => {
             return (
               <div className="cool">
@@ -54,7 +57,7 @@ const validTestCases: ValidTestCase[] = [
 	{
 		code: `
             import React from 'react';
-            
+
             const TestComponent = props => {
               return (
                 <div data-testid="Awesome__CoolStuff">
@@ -73,7 +76,7 @@ const validTestCases: ValidTestCase[] = [
 	{
 		code: `
             import React from 'react';
-            
+
             const TestComponent = props => {
               return (
                 <div data-testid="Awesome">
@@ -92,7 +95,7 @@ const validTestCases: ValidTestCase[] = [
 	{
 		code: `
             import React from 'react';
-            
+
             const TestComponent = props => {
               return (
                 <div data-testid="Parent">
@@ -111,7 +114,7 @@ const validTestCases: ValidTestCase[] = [
 	{
 		code: `
             import React from 'react';
-            
+
             const TestComponent = props => {
               return (
                 <div data-testid="Parent">
@@ -130,7 +133,7 @@ const validTestCases: ValidTestCase[] = [
 	{
 		code: `
             import React from 'react';
-            
+
             const TestComponent = props => {
               return (
                 <div data-testid="wrong" custom-attr="right-1">
@@ -149,7 +152,7 @@ const validTestCases: ValidTestCase[] = [
 	{
 		code: `
             import React from 'react';
-            
+
             const TestComponent = props => {
               return (
                 <div another-custom-attr="right-1" custom-attr="right-2">
@@ -168,7 +171,7 @@ const validTestCases: ValidTestCase[] = [
 	{
 		code: `
             import React from 'react';
-            
+
             const TestComponent = props => {
               return (
                 <div data-test-id="Parent">
@@ -188,7 +191,7 @@ const validTestCases: ValidTestCase[] = [
 	{
 		code: `
           import React from 'react';
-          
+
           const TestComponent = props => {
             const dynamicTestId = 'somethingDynamic';
             return (
@@ -205,7 +208,7 @@ const validTestCases: ValidTestCase[] = [
 	{
 		code: `
             import React from 'react';
-            
+
             const TestComponent = props => {
               return (
                 <div data-testid="__CoolStuff">
@@ -224,7 +227,7 @@ const validTestCases: ValidTestCase[] = [
 	{
 		code: `
             import React from 'react';
-            
+
             const TestComponent = props => {
               return (
                 <div data-testid="__CoolStuff">
@@ -244,7 +247,7 @@ const validTestCases: ValidTestCase[] = [
 	{
 		code: `
             import React from 'react';
-            
+
             const TestComponent = props => {
               return (
                 <div data-testid="__CoolStuff">
@@ -262,11 +265,11 @@ const validTestCases: ValidTestCase[] = [
 		filename: '/my/cool/file/path/[...wildcard].js',
 	},
 ];
-const invalidTestCases: InvalidTestCase[] = [
+const invalidTestCases: RuleInvalidTestCase[] = [
 	{
 		code: `
         import React from 'react';
-            
+
         const TestComponent = props => {
           return (
             <div data-testid="Awesome__CoolStuff">
@@ -291,7 +294,7 @@ const invalidTestCases: InvalidTestCase[] = [
 	{
 		code: `
             import React from 'react';
-            
+
             const TestComponent = props => {
               return (
                 <div data-testid="Nope">
@@ -321,7 +324,7 @@ const invalidTestCases: InvalidTestCase[] = [
 	{
 		code: `
             import React from 'react';
-            
+
             const TestComponent = props => {
               return (
                 <div data-testid="Parent__cool" my-custom-attr="WrongComponent__cool">
@@ -352,7 +355,7 @@ const invalidTestCases: InvalidTestCase[] = [
 	{
 		code: `
             import React from 'react';
-            
+
             const TestComponent = props => {
               return (
                 <div custom-attr="wrong" another-custom-attr="wrong">
@@ -391,7 +394,7 @@ const invalidTestCases: InvalidTestCase[] = [
 	{
 		code: `
             import React from 'react';
-            
+
             const TestComponent = props => {
               return (
                 <div data-testid="WrongComponent__cool">
@@ -421,7 +424,7 @@ const invalidTestCases: InvalidTestCase[] = [
 	{
 		code: ` // test for custom message
             import React from 'react';
-            
+
             const TestComponent = props => {
               return (
                 <div data-testid="snake_case_value">

--- a/tests/lib/rules/no-unnecessary-act.test.ts
+++ b/tests/lib/rules/no-unnecessary-act.test.ts
@@ -1,4 +1,7 @@
-import { type TSESLint } from '@typescript-eslint/utils';
+import {
+	type InvalidTestCase,
+	type ValidTestCase,
+} from '@typescript-eslint/rule-tester';
 
 import rule, {
 	MessageIds,
@@ -9,9 +12,9 @@ import { createRuleTester } from '../test-utils';
 
 const ruleTester = createRuleTester();
 
-type ValidTestCase = TSESLint.ValidTestCase<Options>;
-type InvalidTestCase = TSESLint.InvalidTestCase<MessageIds, Options>;
-type TestCase = InvalidTestCase | ValidTestCase;
+type RuleValidTestCase = ValidTestCase<Options>;
+type RuleInvalidTestCase = InvalidTestCase<MessageIds, Options>;
+type TestCase = RuleInvalidTestCase | RuleValidTestCase;
 
 const addOptions = <T extends TestCase>(
 	array: T[],
@@ -37,7 +40,7 @@ const SUPPORTED_TESTING_FRAMEWORKS = [
 	['@marko/testing-library', 'Marko TL'],
 ];
 
-const validNonStrictTestCases: ValidTestCase[] = [
+const validNonStrictTestCases: RuleValidTestCase[] = [
 	{
 		code: `// case: RTL act wrapping both RTL and non-RTL calls
       import { act, render, waitFor } from '@testing-library/react'
@@ -62,7 +65,7 @@ const validNonStrictTestCases: ValidTestCase[] = [
 	},
 ];
 
-const validTestCases: ValidTestCase[] = [
+const validTestCases: RuleValidTestCase[] = [
 	...SUPPORTED_TESTING_FRAMEWORKS.map(([testingFramework, shortName]) => ({
 		code: `// case: ${shortName} act wrapping non-${shortName} calls
     import { act } from '${testingFramework}'
@@ -214,7 +217,7 @@ const validTestCases: ValidTestCase[] = [
 	})),
 ];
 
-const invalidStrictTestCases: InvalidTestCase[] =
+const invalidStrictTestCases: RuleInvalidTestCase[] =
 	SUPPORTED_TESTING_FRAMEWORKS.flatMap(([testingFramework, shortName]) => [
 		{
 			code: `// case: ${shortName} act wrapping both ${shortName} and non-${shortName} calls with strict option
@@ -244,7 +247,7 @@ const invalidStrictTestCases: InvalidTestCase[] =
 		},
 	]);
 
-const invalidTestCases: InvalidTestCase[] = [
+const invalidTestCases: RuleInvalidTestCase[] = [
 	...SUPPORTED_TESTING_FRAMEWORKS.map(
 		([testingFramework, shortName]) =>
 			({

--- a/tests/lib/rules/prefer-find-by.test.ts
+++ b/tests/lib/rules/prefer-find-by.test.ts
@@ -1,4 +1,7 @@
-import { TSESLint } from '@typescript-eslint/utils';
+import {
+	type InvalidTestCase,
+	type ValidTestCase,
+} from '@typescript-eslint/rule-tester';
 
 import rule, {
 	RULE_NAME,
@@ -26,9 +29,7 @@ function buildFindByMethod(queryMethod: string) {
 }
 
 function createScenario<
-	T extends
-		| TSESLint.InvalidTestCase<MessageIds, []>
-		| TSESLint.ValidTestCase<[]>,
+	T extends InvalidTestCase<MessageIds, []> | ValidTestCase<[]>,
 >(callback: (waitMethod: string, queryMethod: string) => T) {
 	return SYNC_QUERIES_COMBINATIONS.map((queryMethod) =>
 		callback('waitFor', queryMethod)

--- a/tests/lib/rules/prefer-presence-queries.test.ts
+++ b/tests/lib/rules/prefer-presence-queries.test.ts
@@ -1,4 +1,7 @@
-import { TSESLint } from '@typescript-eslint/utils';
+import {
+	type InvalidTestCase,
+	type ValidTestCase,
+} from '@typescript-eslint/rule-tester';
 
 import rule, {
 	RULE_NAME,
@@ -17,8 +20,8 @@ const queryAllByQueries = ALL_QUERIES_METHODS.map(
 	(method) => `queryAll${method}`
 );
 
-type RuleValidTestCase = TSESLint.ValidTestCase<Options>;
-type RuleInvalidTestCase = TSESLint.InvalidTestCase<MessageIds, Options>;
+type RuleValidTestCase = ValidTestCase<Options>;
+type RuleInvalidTestCase = InvalidTestCase<MessageIds, Options>;
 
 type AssertionFnParams = {
 	query: string;
@@ -921,7 +924,7 @@ ruleTester.run(RULE_NAME, rule, {
      // submit button exists
      const submitButton = screen.getByRole('button')
      fireEvent.click(submitButton)
-    
+
      // right after clicking submit button it disappears
      expect(submitButton).not.toBeInTheDocument()
     `,

--- a/tests/lib/rules/prefer-query-matchers.test.ts
+++ b/tests/lib/rules/prefer-query-matchers.test.ts
@@ -1,4 +1,7 @@
-import { TSESLint } from '@typescript-eslint/utils';
+import {
+	type InvalidTestCase,
+	type ValidTestCase,
+} from '@typescript-eslint/rule-tester';
 
 import rule, {
 	RULE_NAME,
@@ -17,8 +20,8 @@ const queryAllByQueries = ALL_QUERIES_METHODS.map(
 	(method) => `queryAll${method}`
 );
 
-type RuleValidTestCase = TSESLint.ValidTestCase<Options>;
-type RuleInvalidTestCase = TSESLint.InvalidTestCase<MessageIds, Options>;
+type RuleValidTestCase = ValidTestCase<Options>;
+type RuleInvalidTestCase = InvalidTestCase<MessageIds, Options>;
 
 type AssertionFnParams = {
 	query: string;

--- a/tests/lib/rules/prefer-user-event.test.ts
+++ b/tests/lib/rules/prefer-user-event.test.ts
@@ -1,4 +1,7 @@
-import { TSESLint } from '@typescript-eslint/utils';
+import {
+	type InvalidTestCase,
+	type ValidTestCase,
+} from '@typescript-eslint/rule-tester';
 
 import rule, {
 	MAPPING_TO_USER_EVENT,
@@ -11,9 +14,7 @@ import { LIBRARY_MODULES } from '../../../lib/utils';
 import { createRuleTester } from '../test-utils';
 
 function createScenarioWithImport<
-	T extends
-		| TSESLint.InvalidTestCase<MessageIds, Options>
-		| TSESLint.ValidTestCase<Options>,
+	T extends InvalidTestCase<MessageIds, Options> | ValidTestCase<Options>,
 >(callback: (libraryModule: string, fireEventMethod: string) => T) {
 	return LIBRARY_MODULES.reduce(
 		(acc: Array<T>, libraryModule) =>
@@ -69,7 +70,7 @@ ruleTester.run(RULE_NAME, rule, {
         userEvent.${userEventMethod}(foo)
       `,
 		})),
-		...createScenarioWithImport<TSESLint.ValidTestCase<Options>>(
+		...createScenarioWithImport<ValidTestCase<Options>>(
 			(libraryModule: string, fireEventMethod: string) => ({
 				code: `
         import { fireEvent } from '${libraryModule}'
@@ -79,7 +80,7 @@ ruleTester.run(RULE_NAME, rule, {
 				options: [{ allowedMethods: [fireEventMethod] }],
 			})
 		),
-		...createScenarioWithImport<TSESLint.ValidTestCase<Options>>(
+		...createScenarioWithImport<ValidTestCase<Options>>(
 			(libraryModule: string, fireEventMethod: string) => ({
 				code: `
         import { fireEvent as fireEventAliased } from '${libraryModule}'
@@ -89,7 +90,7 @@ ruleTester.run(RULE_NAME, rule, {
 				options: [{ allowedMethods: [fireEventMethod] }],
 			})
 		),
-		...createScenarioWithImport<TSESLint.ValidTestCase<Options>>(
+		...createScenarioWithImport<ValidTestCase<Options>>(
 			(libraryModule: string, fireEventMethod: string) => ({
 				code: `
         import * as dom from '${libraryModule}'
@@ -273,7 +274,7 @@ ruleTester.run(RULE_NAME, rule, {
 		},
 	],
 	invalid: [
-		...createScenarioWithImport<TSESLint.InvalidTestCase<MessageIds, Options>>(
+		...createScenarioWithImport<InvalidTestCase<MessageIds, Options>>(
 			(libraryModule: string, fireEventMethod: string) => ({
 				code: `
         import { fireEvent } from '${libraryModule}'
@@ -293,7 +294,7 @@ ruleTester.run(RULE_NAME, rule, {
 				],
 			})
 		),
-		...createScenarioWithImport<TSESLint.InvalidTestCase<MessageIds, Options>>(
+		...createScenarioWithImport<InvalidTestCase<MessageIds, Options>>(
 			(libraryModule: string, fireEventMethod: string) => ({
 				code: `
         import * as dom from '${libraryModule}'
@@ -312,7 +313,7 @@ ruleTester.run(RULE_NAME, rule, {
 				],
 			})
 		),
-		...createScenarioWithImport<TSESLint.InvalidTestCase<MessageIds, Options>>(
+		...createScenarioWithImport<InvalidTestCase<MessageIds, Options>>(
 			(libraryModule: string, fireEventMethod: string) => ({
 				code: `
         const { fireEvent } = require('${libraryModule}')
@@ -331,7 +332,7 @@ ruleTester.run(RULE_NAME, rule, {
 				],
 			})
 		),
-		...createScenarioWithImport<TSESLint.InvalidTestCase<MessageIds, Options>>(
+		...createScenarioWithImport<InvalidTestCase<MessageIds, Options>>(
 			(libraryModule: string, fireEventMethod: string) => ({
 				code: `
         const rtl = require('${libraryModule}')
@@ -484,7 +485,7 @@ ruleTester.run(RULE_NAME, rule, {
 			},
 			code: `
         import { fireEvent, createEvent } from 'test-utils'
-        
+
         fireEvent(node, createEvent('${fireEventMethod}', node))
       `,
 			errors: [


### PR DESCRIPTION
It's a minor change, but I refactored a few parts that caught my attention. Please feel free to close this PR if it doesn't meet your expectations. I appreciate your review!

## Checks

- [ ] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- update test case types to use rule-tester types.
→ Due to deprecation of TSESLint's InvalidTestCase and ValidTestCase

- apply `as const` for stricter type safety on query definitions.
- add explicit return type to `createTestingLibraryRule` for better type safety.
→ Because a type error occurred in test files when passing the rule as the second argument to `ruleTester.run`.

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->
