### PR TITLE
ci: add workflow for coverage on main

### DIFF
--- a/.github/workflows/main-coverage.yml
+++ b/.github/workflows/main-coverage.yml
@@ -3,6 +3,11 @@ on:
   push:
     branches:
       - 'main'
+
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   coverage:
     name: Code Coverage


### PR DESCRIPTION
## Checks

- [X] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- Sends code coverage to Codecov on push to `main` branch

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->
[Just realized we are not updating the code coverage in `main` branch](https://app.codecov.io/gh/testing-library/eslint-plugin-testing-library/commits)