### PR TITLE
refactor: Include test files in type checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"types": "index.d.ts",
 	"scripts": {
 		"prebuild": "del-cli dist",
-		"build": "tsc",
+		"build": "tsc -p ./tsconfig.build.json",
 		"generate-all": "pnpm run --parallel \"/^generate:.*/\"",
 		"generate-all:check": "pnpm run generate-all && git diff --exit-code",
 		"generate:configs": "ts-node tools/generate-configs",

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -61,7 +61,7 @@ it('should export configs that refer to actual rules', () => {
 		'flat/marko',
 	]);
 	const allConfigRules = Object.values(allConfigs)
-		.map((config) => Object.keys(config.rules))
+		.map((config) => Object.keys(config.rules ?? {}))
 		.reduce((previousValue, currentValue) => [
 			...previousValue,
 			...currentValue,

--- a/tests/lib/rules/no-wait-for-side-effects.test.ts
+++ b/tests/lib/rules/no-wait-for-side-effects.test.ts
@@ -1,4 +1,9 @@
-import rule, { RULE_NAME } from '../../../lib/rules/no-wait-for-side-effects';
+import { InvalidTestCase } from '@typescript-eslint/rule-tester';
+
+import rule, {
+	RULE_NAME,
+	type MessageIds,
+} from '../../../lib/rules/no-wait-for-side-effects';
 import { createRuleTester } from '../test-utils';
 
 const ruleTester = createRuleTester();
@@ -118,7 +123,7 @@ ruleTester.run(RULE_NAME, rule, {
 				code: `
           import { waitFor } from '${testingFramework}';
           import { notUserEvent } from 'somewhere-else';
-          
+
           waitFor(() => {
             await notUserEvent.click(button)
           })
@@ -736,7 +741,7 @@ ruleTester.run(RULE_NAME, rule, {
           expect(b).toEqual('b')
         }).then(() => {
           userEvent.click(button) // Side effects are allowed inside .then()
-          expect(b).toEqual('b') 
+          expect(b).toEqual('b')
         })
       `,
 				errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
@@ -808,9 +813,10 @@ ruleTester.run(RULE_NAME, rule, {
 			} as const,
 		]),
 
-		...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
-			{
-				code: `
+		...SUPPORTED_TESTING_FRAMEWORKS.flatMap<InvalidTestCase<MessageIds, []>>(
+			(testingFramework) => [
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         import userEvent from '@testing-library/user-event'
 
@@ -820,8 +826,9 @@ ruleTester.run(RULE_NAME, rule, {
           });
         });
         `,
-				errors: [{ line: 7, column: 13, messageId: 'noSideEffectsWaitFor' }],
-			},
-		]),
+					errors: [{ line: 7, column: 13, messageId: 'noSideEffectsWaitFor' }],
+				},
+			]
+		),
 	],
 });

--- a/tests/lib/rules/prefer-find-by.test.ts
+++ b/tests/lib/rules/prefer-find-by.test.ts
@@ -714,8 +714,9 @@ ruleTester.run(RULE_NAME, rule, {
 			)}('Count is: 0', { timeout: 100, interval: 200 })
         `,
 		})),
-		...ASYNC_QUERIES_COMBINATIONS.map((queryMethod) => ({
-			code: `
+		...ASYNC_QUERIES_COMBINATIONS.map<InvalidTestCase<MessageIds, []>>(
+			(queryMethod) => ({
+				code: `
 				import {waitFor} from '${testingFramework}';
 				it('tests', async () => {
 					await waitFor(async () => {
@@ -724,24 +725,25 @@ ruleTester.run(RULE_NAME, rule, {
 					})
 				})
         `,
-			errors: [
-				{
-					messageId: 'preferFindBy',
-					data: {
-						queryVariant: getFindByQueryVariant(queryMethod),
-						queryMethod: queryMethod.split('By')[1],
-						prevQuery: queryMethod,
-						waitForMethodName: 'waitFor',
+				errors: [
+					{
+						messageId: 'preferFindBy',
+						data: {
+							queryVariant: getFindByQueryVariant(queryMethod),
+							queryMethod: queryMethod.split('By')[1],
+							prevQuery: queryMethod,
+							waitForMethodName: 'waitFor',
+						},
 					},
-				},
-			],
-			output: `
+				],
+				output: `
 				import {waitFor} from '${testingFramework}';
 				it('tests', async () => {
 					const button = await screen.${queryMethod}("button", { name: "Submit" })
 					expect(button).toBeInTheDocument()
 				})
         `,
-		})),
+			})
+		),
 	]),
 });

--- a/tests/lib/rules/prefer-find-by.test.ts
+++ b/tests/lib/rules/prefer-find-by.test.ts
@@ -191,7 +191,7 @@ ruleTester.run(RULE_NAME, rule, {
 		},
 	]),
 	invalid: SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
-		...createScenario((waitMethod: string, queryMethod: string) => ({
+		...createScenario((waitMethod, queryMethod) => ({
 			code: `
           import {${waitMethod}, screen} from '${testingFramework}';
           it('tests', async () => {
@@ -353,7 +353,7 @@ ruleTester.run(RULE_NAME, rule, {
 			output: null,
 		},
 		// presence matchers
-		...createScenario((waitMethod: string, queryMethod: string) => ({
+		...createScenario((waitMethod, queryMethod) => ({
 			code: `
         import {${waitMethod}} from '${testingFramework}';
         it('tests', async () => {
@@ -382,7 +382,7 @@ ruleTester.run(RULE_NAME, rule, {
         })
       `,
 		})),
-		...createScenario((waitMethod: string, queryMethod: string) => ({
+		...createScenario((waitMethod, queryMethod) => ({
 			code: `
         import {${waitMethod}} from '${testingFramework}';
         it('tests', async () => {
@@ -411,7 +411,7 @@ ruleTester.run(RULE_NAME, rule, {
         })
       `,
 		})),
-		...createScenario((waitMethod: string, queryMethod: string) => ({
+		...createScenario((waitMethod, queryMethod) => ({
 			code: `
         import {${waitMethod}} from '${testingFramework}';
         it('tests', async () => {
@@ -440,7 +440,7 @@ ruleTester.run(RULE_NAME, rule, {
         })
       `,
 		})),
-		...createScenario((waitMethod: string, queryMethod: string) => ({
+		...createScenario((waitMethod, queryMethod) => ({
 			code: `
         import {${waitMethod}} from '${testingFramework}';
         it('tests', async () => {
@@ -469,7 +469,7 @@ ruleTester.run(RULE_NAME, rule, {
         })
       `,
 		})),
-		...createScenario((waitMethod: string, queryMethod: string) => ({
+		...createScenario((waitMethod, queryMethod) => ({
 			code: `
         import {${waitMethod}} from '${testingFramework}';
         it('tests', async () => {
@@ -498,7 +498,7 @@ ruleTester.run(RULE_NAME, rule, {
         })
       `,
 		})),
-		...createScenario((waitMethod: string, queryMethod: string) => ({
+		...createScenario((waitMethod, queryMethod) => ({
 			code: `
         import {${waitMethod}} from '${testingFramework}';
         it('tests', async () => {
@@ -527,7 +527,7 @@ ruleTester.run(RULE_NAME, rule, {
         })
       `,
 		})),
-		...createScenario((waitMethod: string, queryMethod: string) => ({
+		...createScenario((waitMethod, queryMethod) => ({
 			code: `
         import {${waitMethod}} from '${testingFramework}';
         it('tests', async () => {
@@ -556,7 +556,7 @@ ruleTester.run(RULE_NAME, rule, {
         })
       `,
 		})),
-		...createScenario((waitMethod: string, queryMethod: string) => ({
+		...createScenario((waitMethod, queryMethod) => ({
 			code: `
           import {${waitMethod}} from '${testingFramework}';
           it('tests', async () => {
@@ -583,7 +583,7 @@ ruleTester.run(RULE_NAME, rule, {
           })
         `,
 		})),
-		...createScenario((waitMethod: string, queryMethod: string) => ({
+		...createScenario((waitMethod, queryMethod) => ({
 			code: `
           import {${waitMethod}} from '${testingFramework}';
           it('tests', async () => {
@@ -610,7 +610,7 @@ ruleTester.run(RULE_NAME, rule, {
           })
         `,
 		})),
-		...createScenario((waitMethod: string, queryMethod: string) => ({
+		...createScenario((waitMethod, queryMethod) => ({
 			code: `
           import {${waitMethod}} from '${testingFramework}';
           it('tests', async () => {
@@ -637,7 +637,7 @@ ruleTester.run(RULE_NAME, rule, {
           })
         `,
 		})),
-		...createScenario((waitMethod: string, queryMethod: string) => ({
+		...createScenario((waitMethod, queryMethod) => ({
 			code: `
           import {${waitMethod}} from '${testingFramework}';
           it('tests', async () => {
@@ -664,7 +664,7 @@ ruleTester.run(RULE_NAME, rule, {
           })
         `,
 		})),
-		...createScenario((waitMethod: string, queryMethod: string) => ({
+		...createScenario((waitMethod, queryMethod) => ({
 			code: `
           import {${waitMethod}} from '${testingFramework}';
           it('tests', async () => {
@@ -693,7 +693,7 @@ ruleTester.run(RULE_NAME, rule, {
 		})),
 		// Issue #579, https://github.com/testing-library/eslint-plugin-testing-library/issues/579
 		// findBy can have two sets of options: await screen.findByText('text', queryOptions, waitForOptions)
-		...createScenario((waitMethod: string, queryMethod: string) => ({
+		...createScenario((waitMethod, queryMethod) => ({
 			code: `import {${waitMethod}} from '${testingFramework}';
 		  const button = await ${waitMethod}(() => screen.${queryMethod}('Count is: 0'), { timeout: 100, interval: 200 })
         `,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["./tests/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
 		"outDir": "dist",
 		"sourceMap": false
 	},
-	"include": ["./lib/**/*.ts"]
+	"include": ["./lib/**/*.ts", "./tests/**/*.ts"]
 }


### PR DESCRIPTION
I noticed several type errors in the `tests` directory, so I updated the config to include them in type-checking.
Let me know what you think!

## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- Created a separate `tsconfig.build.json` for build purposes.
→ To `type-check` both `lib` and `tests`, but exclude `tests` from the build output.
- Fixed type errors that appeared during `type-check`.

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->
