### PR TITLE
fix(no-node-access): exclude `user` to avoid false positives

### DIFF
--- a/lib/rules/no-node-access.ts
+++ b/lib/rules/no-node-access.ts
@@ -73,7 +73,12 @@ export default createTestingLibraryRule<Options, MessageIds>({
 				ALL_PROHIBITED_MEMBERS.some(
 					(allReturningNode) => allReturningNode === propertyName
 				) &&
-				!EVENTS_SIMULATORS.some((simulator) => simulator === objectName)
+				![
+					...EVENTS_SIMULATORS,
+					// TODO: As discussed in https://github.com/testing-library/eslint-plugin-testing-library/issues/1024, this is just a temporary workaround.
+					// We should address the root cause and implement a proper solution instead of explicitly excluding 'user' here.
+					'user',
+				].some((simulator) => simulator === objectName)
 			) {
 				if (allowContainerFirstChild && propertyName === 'firstChild') {
 					return;

--- a/tests/lib/rules/no-node-access.test.ts
+++ b/tests/lib/rules/no-node-access.test.ts
@@ -163,6 +163,16 @@ ruleTester.run(RULE_NAME, rule, {
 				expect(screen.getByText('SomeComponent')).toBeInTheDocument();
 				`,
 			},
+			{
+				code: `
+				import userEvent from '@testing-library/user-event';
+        import { screen } from '${testingFramework}';
+
+        const buttonText = screen.getByText('submit');
+				const user = userEvent.setup();
+				user.click(buttonText);
+      `,
+			},
 			...EVENTS_SIMULATORS.map((simulator) => ({
 				code: `
         import { screen } from '${testingFramework}';


### PR DESCRIPTION
I have applied the temporary workaround that was proposed in #1024.
Sorry for the inconvenience, but I would appreciate your review.🙇‍♂️


## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- Temporarily exclude the variable name 'user' from the no-node-access rule to avoid false positive errors when using `const user = userEvent.setup()`.


## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

#1024 （partially）