### PR TITLE
fix(no-node-access): stop reporting `focus()` usage

### DIFF
--- a/docs/rules/no-node-access.md
+++ b/docs/rules/no-node-access.md
@@ -8,7 +8,11 @@ Disallow direct access or manipulation of DOM nodes in favor of Testing Library'
 
 ## Rule Details
 
-This rule aims to disallow direct access and manipulation of DOM nodes using native HTML properties and methods — including traversal (e.g. `closest`, `lastChild`) as well as direct actions (e.g. `click()`, `focus()`). Use Testing Library’s queries and userEvent APIs instead.
+This rule aims to disallow direct access and manipulation of DOM nodes using native HTML properties and methods — including traversal (e.g. `closest`, `lastChild`) as well as direct actions (e.g. `click()`, `select()`). Use Testing Library’s queries and userEvent APIs instead.
+
+> [!NOTE]
+> This rule does not report usage of `focus()`, because imperative focus (e.g. `getByText('focus me').focus()`) is recommended over `fireEvent.focus()`.
+> If an element is not focusable, related assertions will fail, leading to more robust tests. See [Testing Library Events Guide](https://testing-library.com/docs/guide-events/) for more details.
 
 Examples of **incorrect** code for this rule:
 
@@ -104,3 +108,7 @@ expect(container.firstChild).toMatchSnapshot();
 - [`Document`](https://developer.mozilla.org/en-US/docs/Web/API/Document)
 - [`Element`](https://developer.mozilla.org/en-US/docs/Web/API/Element)
 - [`Node`](https://developer.mozilla.org/en-US/docs/Web/API/Node)
+
+### Testing Library Guides
+
+- [Testing Library Events Guide](https://testing-library.com/docs/guide-events/)

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -114,13 +114,7 @@ const METHODS_RETURNING_NODES = [
 	'querySelectorAll',
 ] as const;
 
-const EVENT_HANDLER_METHODS = [
-	'click',
-	'focus',
-	'blur',
-	'select',
-	'submit',
-] as const;
+const EVENT_HANDLER_METHODS = ['click', 'blur', 'select', 'submit'] as const;
 
 const ALL_RETURNING_NODES = [
 	...PROPERTIES_RETURNING_NODES,


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- remove 'focus' from `EVENT_HANDLER_METHODS` for consistency

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->
Fixes #1027 
