### PR TITLE
fix(no-node-access): stop reporting blur() usage

### DIFF
--- a/docs/rules/no-node-access.md
+++ b/docs/rules/no-node-access.md
@@ -11,7 +11,7 @@ Disallow direct access or manipulation of DOM nodes in favor of Testing Library'
 This rule aims to disallow direct access and manipulation of DOM nodes using native HTML properties and methods — including traversal (e.g. `closest`, `lastChild`) as well as direct actions (e.g. `click()`, `select()`). Use Testing Library’s queries and userEvent APIs instead.
 
 > [!NOTE]
-> This rule does not report usage of `focus()`, because imperative focus (e.g. `getByText('focus me').focus()`) is recommended over `fireEvent.focus()`.
+> This rule does not report usage of `focus()` or `blur()`, because imperative usage (e.g. `getByText('focus me').focus()` or .`blur()`) is recommended over `fireEvent.focus()` or `fireEvent.blur()`.
 > If an element is not focusable, related assertions will fail, leading to more robust tests. See [Testing Library Events Guide](https://testing-library.com/docs/guide-events/) for more details.
 
 Examples of **incorrect** code for this rule:

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -114,7 +114,7 @@ const METHODS_RETURNING_NODES = [
 	'querySelectorAll',
 ] as const;
 
-const EVENT_HANDLER_METHODS = ['click', 'blur', 'select', 'submit'] as const;
+const EVENT_HANDLER_METHODS = ['click', 'select', 'submit'] as const;
 
 const ALL_RETURNING_NODES = [
 	...PROPERTIES_RETURNING_NODES,


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- remove `blur` from EVENT_HANDLER_METHODS for consistency.
- update document.

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->
Fixes #1030 