### PR TITLE
fix(no-node-access): Avoid false positives when Testing Library is not imported

### DIFF
--- a/lib/rules/no-node-access.ts
+++ b/lib/rules/no-node-access.ts
@@ -90,6 +90,13 @@ export default createTestingLibraryRule<Options, MessageIds>({
 
 		return {
 			CallExpression(node: TSESTree.CallExpression) {
+				// This rule is so aggressive that can cause tons of false positives outside test files when Aggressive Reporting
+				// is enabled. Because of that, this rule will skip this mechanism and report only if some Testing Library package
+				// or custom one (set in utils-module Shared Setting) is found.
+				if (!helpers.isTestingLibraryImported(true)) {
+					return;
+				}
+
 				const { callee } = node;
 				const property = isMemberExpression(callee) ? callee.property : null;
 				const object = isMemberExpression(callee) ? callee.object : null;

--- a/tests/lib/rules/no-node-access.test.ts
+++ b/tests/lib/rules/no-node-access.test.ts
@@ -24,6 +24,15 @@ ruleTester.run(RULE_NAME, rule, {
 	valid: SUPPORTED_TESTING_FRAMEWORKS.flatMap<RuleValidTestCase>(
 		(testingFramework) => [
 			{
+				// valid because no Testing Library module is imported
+				code: `
+				// case: custom module set but not imported using ${testingFramework} (aggressive reporting limited)
+				const body = document.body
+
+				body.click();
+      `,
+			},
+			{
 				code: `
         import { screen } from '${testingFramework}';
 


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- Avoid false positives by reporting only when Testing Library or custom utils module is imported.

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

These comments should be resolved with this.
- https://github.com/testing-library/eslint-plugin-testing-library/issues/1041#issuecomment-3061393495
- https://github.com/testing-library/eslint-plugin-testing-library/issues/1041#issuecomment-3062213266
