### PR TITLE
fix: disallow extra properties in rule options

### DIFF
--- a/lib/rules/no-node-access.ts
+++ b/lib/rules/no-node-access.ts
@@ -41,6 +41,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 						type: 'boolean',
 					},
 				},
+				additionalProperties: false,
 			},
 		],
 	},

--- a/lib/rules/no-render-in-lifecycle.ts
+++ b/lib/rules/no-render-in-lifecycle.ts
@@ -72,6 +72,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 						type: 'string',
 					},
 				},
+				additionalProperties: false,
 			},
 		],
 	},

--- a/lib/rules/no-unnecessary-act.ts
+++ b/lib/rules/no-unnecessary-act.ts
@@ -45,6 +45,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 						type: 'boolean',
 					},
 				},
+				additionalProperties: false,
 			},
 		],
 	},

--- a/lib/rules/prefer-query-matchers.ts
+++ b/lib/rules/prefer-query-matchers.ts
@@ -50,6 +50,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 									type: 'string',
 								},
 							},
+							additionalProperties: false,
 						},
 					},
 				},

--- a/lib/rules/prefer-user-event.ts
+++ b/lib/rules/prefer-user-event.ts
@@ -90,6 +90,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 				properties: {
 					allowedMethods: { type: 'array' },
 				},
+				additionalProperties: false,
 			},
 		],
 	},


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

Some rules, for example [no-node-access](https://github.com/testing-library/eslint-plugin-testing-library/blob/35e2b406241c816bf52439075dfc61f0964ca494/lib/rules/no-node-access.ts#L37) currently allow extra properties to be passed in options object, which should not be allowed. This makes it easier for typos in rule options to go unnoticed.

This PR simply disallows extra properties in rules' schemas which currently allow them.

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->
