### PR TITLE
fix: handled promises assigned to vars are valid

### DIFF
--- a/lib/rules/await-async-utils.ts
+++ b/lib/rules/await-async-utils.ts
@@ -7,6 +7,7 @@ import {
 	getFunctionName,
 	getInnermostReturningFunction,
 	getVariableReferences,
+	isCallExpression,
 	isObjectPattern,
 	isPromiseHandled,
 	isProperty,
@@ -110,6 +111,8 @@ export default createTestingLibraryRule<Options, MessageIds>({
 				const isAssigningKnownAsyncFunctionWrapper =
 					ASTUtils.isIdentifier(node.id) &&
 					node.init !== null &&
+					!isCallExpression(node.init) &&
+					!ASTUtils.isAwaitExpression(node.init) &&
 					functionWrappersNames.includes(
 						getDeepestIdentifierNode(node.init)?.name ?? ''
 					);

--- a/tests/lib/rules/await-async-events.test.ts
+++ b/tests/lib/rules/await-async-events.test.ts
@@ -138,6 +138,21 @@ ruleTester.run(RULE_NAME, rule, {
 				options: [{ eventModule: 'fireEvent' }] as const,
 			})),
 			...FIRE_EVENT_ASYNC_FUNCTIONS.map((eventMethod) => ({
+				code: `
+        import { fireEvent } from '${testingFramework}'
+        test('await promise assigned to a variable from function wrapping event method is valid', () => {
+          function triggerEvent() {
+            doSomething()
+            return fireEvent.${eventMethod}(getByLabelText('username'))
+          }
+
+          const result = await triggerEvent()
+          expect(result).toBe(undefined)
+        })
+        `,
+				options: [{ eventModule: 'fireEvent' }] as const,
+			})),
+			...FIRE_EVENT_ASYNC_FUNCTIONS.map((eventMethod) => ({
 				settings: {
 					'testing-library/utils-module': 'test-utils',
 				},
@@ -357,6 +372,21 @@ ruleTester.run(RULE_NAME, rule, {
           }
 
           await triggerEvent()
+        })
+        `,
+				options: [{ eventModule: 'userEvent' }] as const,
+			})),
+			...USER_EVENT_ASYNC_FUNCTIONS.map((eventMethod) => ({
+				code: `
+        import userEvent from '${testingFramework}'
+        test('await promise assigned to a variable from function wrapping event method is valid', () => {
+          function triggerEvent() {
+            doSomething()
+            return userEvent.${eventMethod}(getByLabelText('username'))
+          }
+
+          const result = await triggerEvent()
+          expect(result).toBe(undefined)
         })
         `,
 				options: [{ eventModule: 'userEvent' }] as const,
@@ -775,6 +805,44 @@ ruleTester.run(RULE_NAME, rule, {
 					({
 						code: `
       import { fireEvent } from '${testingFramework}'
+      test('unhandled promise assigned to a variable returned from function wrapping event method is invalid', () => {
+        function triggerEvent() {
+          doSomething()
+          return fireEvent.${eventMethod}(getByLabelText('username'))
+        }
+
+        const result = triggerEvent()
+        expect(result).toBe(undefined)
+      })
+      `,
+						errors: [
+							{
+								line: 9,
+								column: 24,
+								messageId: 'awaitAsyncEventWrapper',
+								data: { name: 'triggerEvent' },
+							},
+						],
+						options: [{ eventModule: 'fireEvent' }],
+						output: `
+      import { fireEvent } from '${testingFramework}'
+      test('unhandled promise assigned to a variable returned from function wrapping event method is invalid', async () => {
+        function triggerEvent() {
+          doSomething()
+          return fireEvent.${eventMethod}(getByLabelText('username'))
+        }
+
+        const result = await triggerEvent()
+        expect(result).toBe(undefined)
+      })
+      `,
+					}) as const
+			),
+			...FIRE_EVENT_ASYNC_FUNCTIONS.map(
+				(eventMethod) =>
+					({
+						code: `
+      import { fireEvent } from '${testingFramework}'
 
       function triggerEvent() {
         doSomething()
@@ -968,6 +1036,44 @@ ruleTester.run(RULE_NAME, rule, {
         }
 
         await triggerEvent()
+      })
+      `,
+					}) as const
+			),
+			...USER_EVENT_ASYNC_FUNCTIONS.map(
+				(eventMethod) =>
+					({
+						code: `
+      import userEvent from '${testingFramework}'
+      test('unhandled promise assigned to a variable returned from function wrapping event method is invalid', function() {
+        function triggerEvent() {
+          doSomething()
+          return userEvent.${eventMethod}(getByLabelText('username'))
+        }
+
+        const result = triggerEvent()
+        expect(result).toBe(undefined)
+      })
+      `,
+						errors: [
+							{
+								line: 9,
+								column: 24,
+								messageId: 'awaitAsyncEventWrapper',
+								data: { name: 'triggerEvent' },
+							},
+						],
+						options: [{ eventModule: 'userEvent' }],
+						output: `
+      import userEvent from '${testingFramework}'
+      test('unhandled promise assigned to a variable returned from function wrapping event method is invalid', async function() {
+        function triggerEvent() {
+          doSomething()
+          return userEvent.${eventMethod}(getByLabelText('username'))
+        }
+
+        const result = await triggerEvent()
+        expect(result).toBe(undefined)
       })
       `,
 					}) as const

--- a/tests/lib/rules/await-async-queries.test.ts
+++ b/tests/lib/rules/await-async-queries.test.ts
@@ -291,6 +291,23 @@ ruleTester.run(RULE_NAME, rule, {
       `,
 		})),
 
+		// handled promise assigned to variable returned from async query wrapper is valid
+		...ALL_ASYNC_COMBINATIONS_TO_TEST.map(
+			(query) =>
+				({
+					code: `
+        const queryWrapper = () => {
+          return screen.${query}('foo')
+        }
+
+        test("A valid example test", async () => {
+          const element = await queryWrapper()
+          expect(element).toBeVisible()
+        })
+      `,
+				}) as const
+		),
+
 		// non-matching query is valid
 		`
     test('A valid example test', async () => {

--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -252,6 +252,20 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
+		...ASYNC_UTILS.map((asyncUtil) => ({
+			code: `
+        import { ${asyncUtil} } from '${testingFramework}';
+
+        function waitForSomethingAsync() {
+          return ${asyncUtil}(() => somethingAsync())
+        }
+
+        test('handled promise in variable declaration from function wrapping ${asyncUtil} util is valid', async () => {
+          const result = await waitForSomethingAsync()
+          expect(result).toBe('foo')
+        });
+      `,
+		})),
 		{
 			code: `
       test('using unrelated promises with Promise.all is valid', async () => {
@@ -497,6 +511,32 @@ ruleTester.run(RULE_NAME, rule, {
 							messageId: 'asyncUtilWrapper',
 							line: 10,
 							column: 11,
+							data: { name: 'waitForSomethingAsync' },
+						},
+					],
+				}) as const
+		),
+		...ASYNC_UTILS.map(
+			(asyncUtil) =>
+				({
+					code: `
+		    import { ${asyncUtil}, render } from '${testingFramework}';
+
+		    function waitForSomethingAsync() {
+		      return ${asyncUtil}(() => somethingAsync())
+		    }
+
+		    test('unhandled promise in variable declaration from function wrapping ${asyncUtil} util is invalid', async () => {
+		      render()
+		      const result = waitForSomethingAsync()
+		      expect(result).toBe('foo')
+		    });
+		  `,
+					errors: [
+						{
+							messageId: 'asyncUtilWrapper',
+							line: 10,
+							column: 24,
 							data: { name: 'waitForSomethingAsync' },
 						},
 					],


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

This tweaks the logic in `isAssigningKnownAsyncFunctionWrapper` to account for return values being assigned to variables. This only impacted `await-async-utils`, as it is less common to assign the result of an async util to a variable than it is an async query. I've added additional test cases to `await-async-queries` and `await-async-events` to explicitly protect against regressions in this behavior.

## Context

Fixes #1046 