### PR TITLE
fix(no-node-access): support user-event instances returned from custom render

### DIFF
--- a/lib/rules/no-node-access.ts
+++ b/lib/rules/no-node-access.ts
@@ -1,10 +1,20 @@
+import {
+	DefinitionType,
+	type ScopeVariable,
+} from '@typescript-eslint/scope-manager';
 import { TSESTree, ASTUtils } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
-import { isCallExpression, isMemberExpression } from '../node-utils';
+import {
+	getDeepestIdentifierNode,
+	getPropertyIdentifierNode,
+	isCallExpression,
+	isMemberExpression,
+} from '../node-utils';
 import {
 	ALL_RETURNING_NODES,
 	EVENT_HANDLER_METHODS,
+	getScope,
 	resolveToTestingLibraryFn,
 } from '../utils';
 
@@ -88,24 +98,39 @@ export default createTestingLibraryRule<Options, MessageIds>({
 			}
 		}
 
+		function detectTestingLibraryFn(
+			node: TSESTree.CallExpression,
+			variable: ScopeVariable | null
+		) {
+			if (variable && variable.defs.length > 0) {
+				const def = variable.defs[0];
+				if (
+					def.type === DefinitionType.Variable &&
+					isCallExpression(def.node.init)
+				) {
+					return resolveToTestingLibraryFn(def.node.init, context);
+				}
+			}
+
+			return resolveToTestingLibraryFn(node, context);
+		}
+
 		return {
 			CallExpression(node: TSESTree.CallExpression) {
-				const { callee } = node;
-				const property = isMemberExpression(callee) ? callee.property : null;
-				const object = isMemberExpression(callee) ? callee.object : null;
-
-				const propertyName = ASTUtils.isIdentifier(property)
-					? property.name
-					: null;
-				const objectName = ASTUtils.isIdentifier(object) ? object.name : null;
+				const property = getDeepestIdentifierNode(node);
+				const identifier = getPropertyIdentifierNode(node);
 
 				const isEventHandlerMethod = EVENT_HANDLER_METHODS.some(
-					(method) => method === propertyName
+					(method) => method === property?.name
 				);
 				const hasUserEventInstanceName = userEventInstanceNames.has(
-					objectName ?? ''
+					identifier?.name ?? ''
 				);
-				const testingLibraryFn = resolveToTestingLibraryFn(node, context);
+
+				const variable = identifier
+					? ASTUtils.findVariable(getScope(context, node), identifier)
+					: null;
+				const testingLibraryFn = detectTestingLibraryFn(node, variable);
 
 				if (
 					!testingLibraryFn &&

--- a/tests/lib/rules/no-node-access.test.ts
+++ b/tests/lib/rules/no-node-access.test.ts
@@ -268,6 +268,22 @@ ruleTester.run(RULE_NAME, rule, {
 				});
       `,
 			},
+			{
+				settings: {
+					'testing-library/utils-module': 'TestUtils',
+					'testing-library/custom-renders': ['renderComponent'],
+				},
+				code: `
+				// case: custom module set but not imported using ${testingFramework} (aggressive reporting limited)
+        import { screen, renderComponent } from './TestUtils';
+				import MyComponent from './MyComponent'
+
+				test('...', async () => {
+					const result = renderComponent(<MyComponent />)
+					await result.user.click(screen.getByRole("button"))
+				});
+      `,
+			},
 		]
 	),
 	invalid: SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [

--- a/tests/lib/rules/no-node-access.test.ts
+++ b/tests/lib/rules/no-node-access.test.ts
@@ -231,7 +231,6 @@ ruleTester.run(RULE_NAME, rule, {
 			},
 			{
 				code: `
-				// case: custom module set but not imported using ${testingFramework} (aggressive reporting limited)
 				import { screen } from '${testingFramework}';
 
         const ui = {
@@ -240,6 +239,32 @@ ruleTester.run(RULE_NAME, rule, {
 				test('...', () => {
 					const select = ui.select.get();
 					expect(select).toHaveClass(selectClasses.select);
+				});
+      `,
+			},
+			{
+				settings: { 'testing-library/utils-module': 'test-utils' },
+				code: `
+				// case: custom module set but not imported using ${testingFramework} (aggressive reporting limited)
+        import { screen, render } from 'test-utils';
+				import MyComponent from './MyComponent'
+
+				test('...', async () => {
+					const { user } = render(<MyComponent />)
+					await user.click(screen.getByRole("button"))
+				});
+      `,
+			},
+			{
+				settings: { 'testing-library/utils-module': 'test-utils' },
+				code: `
+				// case: custom module set but not imported using ${testingFramework} (aggressive reporting limited)
+        import { screen, render } from 'test-utils';
+				import MyComponent from './MyComponent'
+
+				test('...', async () => {
+					const result = render(<MyComponent />)
+					await result.user.click(screen.getByRole("button"))
 				});
       `,
 			},

--- a/tests/lib/rules/no-node-access.test.ts
+++ b/tests/lib/rules/no-node-access.test.ts
@@ -186,6 +186,16 @@ ruleTester.run(RULE_NAME, rule, {
 			{
 				code: `
 				import userEvent from '@testing-library/user-event';
+				import { screen } from '${testingFramework}';
+				test('...', () => {
+					const buttonText = screen.getByText('submit');
+					(() => { click: userEvent.click(buttonText); })();
+				});
+      `,
+			},
+			{
+				code: `
+				import userEvent from '@testing-library/user-event';
         import { screen } from '${testingFramework}';
 
         const buttonText = screen.getByText('submit');


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- Improved detection of user-event calls from render-returned objects in custom testing utilities.

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->
Fixes: Comments below
https://github.com/testing-library/eslint-plugin-testing-library/pull/1033#pullrequestreview-3000041608