### PR TITLE
fix: support AssignmentExpression in userEvent setup detection

### DIFF
--- a/lib/rules/no-node-access.ts
+++ b/lib/rules/no-node-access.ts
@@ -12,8 +12,6 @@ export const RULE_NAME = 'no-node-access';
 export type MessageIds = 'noNodeAccess';
 export type Options = [{ allowContainerFirstChild: boolean }];
 
-const userEventInstanceNames = new Set<string>();
-
 export default createTestingLibraryRule<Options, MessageIds>({
 	name: RULE_NAME,
 	meta: {
@@ -52,6 +50,8 @@ export default createTestingLibraryRule<Options, MessageIds>({
 	],
 
 	create(context, [{ allowContainerFirstChild = false }], helpers) {
+		const userEventInstanceNames = new Set<string>();
+
 		function showErrorForNodeAccess(node: TSESTree.MemberExpression) {
 			// This rule is so aggressive that can cause tons of false positives outside test files when Aggressive Reporting
 			// is enabled. Because of that, this rule will skip this mechanism and report only if some Testing Library package
@@ -142,6 +142,26 @@ export default createTestingLibraryRule<Options, MessageIds>({
 					ASTUtils.isIdentifier(id)
 				) {
 					userEventInstanceNames.add(id.name);
+				}
+			},
+			AssignmentExpression(node: TSESTree.AssignmentExpression) {
+				if (
+					ASTUtils.isIdentifier(node.left) &&
+					isCallExpression(node.right) &&
+					isMemberExpression(node.right.callee) &&
+					ASTUtils.isIdentifier(node.right.callee.object)
+				) {
+					const testingLibraryFn = resolveToTestingLibraryFn(
+						node.right,
+						context
+					);
+					if (
+						node.right.callee.object.name === testingLibraryFn?.local &&
+						ASTUtils.isIdentifier(node.right.callee.property) &&
+						node.right.callee.property.name === 'setup'
+					) {
+						userEventInstanceNames.add(node.left.name);
+					}
 				}
 			},
 			'ExpressionStatement MemberExpression': showErrorForNodeAccess,

--- a/tests/lib/rules/no-node-access.test.ts
+++ b/tests/lib/rules/no-node-access.test.ts
@@ -213,6 +213,43 @@ ruleTester.run(RULE_NAME, rule, {
 			},
 			{
 				code: `
+				import { screen } from '${testingFramework}';
+				import userEvent from '@testing-library/user-event';
+
+				describe('Testing', () => {
+					let user;
+
+					beforeEach(() => {
+						user = userEvent.setup();
+					});
+
+					it('test 1', async () => {
+						await user.click(screen.getByRole('button'));
+					});
+				});
+      `,
+			},
+			{
+				settings: { 'testing-library/utils-module': 'test-utils' },
+				code: `
+				// case: custom module set but not imported using ${testingFramework} (aggressive reporting limited)
+				import { screen, userEvent } from 'test-utils';
+
+				describe('Testing', () => {
+					let user;
+
+					beforeEach(() => {
+						user = userEvent.setup();
+					});
+
+					it('test 1', async () => {
+						await user.click(screen.getByRole('button'));
+					});
+				});
+      `,
+			},
+			{
+				code: `
         import { screen, fireEvent as fe } from '${testingFramework}';
 
         const buttonText = screen.getByText('submit');


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- Add support for detecting userEvent instances assigned via AssignmentExpression.
- Move `userEventInstanceNames` into the `create` function scope to avoid cross-file caching issues.

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->
- https://github.com/testing-library/eslint-plugin-testing-library/issues/1038#issuecomment-3062146982
- https://github.com/testing-library/eslint-plugin-testing-library/issues/1057