### PR TITLE
fix: allow un-called async util references

### DIFF
--- a/lib/rules/await-async-utils.ts
+++ b/lib/rules/await-async-utils.ts
@@ -121,20 +121,29 @@ export default createTestingLibraryRule<Options, MessageIds>({
 					functionWrappersNames.push((node.id as TSESTree.Identifier).name);
 				}
 			},
-			'CallExpression Identifier'(node: TSESTree.Identifier) {
+			CallExpression(node: TSESTree.CallExpression) {
+				const callExpressionIdentifier = getDeepestIdentifierNode(node);
+
+				if (!callExpressionIdentifier) {
+					return;
+				}
+
 				const isAsyncUtilOrKnownAliasAroundIt =
-					helpers.isAsyncUtil(node) ||
-					functionWrappersNames.includes(node.name);
+					helpers.isAsyncUtil(callExpressionIdentifier) ||
+					functionWrappersNames.includes(callExpressionIdentifier.name);
 				if (!isAsyncUtilOrKnownAliasAroundIt) {
 					return;
 				}
 
 				// detect async query used within wrapper function for later analysis
-				if (helpers.isAsyncUtil(node)) {
-					detectAsyncUtilWrapper(node);
+				if (helpers.isAsyncUtil(callExpressionIdentifier)) {
+					detectAsyncUtilWrapper(callExpressionIdentifier);
 				}
 
-				const closestCallExpression = findClosestCallExpressionNode(node, true);
+				const closestCallExpression = findClosestCallExpressionNode(
+					callExpressionIdentifier,
+					true
+				);
 
 				if (!closestCallExpression?.parent) {
 					return;
@@ -146,12 +155,12 @@ export default createTestingLibraryRule<Options, MessageIds>({
 				);
 
 				if (references.length === 0) {
-					if (!isPromiseHandled(node)) {
+					if (!isPromiseHandled(callExpressionIdentifier)) {
 						context.report({
-							node,
-							messageId: getMessageId(node),
+							node: callExpressionIdentifier,
+							messageId: getMessageId(callExpressionIdentifier),
 							data: {
-								name: node.name,
+								name: callExpressionIdentifier.name,
 							},
 						});
 					}
@@ -160,10 +169,10 @@ export default createTestingLibraryRule<Options, MessageIds>({
 						const referenceNode = reference.identifier as TSESTree.Identifier;
 						if (!isPromiseHandled(referenceNode)) {
 							context.report({
-								node,
-								messageId: getMessageId(node),
+								node: callExpressionIdentifier,
+								messageId: getMessageId(callExpressionIdentifier),
 								data: {
-									name: node.name,
+									name: callExpressionIdentifier.name,
 								},
 							});
 							return;

--- a/tests/lib/rules/await-async-queries.test.ts
+++ b/tests/lib/rules/await-async-queries.test.ts
@@ -113,6 +113,11 @@ ruleTester.run(RULE_NAME, rule, {
 			testingFramework: '@marko/testing-library',
 		}),
 
+		// async queries not called are valid
+		...createTestCase((query) => `expect(screen.${query}).toBeDefined()`, {
+			isAsync: false,
+		}),
+
 		// async queries are valid with await operator
 		...createTestCase(
 			(query) => `

--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -296,6 +296,23 @@ ruleTester.run(RULE_NAME, rule, {
         })
       `,
 		},
+		{
+			// edge case for coverage: CallExpressions without deepest identifiers
+			code: `
+        import { waitFor } from '${testingFramework}';
+        test('coverage test for CallExpressions without identifiers', () => {
+          const asyncUtil = waitFor
+
+          // These CallExpressions have no deepest identifier:
+          const funcs = [() => console.log('test')]
+          const obj = { [Symbol.iterator]: () => 'symbol' }
+
+          funcs[0]()
+          obj[Symbol.iterator]()
+          (function() { return 'iife' })()
+        });
+      `,
+		},
 		...ASYNC_UTILS.map((asyncUtil) => ({
 			code: `
 				// implicitly using ${testingFramework}

--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -36,6 +36,14 @@ ruleTester.run(RULE_NAME, rule, {
 		...ASYNC_UTILS.map((asyncUtil) => ({
 			code: `
         import { ${asyncUtil} } from '${testingFramework}';
+        test('${asyncUtil} util not called is valid', () => {
+          expect(${asyncUtil}).toBeDefined();
+        });
+      `,
+		})),
+		...ASYNC_UTILS.map((asyncUtil) => ({
+			code: `
+        import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util directly chained with then is valid', () => {
           doSomethingElse();
           ${asyncUtil}(() => getByLabelText('email')).then(() => { console.log('done') });


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

This prevents false positives for the case where async utils are referenced but not called. This matches the behavior in both `await-async-events` and `await-async-queries`. `await-async-events` explicitly tests for this behavior [here](https://github.com/puglyfe/eslint-plugin-testing-library/blob/allow-async-refs/tests/lib/rules/await-async-events.test.ts#L43-L51) and [here](https://github.com/puglyfe/eslint-plugin-testing-library/blob/allow-async-refs/tests/lib/rules/await-async-events.test.ts#L282-L290). `await-async-queries` doesn't explicitly test for this, but follows a similar implementation of only processing `CallExpression` nodes rather than `CallExpression Identifier` nodes.

- Allow un-called references in `await-async-utils`
- Add tests to `await-async-queries` to prevent regressions in existing behavior

## Context

fixes #1060 