### PR TITLE
fix(await-async-event): prevent adding async/await in forEach loops

### DIFF
--- a/lib/rules/await-async-events.ts
+++ b/lib/rules/await-async-events.ts
@@ -4,6 +4,7 @@ import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {
 	findClosestCallExpressionNode,
 	findClosestFunctionExpressionNode,
+	getDeepestIdentifierNode,
 	getFunctionName,
 	getInnermostReturningFunction,
 	getVariableReferences,
@@ -153,6 +154,13 @@ export default createTestingLibraryRule<Options, MessageIds>({
 										findClosestFunctionExpressionNode(node);
 
 									if (functionExpression) {
+										const deepestCalleeIdentifier = getDeepestIdentifierNode(
+											functionExpression.parent
+										);
+										if (deepestCalleeIdentifier?.name === 'forEach') {
+											return null;
+										}
+
 										const memberExpressionFixer = fixer.insertTextBefore(
 											node.parent,
 											'await '

--- a/tests/lib/rules/await-async-events.test.ts
+++ b/tests/lib/rules/await-async-events.test.ts
@@ -1269,5 +1269,24 @@ ruleTester.run(RULE_NAME, rule, {
       })
       `,
 		},
+		{
+			code: `
+			import userEvent from '${USER_EVENT_ASYNC_FRAMEWORKS[0]}'
+			test('setup method called is valid', () => {
+				const foo = [];
+				foo.forEach(() => {
+					userEvent.click();
+				});
+			})
+				`,
+			errors: [
+				{
+					line: 6,
+					column: 6,
+					messageId: 'awaitAsyncEvent',
+					data: { name: 'click' },
+				},
+			],
+		},
 	],
 });


### PR DESCRIPTION
## Checks

- [ ] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- add support for handling `forEach` in async event method detection

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->
Fixes #843 