### PR TITLE
refactor: enforce strict types in test case mapping

### DIFF
--- a/tests/lib/rules/await-async-utils.test.ts
+++ b/tests/lib/rules/await-async-utils.test.ts
@@ -2,6 +2,15 @@ import rule, { RULE_NAME } from '../../../lib/rules/await-async-utils';
 import { ASYNC_UTILS } from '../../../lib/utils';
 import { createRuleTester } from '../test-utils';
 
+import type { MessageIds } from '../../../lib/rules/await-async-utils';
+import type {
+	InvalidTestCase,
+	ValidTestCase,
+} from '@typescript-eslint/rule-tester';
+
+type RuleValidTestCase = ValidTestCase<[]>;
+type RuleInvalidTestCase = InvalidTestCase<MessageIds, []>;
+
 const ruleTester = createRuleTester();
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
@@ -14,7 +23,7 @@ const SUPPORTED_TESTING_FRAMEWORKS = [
 
 ruleTester.run(RULE_NAME, rule, {
 	valid: SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util directly waited with await operator is valid', async () => {
@@ -23,7 +32,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util promise saved in var and waited with await operator is valid', async () => {
@@ -33,7 +42,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util not called is valid', () => {
@@ -41,7 +50,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util directly chained with then is valid', () => {
@@ -50,7 +59,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util directly chained with catch is valid', () => {
@@ -59,7 +68,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util expect chained with .resolves is valid', () => {
@@ -68,7 +77,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util expect chained with .toResolve is valid', () => {
@@ -77,7 +86,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util expect chained with jasmine async matchers are valid', () => {
@@ -91,7 +100,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util promise saved in var and chained with then is valid', () => {
@@ -101,7 +110,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util directly returned in arrow function is valid', async () => {
@@ -112,7 +121,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util explicitly returned in arrow function is valid', async () => {
@@ -124,7 +133,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util returned in regular function is valid', async () => {
@@ -136,7 +145,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util promise saved in var and returned in function is valid', async () => {
@@ -152,7 +161,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			settings: {
 				'testing-library/utils-module': 'test-utils',
 			},
@@ -166,7 +175,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			settings: {
 				'testing-library/utils-module': 'test-utils',
 			},
@@ -180,7 +189,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util used in with Promise.all() is valid', async () => {
@@ -191,7 +200,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util used in with Promise.all() with an await is valid', async () => {
@@ -202,7 +211,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util used in with Promise.all() with ".then" is valid', async () => {
@@ -234,7 +243,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		},
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util used in Promise.allSettled + await expression is valid', async () => {
@@ -245,7 +254,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util used in Promise.allSettled + then method is valid', async () => {
@@ -256,7 +265,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			code: `
         import { ${asyncUtil} } from '${testingFramework}';
 
@@ -269,7 +278,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			code: `
         import { ${asyncUtil} } from '${testingFramework}';
 
@@ -322,7 +331,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		},
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			code: `
 				// implicitly using ${testingFramework}
         function setup() {
@@ -357,7 +366,7 @@ ruleTester.run(RULE_NAME, rule, {
         });
       `,
 		})),
-		...ASYNC_UTILS.map((asyncUtil) => ({
+		...ASYNC_UTILS.map<RuleValidTestCase>((asyncUtil) => ({
 			code: `
           import React from 'react';
           import { render, act } from '${testingFramework}';
@@ -391,90 +400,76 @@ ruleTester.run(RULE_NAME, rule, {
 		})),
 	]),
 	invalid: SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
-		...ASYNC_UTILS.map(
-			(asyncUtil) =>
-				({
-					code: `
+		...ASYNC_UTILS.map<RuleInvalidTestCase>((asyncUtil) => ({
+			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util not waited is invalid', () => {
           doSomethingElse();
           ${asyncUtil}(() => getByLabelText('email'));
         });
       `,
-					errors: [
-						{
-							line: 5,
-							column: 11,
-							messageId: 'awaitAsyncUtil',
-							data: { name: asyncUtil },
-						},
-					],
-				}) as const
-		),
-		...ASYNC_UTILS.map(
-			(asyncUtil) =>
-				({
-					code: `
+			errors: [
+				{
+					line: 5,
+					column: 11,
+					messageId: 'awaitAsyncUtil',
+					data: { name: asyncUtil },
+				},
+			],
+		})),
+		...ASYNC_UTILS.map<RuleInvalidTestCase>((asyncUtil) => ({
+			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util not waited is invalid', () => {
           doSomethingElse();
           const el = ${asyncUtil}(() => getByLabelText('email'));
         });
       `,
-					errors: [
-						{
-							line: 5,
-							column: 22,
-							messageId: 'awaitAsyncUtil',
-							data: { name: asyncUtil },
-						},
-					],
-				}) as const
-		),
-		...ASYNC_UTILS.map(
-			(asyncUtil) =>
-				({
-					code: `
+			errors: [
+				{
+					line: 5,
+					column: 22,
+					messageId: 'awaitAsyncUtil',
+					data: { name: asyncUtil },
+				},
+			],
+		})),
+		...ASYNC_UTILS.map<RuleInvalidTestCase>((asyncUtil) => ({
+			code: `
         import * as asyncUtil from '${testingFramework}';
         test('asyncUtil.${asyncUtil} util not handled is invalid', () => {
           doSomethingElse();
           asyncUtil.${asyncUtil}(() => getByLabelText('email'));
         });
       `,
-					errors: [
-						{
-							line: 5,
-							column: 21,
-							messageId: 'awaitAsyncUtil',
-							data: { name: asyncUtil },
-						},
-					],
-				}) as const
-		),
-		...ASYNC_UTILS.map(
-			(asyncUtil) =>
-				({
-					code: `
+			errors: [
+				{
+					line: 5,
+					column: 21,
+					messageId: 'awaitAsyncUtil',
+					data: { name: asyncUtil },
+				},
+			],
+		})),
+		...ASYNC_UTILS.map<RuleInvalidTestCase>((asyncUtil) => ({
+			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('${asyncUtil} util promise saved not handled is invalid', () => {
           doSomethingElse();
           const aPromise = ${asyncUtil}(() => getByLabelText('email'));
         });
       `,
-					errors: [
-						{
-							line: 5,
-							column: 28,
-							messageId: 'awaitAsyncUtil',
-							data: { name: asyncUtil },
-						},
-					],
-				}) as const
-		),
-		...ASYNC_UTILS.map(
-			(asyncUtil) =>
-				({
-					code: `
+			errors: [
+				{
+					line: 5,
+					column: 28,
+					messageId: 'awaitAsyncUtil',
+					data: { name: asyncUtil },
+				},
+			],
+		})),
+		...ASYNC_UTILS.map<RuleInvalidTestCase>((asyncUtil) => ({
+			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('several ${asyncUtil} utils not handled are invalid', () => {
           const aPromise = ${asyncUtil}(() => getByLabelText('username'));
@@ -482,26 +477,23 @@ ruleTester.run(RULE_NAME, rule, {
           ${asyncUtil}(() => getByLabelText('email'));
         });
       `,
-					errors: [
-						{
-							line: 4,
-							column: 28,
-							messageId: 'awaitAsyncUtil',
-							data: { name: asyncUtil },
-						},
-						{
-							line: 6,
-							column: 11,
-							messageId: 'awaitAsyncUtil',
-							data: { name: asyncUtil },
-						},
-					],
-				}) as const
-		),
-		...ASYNC_UTILS.map(
-			(asyncUtil) =>
-				({
-					code: `
+			errors: [
+				{
+					line: 4,
+					column: 28,
+					messageId: 'awaitAsyncUtil',
+					data: { name: asyncUtil },
+				},
+				{
+					line: 6,
+					column: 11,
+					messageId: 'awaitAsyncUtil',
+					data: { name: asyncUtil },
+				},
+			],
+		})),
+		...ASYNC_UTILS.map<RuleInvalidTestCase>((asyncUtil) => ({
+			code: `
         import { ${asyncUtil} } from '${testingFramework}';
         test('unhandled expression that evaluates to promise is invalid', () => {
           const aPromise = ${asyncUtil}(() => getByLabelText('username'));
@@ -509,26 +501,23 @@ ruleTester.run(RULE_NAME, rule, {
           ${asyncUtil}(() => getByLabelText('email'));
         });
       `,
-					errors: [
-						{
-							line: 4,
-							column: 28,
-							messageId: 'awaitAsyncUtil',
-							data: { name: asyncUtil },
-						},
-						{
-							line: 6,
-							column: 11,
-							messageId: 'awaitAsyncUtil',
-							data: { name: asyncUtil },
-						},
-					],
-				}) as const
-		),
-		...ASYNC_UTILS.map(
-			(asyncUtil) =>
-				({
-					code: `
+			errors: [
+				{
+					line: 4,
+					column: 28,
+					messageId: 'awaitAsyncUtil',
+					data: { name: asyncUtil },
+				},
+				{
+					line: 6,
+					column: 11,
+					messageId: 'awaitAsyncUtil',
+					data: { name: asyncUtil },
+				},
+			],
+		})),
+		...ASYNC_UTILS.map<RuleInvalidTestCase>((asyncUtil) => ({
+			code: `
         import { ${asyncUtil}, render } from '${testingFramework}';
 
         function waitForSomethingAsync() {
@@ -540,20 +529,17 @@ ruleTester.run(RULE_NAME, rule, {
           waitForSomethingAsync()
         });
       `,
-					errors: [
-						{
-							messageId: 'asyncUtilWrapper',
-							line: 10,
-							column: 11,
-							data: { name: 'waitForSomethingAsync' },
-						},
-					],
-				}) as const
-		),
-		...ASYNC_UTILS.map(
-			(asyncUtil) =>
-				({
-					code: `
+			errors: [
+				{
+					messageId: 'asyncUtilWrapper',
+					line: 10,
+					column: 11,
+					data: { name: 'waitForSomethingAsync' },
+				},
+			],
+		})),
+		...ASYNC_UTILS.map<RuleInvalidTestCase>((asyncUtil) => ({
+			code: `
 		    import { ${asyncUtil}, render } from '${testingFramework}';
 
 		    function waitForSomethingAsync() {
@@ -566,20 +552,17 @@ ruleTester.run(RULE_NAME, rule, {
 		      expect(result).toBe('foo')
 		    });
 		  `,
-					errors: [
-						{
-							messageId: 'asyncUtilWrapper',
-							line: 10,
-							column: 24,
-							data: { name: 'waitForSomethingAsync' },
-						},
-					],
-				}) as const
-		),
-		...ASYNC_UTILS.map(
-			(asyncUtil) =>
-				({
-					code: `
+			errors: [
+				{
+					messageId: 'asyncUtilWrapper',
+					line: 10,
+					column: 24,
+					data: { name: 'waitForSomethingAsync' },
+				},
+			],
+		})),
+		...ASYNC_UTILS.map<RuleInvalidTestCase>((asyncUtil) => ({
+			code: `
         import { ${asyncUtil} } from 'some-other-library'; // rather than ${testingFramework}
         test(
         'aggressive reporting - util "${asyncUtil}" which is not related to testing library is invalid',
@@ -588,20 +571,17 @@ ruleTester.run(RULE_NAME, rule, {
           ${asyncUtil}();
         });
       `,
-					errors: [
-						{
-							line: 7,
-							column: 11,
-							messageId: 'awaitAsyncUtil',
-							data: { name: asyncUtil },
-						},
-					],
-				}) as const
-		),
-		...ASYNC_UTILS.map(
-			(asyncUtil) =>
-				({
-					code: `
+			errors: [
+				{
+					line: 7,
+					column: 11,
+					messageId: 'awaitAsyncUtil',
+					data: { name: asyncUtil },
+				},
+			],
+		})),
+		...ASYNC_UTILS.map<RuleInvalidTestCase>((asyncUtil) => ({
+			code: `
         import { ${asyncUtil}, render } from '${testingFramework}';
 
         function waitForSomethingAsync() {
@@ -613,21 +593,18 @@ ruleTester.run(RULE_NAME, rule, {
           const el = waitForSomethingAsync()
         });
       `,
-					errors: [
-						{
-							messageId: 'asyncUtilWrapper',
-							line: 10,
-							column: 22,
-							data: { name: 'waitForSomethingAsync' },
-						},
-					],
-				}) as const
-		),
+			errors: [
+				{
+					messageId: 'asyncUtilWrapper',
+					line: 10,
+					column: 22,
+					data: { name: 'waitForSomethingAsync' },
+				},
+			],
+		})),
 
-		...ASYNC_UTILS.map(
-			(asyncUtil) =>
-				({
-					code: `
+		...ASYNC_UTILS.map<RuleInvalidTestCase>((asyncUtil) => ({
+			code: `
         import * as asyncUtils from 'some-other-library'; // rather than ${testingFramework}
         test(
         'aggressive reporting - util "asyncUtils.${asyncUtil}" which is not related to testing library is invalid',
@@ -636,20 +613,17 @@ ruleTester.run(RULE_NAME, rule, {
           asyncUtils.${asyncUtil}();
         });
       `,
-					errors: [
-						{
-							line: 7,
-							column: 22,
-							messageId: 'awaitAsyncUtil',
-							data: { name: asyncUtil },
-						},
-					],
-				}) as const
-		),
-		...ASYNC_UTILS.map(
-			(asyncUtil) =>
-				({
-					code: `
+			errors: [
+				{
+					line: 7,
+					column: 22,
+					messageId: 'awaitAsyncUtil',
+					data: { name: asyncUtil },
+				},
+			],
+		})),
+		...ASYNC_UTILS.map<RuleInvalidTestCase>((asyncUtil) => ({
+			code: `
 				// implicitly using ${testingFramework}
         function setup() {
           const utils = render(<MyComponent />);
@@ -666,20 +640,17 @@ ruleTester.run(RULE_NAME, rule, {
           waitForAsyncUtil();
         });
       `,
-					errors: [
-						{
-							line: 15,
-							column: 11,
-							messageId: 'asyncUtilWrapper',
-							data: { name: 'waitForAsyncUtil' },
-						},
-					],
-				}) as const
-		),
-		...ASYNC_UTILS.map(
-			(asyncUtil) =>
-				({
-					code: `
+			errors: [
+				{
+					line: 15,
+					column: 11,
+					messageId: 'asyncUtilWrapper',
+					data: { name: 'waitForAsyncUtil' },
+				},
+			],
+		})),
+		...ASYNC_UTILS.map<RuleInvalidTestCase>((asyncUtil) => ({
+			code: `
 				// implicitly using ${testingFramework}
         function setup() {
           const utils = render(<MyComponent />);
@@ -697,20 +668,17 @@ ruleTester.run(RULE_NAME, rule, {
           myAlias();
         });
       `,
-					errors: [
-						{
-							line: 16,
-							column: 11,
-							messageId: 'asyncUtilWrapper',
-							data: { name: 'myAlias' },
-						},
-					],
-				}) as const
-		),
-		...ASYNC_UTILS.map(
-			(asyncUtil) =>
-				({
-					code: `
+			errors: [
+				{
+					line: 16,
+					column: 11,
+					messageId: 'asyncUtilWrapper',
+					data: { name: 'myAlias' },
+				},
+			],
+		})),
+		...ASYNC_UTILS.map<RuleInvalidTestCase>((asyncUtil) => ({
+			code: `
 				// implicitly using ${testingFramework}
         function setup() {
           const utils = render(<MyComponent />);
@@ -727,20 +695,17 @@ ruleTester.run(RULE_NAME, rule, {
           clone.waitForAsyncUtil();
         });
       `,
-					errors: [
-						{
-							line: 15,
-							column: 17,
-							messageId: 'asyncUtilWrapper',
-							data: { name: 'waitForAsyncUtil' },
-						},
-					],
-				}) as const
-		),
-		...ASYNC_UTILS.map(
-			(asyncUtil) =>
-				({
-					code: `
+			errors: [
+				{
+					line: 15,
+					column: 17,
+					messageId: 'asyncUtilWrapper',
+					data: { name: 'waitForAsyncUtil' },
+				},
+			],
+		})),
+		...ASYNC_UTILS.map<RuleInvalidTestCase>((asyncUtil) => ({
+			code: `
 				// implicitly using ${testingFramework}
         function setup() {
           const utils = render(<MyComponent />);
@@ -757,20 +722,17 @@ ruleTester.run(RULE_NAME, rule, {
           myAlias();
         });
       `,
-					errors: [
-						{
-							line: 15,
-							column: 11,
-							messageId: 'asyncUtilWrapper',
-							data: { name: 'myAlias' },
-						},
-					],
-				}) as const
-		),
-		...ASYNC_UTILS.map(
-			(asyncUtil) =>
-				({
-					code: `
+			errors: [
+				{
+					line: 15,
+					column: 11,
+					messageId: 'asyncUtilWrapper',
+					data: { name: 'myAlias' },
+				},
+			],
+		})),
+		...ASYNC_UTILS.map<RuleInvalidTestCase>((asyncUtil) => ({
+			code: `
 				// implicitly using ${testingFramework}
         function setup() {
           const utils = render(<MyComponent />);
@@ -786,20 +748,17 @@ ruleTester.run(RULE_NAME, rule, {
           setup().waitForAsyncUtil();
         });
       `,
-					errors: [
-						{
-							line: 14,
-							column: 19,
-							messageId: 'asyncUtilWrapper',
-							data: { name: 'waitForAsyncUtil' },
-						},
-					],
-				}) as const
-		),
-		...ASYNC_UTILS.map(
-			(asyncUtil) =>
-				({
-					code: `
+			errors: [
+				{
+					line: 14,
+					column: 19,
+					messageId: 'asyncUtilWrapper',
+					data: { name: 'waitForAsyncUtil' },
+				},
+			],
+		})),
+		...ASYNC_UTILS.map<RuleInvalidTestCase>((asyncUtil) => ({
+			code: `
 				// implicitly using ${testingFramework}
         function setup() {
           const utils = render(<MyComponent />);
@@ -816,15 +775,14 @@ ruleTester.run(RULE_NAME, rule, {
           myAlias();
         });
       `,
-					errors: [
-						{
-							line: 15,
-							column: 11,
-							messageId: 'asyncUtilWrapper',
-							data: { name: 'myAlias' },
-						},
-					],
-				}) as const
-		),
+			errors: [
+				{
+					line: 15,
+					column: 11,
+					messageId: 'asyncUtilWrapper',
+					data: { name: 'myAlias' },
+				},
+			],
+		})),
 	]),
 });

--- a/tests/lib/rules/no-wait-for-multiple-assertions.test.ts
+++ b/tests/lib/rules/no-wait-for-multiple-assertions.test.ts
@@ -3,6 +3,15 @@ import rule, {
 } from '../../../lib/rules/no-wait-for-multiple-assertions';
 import { createRuleTester } from '../test-utils';
 
+import type { MessageIds } from '../../../lib/rules/no-wait-for-multiple-assertions';
+import type {
+	InvalidTestCase,
+	ValidTestCase,
+} from '@typescript-eslint/rule-tester';
+
+type RuleValidTestCase = ValidTestCase<[]>;
+type RuleInvalidTestCase = InvalidTestCase<MessageIds, []>;
+
 const ruleTester = createRuleTester();
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
@@ -37,9 +46,10 @@ ruleTester.run(RULE_NAME, rule, {
         })
       `,
 		},
-		...SUPPORTED_TESTING_FRAMEWORKS.map((testingFramework) => ({
-			settings: { 'testing-library/utils-module': 'test-utils' },
-			code: `// Aggressive Reporting disabled - waitFor renamed
+		...SUPPORTED_TESTING_FRAMEWORKS.map<RuleValidTestCase>(
+			(testingFramework) => ({
+				settings: { 'testing-library/utils-module': 'test-utils' },
+				code: `// Aggressive Reporting disabled - waitFor renamed
         import { waitFor as renamedWaitFor } from '${testingFramework}'
         import { waitFor } from 'somewhere-else'
         await waitFor(() => {
@@ -47,7 +57,8 @@ ruleTester.run(RULE_NAME, rule, {
           expect(b).toEqual('b')
         })
       `,
-		})),
+			})
+		),
 		// this needs to be check by other rule
 		{
 			code: `
@@ -111,21 +122,20 @@ ruleTester.run(RULE_NAME, rule, {
 				{ line: 4, column: 11, messageId: 'noWaitForMultipleAssertion' },
 			],
 		},
-		...SUPPORTED_TESTING_FRAMEWORKS.map(
-			(testingFramework) =>
-				({
-					settings: { 'testing-library/utils-module': 'test-utils' },
-					code: `// Aggressive Reporting disabled
+		...SUPPORTED_TESTING_FRAMEWORKS.map<RuleInvalidTestCase>(
+			(testingFramework) => ({
+				settings: { 'testing-library/utils-module': 'test-utils' },
+				code: `// Aggressive Reporting disabled
         import { waitFor } from '${testingFramework}'
         await waitFor(() => {
           expect(a).toEqual('a')
           expect(b).toEqual('b')
         })
       `,
-					errors: [
-						{ line: 5, column: 11, messageId: 'noWaitForMultipleAssertion' },
-					],
-				}) as const
+				errors: [
+					{ line: 5, column: 11, messageId: 'noWaitForMultipleAssertion' },
+				],
+			})
 		),
 		{
 			settings: { 'testing-library/utils-module': 'test-utils' },

--- a/tests/lib/rules/no-wait-for-side-effects.test.ts
+++ b/tests/lib/rules/no-wait-for-side-effects.test.ts
@@ -4,7 +4,13 @@ import rule, {
 } from '../../../lib/rules/no-wait-for-side-effects';
 import { createRuleTester } from '../test-utils';
 
-import type { InvalidTestCase } from '@typescript-eslint/rule-tester';
+import type {
+	InvalidTestCase,
+	ValidTestCase,
+} from '@typescript-eslint/rule-tester';
+
+type RuleValidTestCase = ValidTestCase<[]>;
+type RuleInvalidTestCase = InvalidTestCase<MessageIds, []>;
 
 const ruleTester = createRuleTester();
 
@@ -18,97 +24,98 @@ const SUPPORTED_TESTING_FRAMEWORKS = [
 
 ruleTester.run(RULE_NAME, rule, {
 	valid: [
-		...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
-			{
-				code: `
+		...SUPPORTED_TESTING_FRAMEWORKS.flatMap<RuleValidTestCase>(
+			(testingFramework) => [
+				{
+					code: `
           import { waitFor } from '${testingFramework}';
           await waitFor(() => expect(a).toEqual('a'))
         `,
-			},
-			{
-				code: `
+				},
+				{
+					code: `
           import { waitFor } from '${testingFramework}';
           await waitFor(function() {
             expect(a).toEqual('a')
           })
         `,
-			},
-			{
-				code: `
+				},
+				{
+					code: `
           import { waitFor } from '${testingFramework}';
           await waitFor(() => {
             console.log('testing-library')
             expect(b).toEqual('b')
           })
         `,
-			},
-			{
-				code: `
+				},
+				{
+					code: `
           import { waitFor } from '${testingFramework}';
           await waitFor(function() {
             console.log('testing-library')
             expect(b).toEqual('b')
           })
         `,
-			},
-			{
-				code: `
+				},
+				{
+					code: `
           import { waitFor } from '${testingFramework}';
           await waitFor(() => {})
         `,
-			},
-			{
-				code: `
+				},
+				{
+					code: `
           import { waitFor } from '${testingFramework}';
           await waitFor(function() {})
         `,
-			},
-			{
-				code: `
+				},
+				{
+					code: `
           import { waitFor } from '${testingFramework}';
           await waitFor(() => {
             // testing
           })
         `,
-			},
-			{
-				code: `
+				},
+				{
+					code: `
           import { waitFor } from '${testingFramework}';
           await waitFor(function() {
             // testing
           })
         `,
-			},
-			{
-				code: `
+				},
+				{
+					code: `
           import { waitFor } from '${testingFramework}';
           fireEvent.keyDown(input, {key: 'ArrowDown'})
           await waitFor(() => {
             expect(b).toEqual('b')
           })
         `,
-			},
-			{
-				code: `
+				},
+				{
+					code: `
           import { waitFor } from '${testingFramework}';
           fireEvent.keyDown(input, {key: 'ArrowDown'})
           await waitFor(function() {
             expect(b).toEqual('b')
           })
         `,
-			},
-			{
-				code: `
+				},
+				{
+					code: `
           import { waitFor } from '${testingFramework}';
           userEvent.click(button)
           await waitFor(function() {
             expect(b).toEqual('b')
           })
         `,
-			},
-			{
-				// Issue #500, https://github.com/testing-library/eslint-plugin-testing-library/issues/500
-				code: `
+				},
+				{
+					// Issue #500, https://github.com/testing-library/eslint-plugin-testing-library/issues/500
+					code: `
           import { waitFor } from '${testingFramework}';
           userEvent.click(button)
           waitFor(function() {
@@ -118,9 +125,9 @@ ruleTester.run(RULE_NAME, rule, {
             userEvent.click(button);
           })
         `,
-			},
-			{
-				code: `
+				},
+				{
+					code: `
           import { waitFor } from '${testingFramework}';
           import { notUserEvent } from 'somewhere-else';
 
@@ -128,8 +135,9 @@ ruleTester.run(RULE_NAME, rule, {
             await notUserEvent.click(button)
           })
         `,
-			},
-		]),
+				},
+			]
+		),
 		{
 			settings: { 'testing-library/utils-module': 'test-utils' },
 			code: `
@@ -140,8 +148,9 @@ ruleTester.run(RULE_NAME, rule, {
         })
       `,
 		},
-		...SUPPORTED_TESTING_FRAMEWORKS.map((testingFramework) => ({
-			code: `
+		...SUPPORTED_TESTING_FRAMEWORKS.map<RuleValidTestCase>(
+			(testingFramework) => ({
+				code: `
         import { waitFor } from '${testingFramework}';
 
         anotherFunction(() => {
@@ -155,7 +164,8 @@ ruleTester.run(RULE_NAME, rule, {
           expect(b).toEqual('b')
         });
       `,
-		})),
+			})
+		),
 		{
 			settings: { 'testing-library/utils-module': 'test-utils' },
 			code: `
@@ -203,14 +213,16 @@ ruleTester.run(RULE_NAME, rule, {
         await waitFor(() => fireEvent.keyDown(input, {key: 'ArrowDown'}))
       `,
 		},
-		...SUPPORTED_TESTING_FRAMEWORKS.map((testingFramework) => ({
-			settings: { 'testing-library/utils-module': 'test-utils' },
-			code: `
+		...SUPPORTED_TESTING_FRAMEWORKS.map<RuleValidTestCase>(
+			(testingFramework) => ({
+				settings: { 'testing-library/utils-module': 'test-utils' },
+				code: `
         import { waitFor } from 'somewhere-else';
         import { userEvent } from '${testingFramework}';
         await waitFor(() => userEvent.click(button))
       `,
-		})),
+			})
+		),
 		{
 			settings: { 'testing-library/utils-module': '~/test-utils' },
 			code: `
@@ -252,44 +264,46 @@ ruleTester.run(RULE_NAME, rule, {
         await waitFor(() => render(<App />))
       `,
 		},
-		...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
-			{
-				settings: { 'testing-library/utils-module': '~/test-utils' },
-				code: `
+		...SUPPORTED_TESTING_FRAMEWORKS.flatMap<RuleValidTestCase>(
+			(testingFramework) => [
+				{
+					settings: { 'testing-library/utils-module': '~/test-utils' },
+					code: `
           import { waitFor } from '${testingFramework}';
           import { render } from 'somewhere-else';
           await waitFor(() => render(<App />))
         `,
-			},
-			{
-				settings: { 'testing-library/custom-renders': ['renderHelper'] },
-				code: `
+				},
+				{
+					settings: { 'testing-library/custom-renders': ['renderHelper'] },
+					code: `
           import { waitFor } from '${testingFramework}';
           import { renderWrapper } from 'somewhere-else';
           await waitFor(() => renderWrapper(<App />))
         `,
-			},
-			{
-				settings: { 'testing-library/custom-renders': ['renderHelper'] },
-				code: `
+				},
+				{
+					settings: { 'testing-library/custom-renders': ['renderHelper'] },
+					code: `
           import { waitFor } from '${testingFramework}';
           import { renderWrapper } from 'somewhere-else';
           await waitFor(() => {
             renderWrapper(<App />)
           })
         `,
-			},
-			{
-				settings: { 'testing-library/custom-renders': ['renderHelper'] },
-				code: `
+				},
+				{
+					settings: { 'testing-library/custom-renders': ['renderHelper'] },
+					code: `
           import { waitFor } from '${testingFramework}';
           import { renderWrapper } from 'somewhere-else';
           await waitFor(() => {
             const { container } = renderWrapper(<App />)
           })
         `,
-			},
-		]),
+				},
+			]
+		),
 		{
 			settings: { 'testing-library/utils-module': 'test-utils' },
 			code: `
@@ -309,15 +323,17 @@ ruleTester.run(RULE_NAME, rule, {
         })
       `,
 		},
-		...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
-			{
-				settings: { 'testing-library/custom-renders': ['renderHelper'] },
-				code: `
+		...SUPPORTED_TESTING_FRAMEWORKS.flatMap<RuleValidTestCase>(
+			(testingFramework) => [
+				{
+					settings: { 'testing-library/custom-renders': ['renderHelper'] },
+					code: `
           import { waitFor } from '${testingFramework}';
           await waitFor(() => result = renderWrapper(<App />))
         `,
-			},
-		]),
+				},
+			]
+		),
 		{
 			settings: { 'testing-library/utils-module': 'test-utils' },
 			code: `
@@ -336,66 +352,67 @@ ruleTester.run(RULE_NAME, rule, {
 	],
 	invalid: [
 		// render
-		...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
-			{
-				code: `
+		...SUPPORTED_TESTING_FRAMEWORKS.flatMap<RuleInvalidTestCase>(
+			(testingFramework) => [
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(() => render(<App />))
       `,
-				errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(function() {
           render(<App />)
         })
       `,
-				errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(function() {
           const { container } = renderHelper(<App />)
         })
       `,
-				errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				settings: { 'testing-library/custom-renders': ['renderHelper'] },
-				code: `
+					errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					settings: { 'testing-library/custom-renders': ['renderHelper'] },
+					code: `
         import { waitFor } from '${testingFramework}';
         import { renderHelper } from 'somewhere-else';
         await waitFor(() => renderHelper(<App />))
       `,
-				errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				settings: { 'testing-library/custom-renders': ['renderHelper'] },
-				code: `
+					errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					settings: { 'testing-library/custom-renders': ['renderHelper'] },
+					code: `
         import { waitFor } from '${testingFramework}';
         import { renderHelper } from 'somewhere-else';
         await waitFor(() => {
           renderHelper(<App />)
         })
       `,
-				errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				settings: { 'testing-library/custom-renders': ['renderHelper'] },
-				code: `
+					errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					settings: { 'testing-library/custom-renders': ['renderHelper'] },
+					code: `
         import { waitFor } from '${testingFramework}';
         import { renderHelper } from 'somewhere-else';
         await waitFor(() => {
           const { container } = renderHelper(<App />)
         })
       `,
-				errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				settings: { 'testing-library/custom-renders': ['renderHelper'] },
-				code: `
+					errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					settings: { 'testing-library/custom-renders': ['renderHelper'] },
+					code: `
         import { waitFor } from '${testingFramework}';
         import { renderHelper } from 'somewhere-else';
         let container;
@@ -403,53 +420,54 @@ ruleTester.run(RULE_NAME, rule, {
           ({ container } = renderHelper(<App />))
         })
       `,
-				errors: [{ line: 6, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 6, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(() => result = render(<App />))
       `,
-				errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(() => (a = 5, result = render(<App />)))
       `,
-				errors: [{ line: 3, column: 30, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 3, column: 30, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         const { rerender } = render(<App />)
         await waitFor(() => rerender(<App />))
       `,
-				errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor, render } from '${testingFramework}';
         await waitFor(() => render(<App />))
       `,
-				errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(() => renderHelper(<App />))
       `,
-				errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         import { render } from 'somewhere-else';
         await waitFor(() => render(<App />))
       `,
-				errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-		]),
+					errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
+				},
+			]
+		),
 		{
 			settings: { 'testing-library/utils-module': '~/test-utils' },
 			code: `
@@ -458,100 +476,101 @@ ruleTester.run(RULE_NAME, rule, {
       `,
 			errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
 		},
-		...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
-			{
-				settings: { 'testing-library/custom-renders': ['renderWrapper'] },
-				code: `
+		...SUPPORTED_TESTING_FRAMEWORKS.flatMap<RuleInvalidTestCase>(
+			(testingFramework) => [
+				{
+					settings: { 'testing-library/custom-renders': ['renderWrapper'] },
+					code: `
         import { waitFor } from '${testingFramework}';
         import { renderWrapper } from 'somewhere-else';
         await waitFor(() => renderWrapper(<App />))
       `,
-				errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 4, column: 29, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           render(<App />)
         })
       `,
-				errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           const { container } = render(<App />)
         })
       `,
-				errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           result = render(<App />)
         })
       `,
-				errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           const a = 5,
           { container } = render(<App />)
         })
       `,
-				errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         const { rerender } = render(<App />)
         await waitFor(() => {
           rerender(<App />)
         })
       `,
-				errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           render(<App />)
           fireEvent.keyDown(input, {key: 'ArrowDown'})
         })
       `,
-				errors: [
-					{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' },
-					{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' },
-				],
-			} as const,
-			{
-				code: `
+					errors: [
+						{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' },
+						{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' },
+					],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           render(<App />)
           userEvent.click(button)
         })
       `,
-				errors: [
-					{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' },
-					{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' },
-				],
-			} as const,
-		]),
+					errors: [
+						{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' },
+						{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' },
+					],
+				},
+			]
+		),
 		// fireEvent
-		...SUPPORTED_TESTING_FRAMEWORKS.map(
-			(testingFramework) =>
-				({
-					code: `
+		...SUPPORTED_TESTING_FRAMEWORKS.map<RuleInvalidTestCase>(
+			(testingFramework) => ({
+				code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(() => fireEvent.keyDown(input, {key: 'ArrowDown'}))
       `,
-					errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
-				}) as const
+				errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
+			})
 		),
 		{
 			settings: { 'testing-library/utils-module': '~/test-utils' },
@@ -561,26 +580,28 @@ ruleTester.run(RULE_NAME, rule, {
       `,
 			errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
 		},
-		...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
-			{
-				code: `
+		...SUPPORTED_TESTING_FRAMEWORKS.flatMap<RuleInvalidTestCase>(
+			(testingFramework) => [
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           fireEvent.keyDown(input, {key: 'ArrowDown'})
         })
       `,
-				errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor, fireEvent as renamedFireEvent } from '${testingFramework}';
         await waitFor(() => {
           renamedFireEvent.keyDown(input, {key: 'ArrowDown'})
         })
       `,
-				errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-		]),
+					errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+			]
+		),
 		{
 			settings: { 'testing-library/utils-module': '~/test-utils' },
 			code: `
@@ -591,86 +612,90 @@ ruleTester.run(RULE_NAME, rule, {
       `,
 			errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
 		},
-		...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
-			{
-				code: `
+		...SUPPORTED_TESTING_FRAMEWORKS.flatMap<RuleInvalidTestCase>(
+			(testingFramework) => [
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           expect(b).toEqual('b')
           fireEvent.keyDown(input, {key: 'ArrowDown'})
         })
       `,
-				errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           fireEvent.keyDown(input, {key: 'ArrowDown'})
           expect(b).toEqual('b')
         })
       `,
-				errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(function() {
           fireEvent.keyDown(input, {key: 'ArrowDown'})
         })
       `,
-				errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(function() {
           expect(b).toEqual('b')
           fireEvent.keyDown(input, {key: 'ArrowDown'})
         })
       `,
-				errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(function() {
           fireEvent.keyDown(input, {key: 'ArrowDown'})
           expect(b).toEqual('b')
         })
       `,
-				errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-		]),
+					errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+			]
+		),
 		// userEvent
-		...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
-			{
-				code: `
+		...SUPPORTED_TESTING_FRAMEWORKS.flatMap<RuleInvalidTestCase>(
+			(testingFramework) => [
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(() => userEvent.click(button))
       `,
-				errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 3, column: 29, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           userEvent.click(button)
         })
       `,
-				errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         import renamedUserEvent from '@testing-library/user-event'
         await waitFor(() => {
           renamedUserEvent.click(button)
         })
       `,
-				errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-		]),
+					errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+			]
+		),
 		{
 			settings: { 'testing-library/utils-module': '~/test-utils' },
 			code: `
@@ -682,59 +707,60 @@ ruleTester.run(RULE_NAME, rule, {
       `,
 			errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
 		},
-		...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
-			{
-				code: `
+		...SUPPORTED_TESTING_FRAMEWORKS.flatMap<RuleInvalidTestCase>(
+			(testingFramework) => [
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           expect(b).toEqual('b')
           userEvent.click(button)
         })
       `,
-				errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(() => {
           userEvent.click(button)
           expect(b).toEqual('b')
         })
       `,
-				errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(function() {
           userEvent.click(button)
         })
       `,
-				errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(function() {
           expect(b).toEqual('b')
           userEvent.click(button)
         })
       `,
-				errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				code: `
+					errors: [{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					code: `
         import { waitFor } from '${testingFramework}';
         await waitFor(function() {
           userEvent.click(button)
           expect(b).toEqual('b')
         })
       `,
-				errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				// Issue #500, https://github.com/testing-library/eslint-plugin-testing-library/issues/500
-				code: `
+					errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					// Issue #500, https://github.com/testing-library/eslint-plugin-testing-library/issues/500
+					code: `
         import { waitFor } from '${testingFramework}';
         waitFor(function() {
           userEvent.click(button)
@@ -744,11 +770,11 @@ ruleTester.run(RULE_NAME, rule, {
           expect(b).toEqual('b')
         })
       `,
-				errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
-			} as const,
-			{
-				// Issue #500, https://github.com/testing-library/eslint-plugin-testing-library/issues/500
-				code: `
+					errors: [{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' }],
+				},
+				{
+					// Issue #500, https://github.com/testing-library/eslint-plugin-testing-library/issues/500
+					code: `
         import { waitFor } from '${testingFramework}';
         waitFor(function() {
           userEvent.click(button)
@@ -762,12 +788,13 @@ ruleTester.run(RULE_NAME, rule, {
           })
         })
       `,
-				errors: [
-					{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' },
-					{ line: 10, column: 13, messageId: 'noSideEffectsWaitFor' },
-				],
-			} as const,
-		]),
+					errors: [
+						{ line: 4, column: 11, messageId: 'noSideEffectsWaitFor' },
+						{ line: 10, column: 13, messageId: 'noSideEffectsWaitFor' },
+					],
+				},
+			]
+		),
 
 		{
 			settings: { 'testing-library/utils-module': 'test-utils' },
@@ -793,10 +820,11 @@ ruleTester.run(RULE_NAME, rule, {
 			],
 		},
 		// side effects (userEvent, fireEvent or render) in variable declarations
-		...SUPPORTED_TESTING_FRAMEWORKS.flatMap((testingFramework) => [
-			{
-				// Issue #368, https://github.com/testing-library/eslint-plugin-testing-library/issues/368
-				code: `
+		...SUPPORTED_TESTING_FRAMEWORKS.flatMap<RuleInvalidTestCase>(
+			(testingFramework) => [
+				{
+					// Issue #368, https://github.com/testing-library/eslint-plugin-testing-library/issues/368
+					code: `
         import { waitFor } from '${testingFramework}';
         import userEvent from '@testing-library/user-event'
         await waitFor(() => {
@@ -805,13 +833,14 @@ ruleTester.run(RULE_NAME, rule, {
           const wrapper = render(<App />);
         })
         `,
-				errors: [
-					{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' },
-					{ line: 6, column: 11, messageId: 'noSideEffectsWaitFor' },
-					{ line: 7, column: 11, messageId: 'noSideEffectsWaitFor' },
-				],
-			} as const,
-		]),
+					errors: [
+						{ line: 5, column: 11, messageId: 'noSideEffectsWaitFor' },
+						{ line: 6, column: 11, messageId: 'noSideEffectsWaitFor' },
+						{ line: 7, column: 11, messageId: 'noSideEffectsWaitFor' },
+					],
+				},
+			]
+		),
 
 		...SUPPORTED_TESTING_FRAMEWORKS.flatMap<InvalidTestCase<MessageIds, []>>(
 			(testingFramework) => [


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- Explicitly specified type arguments for `map` and `flatMap` calls used in test case definitions


### Motivation

This change improves developer experience and code maintainability by leveraging TypeScript's type system more effectively in test definitions. With proper type arguments, we gain better autocompletion, stricter checks, and clearer code when working with test case arrays.

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

Since the diff is expected to be large, this PR updates only the tests for the rule mentioned in issue #202 for now.
