### PR TITLE
feat(no-wait-for-multiple-assertions): avoid reporting unrelated assertions

### DIFF
--- a/docs/rules/no-wait-for-multiple-assertions.md
+++ b/docs/rules/no-wait-for-multiple-assertions.md
@@ -7,9 +7,13 @@
 ## Rule Details
 
 This rule aims to ensure the correct usage of `expect` inside `waitFor`, in the way that they're intended to be used.
-When using multiple assertions inside `waitFor`, if one fails, you have to wait for a timeout before seeing it failing.
-Putting one assertion, you can both wait for the UI to settle to the state you want to assert on,
-and also fail faster if one of the assertions do end up failing
+
+If you use multiple assertions against the **same asynchronous target** inside `waitFor`,
+you may have to wait for a timeout before seeing a test failure, which is inefficient.
+Therefore, you should avoid using multiple assertions on the same async target inside a single `waitFor` callback.
+
+However, multiple assertions against **different async targets** (for example, independent state updates or different function calls) are allowed.
+This avoids unnecessary verbosity and maintains readability, without increasing the risk of missing failures.
 
 Example of **incorrect** code for this rule:
 
@@ -17,13 +21,13 @@ Example of **incorrect** code for this rule:
 const foo = async () => {
 	await waitFor(() => {
 		expect(a).toEqual('a');
-		expect(b).toEqual('b');
+		expect(a).toEqual('a');
 	});
 
 	// or
 	await waitFor(function () {
 		expect(a).toEqual('a');
-		expect(b).toEqual('b');
+		expect(a).toEqual('a');
 	});
 };
 ```
@@ -33,13 +37,13 @@ Examples of **correct** code for this rule:
 ```js
 const foo = async () => {
 	await waitFor(() => expect(a).toEqual('a'));
-	expect(b).toEqual('b');
+	expect(a).toEqual('a');
 
 	// or
 	await waitFor(function () {
 		expect(a).toEqual('a');
 	});
-	expect(b).toEqual('b');
+	expect(a).toEqual('a');
 
 	// it only detects expect
 	// so this case doesn't generate warnings

--- a/docs/rules/no-wait-for-multiple-assertions.md
+++ b/docs/rules/no-wait-for-multiple-assertions.md
@@ -20,14 +20,14 @@ Example of **incorrect** code for this rule:
 ```js
 const foo = async () => {
 	await waitFor(() => {
-		expect(a).toEqual('a');
-		expect(a).toEqual('a');
+		expect(window.fetch).toHaveBeenCalledWith('/foo');
+		expect(window.fetch).toHaveBeenCalledWith('/foo');
 	});
 
 	// or
 	await waitFor(function () {
-		expect(a).toEqual('a');
-		expect(a).toEqual('a');
+		expect(window.fetch).toHaveBeenCalledWith('/foo');
+		expect(window.fetch).toHaveBeenCalledWith('/foo');
 	});
 };
 ```
@@ -36,20 +36,26 @@ Examples of **correct** code for this rule:
 
 ```js
 const foo = async () => {
-	await waitFor(() => expect(a).toEqual('a'));
-	expect(a).toEqual('a');
+	await waitFor(() => expect(window.fetch).toHaveBeenCalledWith('foo'));
+	expect(window.fetch).toHaveBeenCalledTimes(1);
 
 	// or
 	await waitFor(function () {
-		expect(a).toEqual('a');
+		expect(window.fetch).toHaveBeenCalledWith('foo');
 	});
-	expect(a).toEqual('a');
+	expect(window.fetch).toHaveBeenCalledTimes(1);
 
 	// it only detects expect
 	// so this case doesn't generate warnings
 	await waitFor(() => {
 		fireEvent.keyDown(input, { key: 'ArrowDown' });
-		expect(b).toEqual('b');
+		expect(window.fetch).toHaveBeenCalledTimes(1);
+	});
+
+	// different async targets so the rule does not report it
+	await waitFor(() => {
+		expect(window.fetch).toHaveBeenCalledWith('/foo');
+		expect(localStorage.setItem).toHaveBeenCalledWith('bar', 'baz');
 	});
 };
 ```

--- a/docs/rules/no-wait-for-multiple-assertions.md
+++ b/docs/rules/no-wait-for-multiple-assertions.md
@@ -20,13 +20,13 @@ Example of **incorrect** code for this rule:
 ```js
 const foo = async () => {
 	await waitFor(() => {
-		expect(window.fetch).toHaveBeenCalledWith('/foo');
+		expect(window.fetch).toHaveBeenCalledTimes(1);
 		expect(window.fetch).toHaveBeenCalledWith('/foo');
 	});
 
 	// or
 	await waitFor(function () {
-		expect(window.fetch).toHaveBeenCalledWith('/foo');
+		expect(window.fetch).toHaveBeenCalledTimes(1);
 		expect(window.fetch).toHaveBeenCalledWith('/foo');
 	});
 };
@@ -36,14 +36,14 @@ Examples of **correct** code for this rule:
 
 ```js
 const foo = async () => {
-	await waitFor(() => expect(window.fetch).toHaveBeenCalledWith('foo'));
-	expect(window.fetch).toHaveBeenCalledTimes(1);
+	await waitFor(() => expect(window.fetch).toHaveBeenCalledTimes(1);
+	expect(window.fetch).toHaveBeenCalledWith('/foo');
 
 	// or
 	await waitFor(function () {
-		expect(window.fetch).toHaveBeenCalledWith('foo');
+		expect(window.fetch).toHaveBeenCalledTimes(1);
 	});
-	expect(window.fetch).toHaveBeenCalledTimes(1);
+	expect(window.fetch).toHaveBeenCalledWith('/foo');
 
 	// it only detects expect
 	// so this case doesn't generate warnings

--- a/lib/rules/no-wait-for-multiple-assertions.ts
+++ b/lib/rules/no-wait-for-multiple-assertions.ts
@@ -103,9 +103,6 @@ export default createTestingLibraryRule<Options, MessageIds>({
 			}
 
 			for (const expressionStatements of expectArgumentMap.values()) {
-				if (expressionStatements.length <= 1) {
-					continue;
-				}
 				// Skip the first matched assertion; only report subsequent duplicates.
 				for (const expressionStatement of expressionStatements.slice(1)) {
 					context.report({

--- a/lib/rules/no-wait-for-multiple-assertions.ts
+++ b/lib/rules/no-wait-for-multiple-assertions.ts
@@ -106,6 +106,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 				if (expressionStatements.length <= 1) {
 					continue;
 				}
+				// Skip the first matched assertion; only report subsequent duplicates.
 				for (const expressionStatement of expressionStatements.slice(1)) {
 					context.report({
 						node: expressionStatement,

--- a/lib/rules/no-wait-for-multiple-assertions.ts
+++ b/lib/rules/no-wait-for-multiple-assertions.ts
@@ -1,5 +1,10 @@
 import { createTestingLibraryRule } from '../create-testing-library-rule';
-import { getPropertyIdentifierNode } from '../node-utils';
+import {
+	getPropertyIdentifierNode,
+	isCallExpression,
+	isMemberExpression,
+} from '../node-utils';
+import { getSourceCode } from '../utils';
 
 import type { TSESTree } from '@typescript-eslint/utils';
 
@@ -44,6 +49,24 @@ export default createTestingLibraryRule<Options, MessageIds>({
 			}) as Array<TSESTree.ExpressionStatement>;
 		}
 
+		function getExpectArgument(expression: TSESTree.Expression) {
+			if (!isCallExpression(expression)) {
+				return null;
+			}
+
+			const { callee } = expression;
+			if (!isMemberExpression(callee)) {
+				return null;
+			}
+
+			const { object } = callee;
+			if (!isCallExpression(object) || object.arguments.length === 0) {
+				return null;
+			}
+
+			return object.arguments[0];
+		}
+
 		function reportMultipleAssertion(node: TSESTree.BlockStatement) {
 			if (!node.parent) {
 				return;
@@ -62,14 +85,30 @@ export default createTestingLibraryRule<Options, MessageIds>({
 
 			const expectNodes = getExpectNodes(node.body);
 
-			if (expectNodes.length <= 1) {
-				return;
+			const expectArgumentMap = new Map<
+				string,
+				TSESTree.ExpressionStatement[]
+			>();
+
+			for (const expectNode of expectNodes) {
+				const argument = getExpectArgument(expectNode.expression);
+				if (!argument) {
+					continue;
+				}
+
+				const argumentText = getSourceCode(context).getText(argument);
+				const existingNodes = expectArgumentMap.get(argumentText) ?? [];
+				const newTargetNodes = [...existingNodes, expectNode];
+				expectArgumentMap.set(argumentText, newTargetNodes);
 			}
 
-			for (let i = 0; i < expectNodes.length; i++) {
-				if (i !== 0) {
+			for (const expressionStatements of expectArgumentMap.values()) {
+				if (expressionStatements.length <= 1) {
+					continue;
+				}
+				for (const expressionStatement of expressionStatements.slice(1)) {
 					context.report({
-						node: expectNodes[i],
+						node: expressionStatement,
 						messageId: 'noWaitForMultipleAssertion',
 					});
 				}

--- a/tests/lib/rules/no-wait-for-multiple-assertions.test.ts
+++ b/tests/lib/rules/no-wait-for-multiple-assertions.test.ts
@@ -16,10 +16,10 @@ const ruleTester = createRuleTester();
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
 	'@testing-library/dom',
-	'@testing-library/angular',
-	'@testing-library/react',
-	'@testing-library/vue',
-	'@marko/testing-library',
+	// '@testing-library/angular',
+	// '@testing-library/react',
+	// '@testing-library/vue',
+	// '@marko/testing-library',
 ];
 
 ruleTester.run(RULE_NAME, rule, {
@@ -33,6 +33,22 @@ ruleTester.run(RULE_NAME, rule, {
 			code: `
         await waitFor(function() {
           expect(a).toEqual('a')
+        })
+      `,
+		},
+		{
+			code: `
+        await waitFor(function() {
+          expect(a).toEqual('a')
+          expect(b).toEqual('b')
+        })
+      `,
+		},
+		{
+			code: `
+        await waitFor(function() {
+          expect(a).toEqual('a')
+          expect('a').toEqual('a')
         })
       `,
 		},
@@ -115,7 +131,18 @@ ruleTester.run(RULE_NAME, rule, {
 			code: `
         await waitFor(() => {
           expect(a).toEqual('a')
-          expect(b).toEqual('b')
+          expect(a).toEqual('a')
+        })
+      `,
+			errors: [
+				{ line: 4, column: 11, messageId: 'noWaitForMultipleAssertion' },
+			],
+		},
+		{
+			code: `
+        await waitFor(() => {
+          expect(screen.getByTestId('a')).toHaveTextContent('a')
+          expect(screen.getByTestId('a')).toHaveTextContent('a')
         })
       `,
 			errors: [
@@ -129,7 +156,7 @@ ruleTester.run(RULE_NAME, rule, {
         import { waitFor } from '${testingFramework}'
         await waitFor(() => {
           expect(a).toEqual('a')
-          expect(b).toEqual('b')
+          expect(a).toEqual('a')
         })
       `,
 				errors: [
@@ -143,7 +170,7 @@ ruleTester.run(RULE_NAME, rule, {
         import { waitFor as renamedWaitFor } from 'test-utils'
         await renamedWaitFor(() => {
           expect(a).toEqual('a')
-          expect(b).toEqual('b')
+          expect(a).toEqual('a')
         })
       `,
 			errors: [
@@ -155,7 +182,7 @@ ruleTester.run(RULE_NAME, rule, {
         await waitFor(() => {
           expect(a).toEqual('a')
           console.log('testing-library')
-          expect(b).toEqual('b')
+          expect(a).toEqual('a')
         })
       `,
 			errors: [
@@ -168,7 +195,7 @@ ruleTester.run(RULE_NAME, rule, {
           await waitFor(() => {
             expect(a).toEqual('a')
             console.log('testing-library')
-            expect(b).toEqual('b')
+            expect(a).toEqual('a')
           })
         })
       `,
@@ -181,7 +208,7 @@ ruleTester.run(RULE_NAME, rule, {
         await waitFor(async () => {
           expect(a).toEqual('a')
           await somethingAsync()
-          expect(b).toEqual('b')
+          expect(a).toEqual('a')
         })
       `,
 			errors: [
@@ -192,9 +219,9 @@ ruleTester.run(RULE_NAME, rule, {
 			code: `
         await waitFor(function() {
           expect(a).toEqual('a')
-          expect(b).toEqual('b')
-          expect(c).toEqual('c')
-          expect(d).toEqual('d')
+          expect(a).toEqual('a')
+          expect(a).toEqual('a')
+          expect(a).toEqual('a')
         })
       `,
 			errors: [
@@ -207,8 +234,22 @@ ruleTester.run(RULE_NAME, rule, {
 			code: `
         await waitFor(function() {
           expect(a).toEqual('a')
-          console.log('testing-library')
+          expect(a).toEqual('a')
           expect(b).toEqual('b')
+          expect(b).toEqual('b')
+        })
+      `,
+			errors: [
+				{ line: 4, column: 11, messageId: 'noWaitForMultipleAssertion' },
+				{ line: 6, column: 11, messageId: 'noWaitForMultipleAssertion' },
+			],
+		},
+		{
+			code: `
+        await waitFor(function() {
+          expect(a).toEqual('a')
+          console.log('testing-library')
+          expect(a).toEqual('a')
         })
       `,
 			errors: [
@@ -220,8 +261,20 @@ ruleTester.run(RULE_NAME, rule, {
         await waitFor(async function() {
           expect(a).toEqual('a')
           const el = await somethingAsync()
-          expect(b).toEqual('b')
+          expect(a).toEqual('a')
         })
+      `,
+			errors: [
+				{ line: 5, column: 11, messageId: 'noWaitForMultipleAssertion' },
+			],
+		},
+		{
+			code: `
+        await waitFor(() => {
+          expect(window.fetch).toHaveBeenCalledTimes(1);
+          expect(localStorage.setItem).toHaveBeenCalledWith('bar', 'baz');
+          expect(window.fetch).toHaveBeenCalledWith('/foo');
+        });
       `,
 			errors: [
 				{ line: 5, column: 11, messageId: 'noWaitForMultipleAssertion' },

--- a/tests/lib/rules/no-wait-for-multiple-assertions.test.ts
+++ b/tests/lib/rules/no-wait-for-multiple-assertions.test.ts
@@ -16,10 +16,10 @@ const ruleTester = createRuleTester();
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
 	'@testing-library/dom',
-	// '@testing-library/angular',
-	// '@testing-library/react',
-	// '@testing-library/vue',
-	// '@marko/testing-library',
+	'@testing-library/angular',
+	'@testing-library/react',
+	'@testing-library/vue',
+	'@marko/testing-library',
 ];
 
 ruleTester.run(RULE_NAME, rule, {


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- Updated rule logic to better distinguish between unique async elements.
- Update doc and test.

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

Fixes #1084 


---
This is completely unrelated to the changes in this PR, but I noticed an [error](https://github.com/testing-library/eslint-plugin-testing-library/actions/runs/18224863863/job/51893411818?pr=1097#step:8:273) in the "Upload coverage reports to Codecov" step, and the coverage notification is not being sent.  
Is this something we should be concerned about, or is it fine to ignore?
