### PR TITLE
add react-native library module

### DIFF
--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -25,6 +25,7 @@ const LIBRARY_MODULES = [
 	'@testing-library/dom',
 	'@testing-library/angular',
 	'@testing-library/react',
+	'@testing-library/react-native',
 	'@testing-library/preact',
 	'@testing-library/vue',
 	'@testing-library/svelte',


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

the current system does not support react native, which means that some rules (like `no-node-access`) never work with react native. it's possible to set a custom module, but only one of them, so I can't set our actual custom module and `@testing-library/react-native`.

-

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->
