### PR TITLE
chore: set up npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  id-token: write # to enable use of OIDC (npm trusted publishing and provenance)
   contents: write # to be able to publish a GitHub release
-  id-token: write # to enable use of OIDC for npm provenance
   issues: write # to be able to comment on released issues
   pull-requests: write # to be able to comment on released pull requests
 
@@ -50,5 +50,3 @@ jobs:
         run: pnpm exec semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
-          NPM_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}


### PR DESCRIPTION
## Checks

- [X] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

Set up the trusted publishing for npm packages [following the official docs](https://docs.npmjs.com/trusted-publishers).

The corresponding config is already set in the package settings within npm:
<img width="1684" height="1500" alt="CleanShot 2025-10-27 at 09 41 25@2x" src="https://github.com/user-attachments/assets/eee17afb-58cf-4140-8d33-f346aec5514b" />


## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->
