### PR TITLE
ci: fix codecov report upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
   merge_group:
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -15,6 +12,8 @@ jobs:
   verifications:
     name: Verifications
     uses: ./.github/workflows/verifications.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   required-checks:
     name: Require CI status checks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ jobs:
         with:
           cache: 'pnpm'
           node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
 
       # Ensure npm 11.5.1 or later is installed for correct OIDC publishing
       - name: Update npm

--- a/.github/workflows/verifications.yml
+++ b/.github/workflows/verifications.yml
@@ -2,6 +2,9 @@ name: Verifications
 
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: true
 
 jobs:
   code-validation:


### PR DESCRIPTION
## Checks

- [X] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- Forward corresponding secret to reusable workflow, so codecov can read the token for uploading the coverage report.

[Example of successful run](https://github.com/testing-library/eslint-plugin-testing-library/actions/runs/20163107492/job/57879960486?pr=1127#step:8:284).

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

Fixes #1098