### PR TITLE
fix: expose correct meta version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { baseConfigs } from './configs';
 import { rules } from './rules';
@@ -11,14 +13,16 @@ type FlatConfigs = Record<`flat/${SupportedTestingFramework}`, Linter.Config>;
 type PluginConfigs = ClassicConfigs & FlatConfigs;
 
 const require = createRequire(import.meta.url);
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Reference package.json with `require` so it takes the right "version"
 // with semantic release after bundle is generated.
-const { name: packageName, version: packageVersion } =
-	require('./package.json') as {
-		name: string;
-		version: string;
-	};
+const { name: packageName, version: packageVersion } = require(
+	resolve(__dirname, '../package.json')
+) as {
+	name: string;
+	version: string;
+};
 
 const PLUGIN_NAME = 'testing-library' as const;
 


### PR DESCRIPTION
## Checks

- [X] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

Import the `package.json` dynamically using `require`, so the meta version is not frozen at build time, but read from the actual `package.json`, which is updated by semantic-release at publish time. Otherwise, the version is fixed to `0.0.0-semantically-released`.

## Context

N/A

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->
