### PR TITLE
feat: make eslint an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,11 @@
 	"peerDependencies": {
 		"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
 	},
+	"peerDependenciesMeta": {
+		"eslint": {
+			"optional": true
+		}
+	},
 	"engines": {
 		"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 	},


### PR DESCRIPTION
## Problem

With the rise of Rust-based linters like [Oxlint](https://oxc.rs/docs/guide/usage/linter.html) and Biome, many projects run ESLint plugins through compatibility layers without having ESLint itself installed as a direct dependency. See for example https://oxc.rs/blog/2026-03-11-oxlint-js-plugins-alpha

When using `eslint-plugin-testing-library` this way, package managers (especially Yarn and pnpm) emit peer dependency warnings/errors because `eslint` is listed as a required peer but is not present — even though the plugin works fine at runtime through the compatibility layer.

## Solution

Mark `eslint` as an optional peer dependency via `peerDependenciesMeta`:

```json
"peerDependenciesMeta": {
  "eslint": {
    "optional": true
  }
}
```

This is a **non-breaking change** — projects with ESLint installed continue to work exactly as before. Projects using alternative runners no longer get spurious warnings.

## Workaround Currently Required

Without this change, users have to add package manager overrides to suppress the warning, e.g. for Yarn:

```json
"resolutions": {
  "eslint-plugin-testing-library/eslint": "npm:eslint@^9"
}
```

Making `eslint` optional removes the need for this workaround.