### PR TITLE
ci: set workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   merge_group:


### PR DESCRIPTION
Potential fix for [https://github.com/testing-library/eslint-plugin-testing-library/security/code-scanning/4](https://github.com/testing-library/eslint-plugin-testing-library/security/code-scanning/4)

In general, fix this by adding an explicit `permissions` block either at the workflow root (to cover all jobs) or on the specific job, granting only the minimal required scopes. For a workflow that only reads workflow/job state and does not interact with repository contents or PRs, it is safe to set `permissions: contents: read` at the workflow level; this is the common minimal baseline and aligns with GitHub’s recommendation for read-only defaults.

The best targeted fix here is to define `permissions` at the workflow root, just below `name: CI`, so that both `verifications` and `required-checks` jobs inherit it unless they define their own. Given the information in the snippet, the minimal sane configuration is:

```yaml
permissions:
  contents: read
```

This explicitly restricts `GITHUB_TOKEN` to read-only repository contents, which is sufficient for typical CI and avoids unexpected write capabilities. No new imports, actions, or logic changes are needed; only the YAML workflow header is updated. Concretely, in `.github/workflows/ci.yml`, insert a `permissions` block after line 1 and before `on:` at line 3.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
