### PR TITLE
Fix no-node-access false positives for object literal properties

### DIFF
--- a/src/rules/no-node-access.ts
+++ b/src/rules/no-node-access.ts
@@ -1,4 +1,4 @@
-import { ASTUtils } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, ASTUtils } from '@typescript-eslint/utils';
 
 import { createTestingLibraryRule } from '../create-testing-library-rule';
 import {
@@ -10,6 +10,7 @@ import {
 	ALL_QUERIES_COMBINATIONS,
 	ALL_RETURNING_NODES,
 	EVENT_HANDLER_METHODS,
+	getScope,
 	resolveToTestingLibraryFn,
 } from '../utils';
 
@@ -57,6 +58,55 @@ export default createTestingLibraryRule<Options, MessageIds>({
 	],
 
 	create(context, [{ allowContainerFirstChild = false }], helpers) {
+		function getObjectPropertyName(node: TSESTree.Property['key']) {
+			if (ASTUtils.isIdentifier(node)) {
+				return node.name;
+			}
+
+			if (isLiteral(node) && typeof node.value === 'string') {
+				return node.value;
+			}
+
+			return null;
+		}
+
+		function objectExpressionHasProperty(
+			node: TSESTree.ObjectExpression,
+			propertyName: string
+		) {
+			return node.properties.some(
+				(property) =>
+					property.type === AST_NODE_TYPES.Property &&
+					getObjectPropertyName(property.key) === propertyName
+			);
+		}
+
+		function isDeclaredObjectProperty(
+			node: TSESTree.MemberExpression,
+			propertyName: string
+		) {
+			if (!ASTUtils.isIdentifier(node.object)) {
+				return false;
+			}
+
+			const variable = ASTUtils.findVariable(
+				getScope(context, node),
+				node.object.name
+			);
+
+			return (
+				variable?.defs.some((definition) => {
+					const { node: definitionNode } = definition;
+
+					return (
+						ASTUtils.isVariableDeclarator(definitionNode) &&
+						definitionNode.init?.type === AST_NODE_TYPES.ObjectExpression &&
+						objectExpressionHasProperty(definitionNode.init, propertyName)
+					);
+				}) ?? false
+			);
+		}
+
 		function showErrorForNodeAccess(node: TSESTree.MemberExpression) {
 			// This rule is so aggressive that can cause tons of false positives outside test files when Aggressive Reporting
 			// is enabled. Because of that, this rule will skip this mechanism and report only if some Testing Library package
@@ -87,7 +137,8 @@ export default createTestingLibraryRule<Options, MessageIds>({
 
 				if (
 					ASTUtils.isIdentifier(node.object) &&
-					node.object.name === 'props'
+					(node.object.name === 'props' ||
+						isDeclaredObjectProperty(node, propertyName))
 				) {
 					return;
 				}

--- a/tests/rules/no-node-access.test.ts
+++ b/tests/rules/no-node-access.test.ts
@@ -119,6 +119,34 @@ ruleTester.run(rule.name, rule, {
 				`,
 				},
 				{
+					code: `// issue #683 examples, plain object properties should not be reported
+				import { render } from '${testingFramework}';
+
+				const navItemWithChildren = {
+					title: 'Cars',
+					children: [
+						{ title: 'Add car' },
+						{ title: 'All cars' },
+					],
+				};
+
+				render(<NavComponent itemWithChildren={navItemWithChildren} />);
+				expect(navItemWithChildren.children).toHaveLength(2);
+				`,
+				},
+				{
+					code: `// issue #683 examples, plain object properties should not be reported
+				import { render } from '${testingFramework}';
+
+				const applicationState = {
+					activeElement: 'settings-tab',
+				};
+
+				render(<NavComponent state={applicationState} />);
+				expect(applicationState.activeElement).toBe('settings-tab');
+				`,
+				},
+				{
 					settings: {
 						'testing-library/utils-module': 'test-utils',
 					},


### PR DESCRIPTION
## Summary

Fixes false positives in `no-node-access` when accessing data properties such as `children` or `activeElement` on plain object literals.

## What changed

- Added regression coverage for object literal properties whose names overlap with DOM node properties.
- Updated the rule to skip these accesses when the object resolves to an object literal declaring that property.
- Preserved existing reports for Testing Library DOM node access, including query results and render containers.

## Why

Issue #683 reports that `no-node-access` can report regular data objects if their property names overlap with DOM node-returning properties. These object properties are not direct DOM node access and should not be reported.

## Testing

- `pnpm test tests/rules/no-node-access.test.ts`
- `pnpm run lint`
- `pnpm run type-check`
- `pnpm test`

Fixes #683