### PR TITLE
Fix consistent-data-testid fileName on Windows paths

### DIFF
--- a/src/rules/consistent-data-testid.ts
+++ b/src/rules/consistent-data-testid.ts
@@ -15,6 +15,7 @@ export type Options = [
 ];
 
 const FILENAME_PLACEHOLDER = '{fileName}';
+const PATH_SEPARATOR_PATTERN = /[/\\]/u;
 
 export default createTestingLibraryRule<Options, MessageIds>({
 	name: RULE_NAME,
@@ -82,7 +83,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 		const { testIdPattern, testIdAttribute: attr, customMessage } = options;
 
 		function getFileNameData() {
-			const splitPath = getFilename(context).split('/');
+			const splitPath = getFilename(context).split(PATH_SEPARATOR_PATTERN);
 			const fileNameWithExtension = splitPath.pop() ?? '';
 			if (
 				fileNameWithExtension.includes('[') ||

--- a/tests/rules/consistent-data-testid.test.ts
+++ b/tests/rules/consistent-data-testid.test.ts
@@ -79,6 +79,25 @@ const validTestCases: RuleValidTestCase[] = [
 
             const TestComponent = props => {
               return (
+                <div data-testid="Link__Button">
+                  Hello
+                </div>
+              )
+            };
+          `,
+		options: [
+			{
+				testIdPattern: '^{fileName}__([A-Z]+[a-z]*?)+$',
+			},
+		],
+		filename: 'C:\\workspace\\projectX\\src\\components\\Link\\Link.tsx',
+	},
+	{
+		code: `
+            import React from 'react';
+
+            const TestComponent = props => {
+              return (
                 <div data-testid="Awesome">
                   Hello
                 </div>


### PR DESCRIPTION
## Summary

Fixes `{fileName}` replacement in `consistent-data-testid` when ESLint reports Windows-style paths.

## What changed

- Added regression coverage for a Windows path in the `filename` test case.
- Updated filename extraction to handle both POSIX and Windows path separators.
- Preserved the existing `index` file and dynamic route filename behavior.

## Why

Issue #782 reports that `{fileName}` can expand to the full Windows path instead of just the component file name because the rule only splits paths on `/`.

## Testing

- `pnpm test tests/rules/consistent-data-testid.test.ts`
- `pnpm run lint`
- `pnpm run type-check`
- `pnpm test`
- `git diff upstream/main...HEAD --check`

Fixes #782