### PR TITLE
Standardize bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
 		"testing"
 	],
 	"homepage": "https://github.com/testing-library/eslint-plugin-testing-library",
-	"bugs": "testing-library/eslint-plugin-testing-library/issues",
+	"bugs": {
+		"url": "https://github.com/testing-library/eslint-plugin-testing-library/issues"
+	},
 	"repository": "testing-library/eslint-plugin-testing-library",
 	"license": "MIT",
 	"author": "Mario Beltrán (https://belco.dev)",


### PR DESCRIPTION
## Summary
- change the package `bugs` metadata from a GitHub shorthand string to a standard npm `bugs.url` object
- keep the existing homepage and repository metadata unchanged

The published package currently exposes homepage and repository metadata, but does not expose a usable `bugs` link in npm package metadata.

## Verification
- `node -e "const p=require('./package.json'); console.log(JSON.stringify({name:p.name,version:p.version,homepage:p.homepage,bugs:p.bugs,repository:p.repository},null,2)); if(p.name!=='eslint-plugin-testing-library'||p.bugs?.url!=='https://github.com/testing-library/eslint-plugin-testing-library/issues') process.exit(1)"`
- `git diff --check`