### PR TITLE
fix: update destructured query names in presence query autofix

### DIFF
--- a/src/rules/prefer-presence-queries.ts
+++ b/src/rules/prefer-presence-queries.ts
@@ -1,7 +1,14 @@
-import { createTestingLibraryRule } from '../create-testing-library-rule';
-import { findClosestCallNode, isMemberExpression } from '../node-utils';
+import { ASTUtils } from '@typescript-eslint/utils';
 
-import type { TSESTree } from '@typescript-eslint/utils';
+import { createTestingLibraryRule } from '../create-testing-library-rule';
+import {
+	findClosestCallNode,
+	isMemberExpression,
+	isProperty,
+} from '../node-utils';
+import { getScope } from '../utils';
+
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 
 const RULE_NAME = 'prefer-presence-queries';
 export type MessageIds = 'wrongAbsenceQuery' | 'wrongPresenceQuery';
@@ -58,6 +65,60 @@ export default createTestingLibraryRule<Options, MessageIds>({
 	],
 
 	create(context, [{ absence = true, presence = true }], helpers) {
+		function getDestructuredQueryIdentifier(
+			node: TSESTree.Identifier
+		): TSESTree.Identifier | 'unsafe' | null {
+			const variable = ASTUtils.findVariable(
+				getScope(context, node),
+				node.name
+			);
+			const variableDefinition = variable?.defs[0];
+			const identifier = variableDefinition?.name;
+
+			if (!variable || !identifier || !ASTUtils.isIdentifier(identifier)) {
+				return null;
+			}
+
+			const property = identifier.parent;
+
+			if (
+				!isProperty(property) ||
+				!ASTUtils.isIdentifier(property.key) ||
+				!ASTUtils.isIdentifier(property.value) ||
+				property.key.name !== node.name ||
+				property.value.name !== node.name
+			) {
+				return null;
+			}
+
+			const references = variable.references.filter(
+				(reference) => reference.identifier !== identifier
+			);
+
+			return references.length === 1 ? identifier : 'unsafe';
+		}
+
+		function fixQueryName(
+			fixer: TSESLint.RuleFixer,
+			node: TSESTree.Identifier,
+			newQueryName: string
+		): TSESLint.RuleFix[] | null {
+			const fixes = [fixer.replaceText(node, newQueryName)];
+			const destructuredQueryIdentifier = getDestructuredQueryIdentifier(node);
+
+			if (destructuredQueryIdentifier === 'unsafe') {
+				return null;
+			}
+
+			if (destructuredQueryIdentifier) {
+				fixes.push(
+					fixer.replaceText(destructuredQueryIdentifier, newQueryName)
+				);
+			}
+
+			return fixes;
+		}
+
 		return {
 			'CallExpression Identifier'(node: TSESTree.Identifier) {
 				const expectCallNode = findClosestCallNode(node, 'expect');
@@ -92,7 +153,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 					context.report({
 						node,
 						messageId: 'wrongPresenceQuery',
-						fix: (fixer) => fixer.replaceText(node, newQueryName),
+						fix: (fixer) => fixQueryName(fixer, node, newQueryName),
 					});
 				} else if (
 					!withinCallNode &&
@@ -104,7 +165,7 @@ export default createTestingLibraryRule<Options, MessageIds>({
 					context.report({
 						node,
 						messageId: 'wrongAbsenceQuery',
-						fix: (fixer) => fixer.replaceText(node, newQueryName),
+						fix: (fixer) => fixQueryName(fixer, node, newQueryName),
 					});
 				}
 			},

--- a/tests/rules/prefer-presence-queries.test.ts
+++ b/tests/rules/prefer-presence-queries.test.ts
@@ -953,6 +953,17 @@ ruleTester.run(rule.name, rule, {
 	],
 	invalid: [
 		// cases: asserting absence incorrectly with `getBy*` queries
+		{
+			code: `
+				const { getByRole } = render(<Component />);
+				expect(getByRole('alert')).not.toBeInTheDocument();
+			`,
+			output: `
+				const { queryByRole } = render(<Component />);
+				expect(queryByRole('alert')).not.toBeInTheDocument();
+			`,
+			errors: [{ line: 3, column: 12, messageId: 'wrongAbsenceQuery' }],
+		},
 		...getByQueries.reduce<RuleInvalidTestCase[]>(
 			(invalidRules, queryName) => [
 				...invalidRules,
@@ -1137,6 +1148,26 @@ ruleTester.run(rule.name, rule, {
 			[]
 		),
 		// cases: asserting presence incorrectly with `queryBy*` queries
+		{
+			code: `
+				const { queryByRole } = render(<Component />);
+				expect(queryByRole('alert')).toBeInTheDocument();
+			`,
+			output: `
+				const { getByRole } = render(<Component />);
+				expect(getByRole('alert')).toBeInTheDocument();
+			`,
+			errors: [{ line: 3, column: 12, messageId: 'wrongPresenceQuery' }],
+		},
+		{
+			code: `
+				const { queryByRole } = render(<Component />);
+				expect(queryByRole('alert')).toBeInTheDocument();
+				expect(queryByRole('dialog')).not.toBeInTheDocument();
+			`,
+			output: null,
+			errors: [{ line: 3, column: 12, messageId: 'wrongPresenceQuery' }],
+		},
 		...queryByQueries.reduce<RuleInvalidTestCase[]>(
 			(validRules, queryName) => [
 				...validRules,


### PR DESCRIPTION
Fixes #1359

## Summary
- update `prefer-presence-queries` autofixes to also rename safe destructured query bindings
- avoid autofixing multi-reference destructured bindings where changing only one assertion would produce unsafe output
- add regression coverage for presence, absence, and unsafe multi-reference destructured query cases

## Tests
- `pnpm run lint`
- `pnpm run type-check`
- `vitest run tests/rules/prefer-presence-queries.test.ts --reporter=dot`