### PR TITLE
feat(angular): support ATL zoneless imports

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -23,6 +23,7 @@ const getDocsUrl = (ruleName: string): string =>
 const LIBRARY_MODULES = [
 	'@testing-library/dom',
 	'@testing-library/angular',
+	'@testing-library/angular/zoneless',
 	'@testing-library/react',
 	'@testing-library/preact',
 	'@testing-library/vue',

--- a/tests/rules/await-async-queries.test.ts
+++ b/tests/rules/await-async-queries.test.ts
@@ -22,6 +22,7 @@ type RuleInvalidTestCase = InvalidTestCase<MessageIds, []>;
 const SUPPORTED_TESTING_FRAMEWORKS = [
 	'@testing-library/dom',
 	'@testing-library/angular',
+	'@testing-library/angular/zoneless',
 	'@testing-library/react',
 	'@testing-library/vue',
 	'@marko/testing-library',

--- a/tests/rules/await-async-utils.test.ts
+++ b/tests/rules/await-async-utils.test.ts
@@ -16,6 +16,7 @@ const ruleTester = createRuleTester();
 const SUPPORTED_TESTING_FRAMEWORKS = [
 	'@testing-library/dom',
 	'@testing-library/angular',
+	'@testing-library/angular/zoneless',
 	'@testing-library/react',
 	'@testing-library/vue',
 	'@marko/testing-library',

--- a/tests/rules/no-await-sync-events.test.ts
+++ b/tests/rules/no-await-sync-events.test.ts
@@ -91,6 +91,7 @@ const FIRE_EVENT_FUNCTIONS = [
 const SUPPORTED_TESTING_FRAMEWORKS = [
 	'@testing-library/dom',
 	'@testing-library/angular',
+	'@testing-library/angular/zoneless',
 	'@testing-library/react',
 	'@testing-library/vue',
 	'@marko/testing-library',

--- a/tests/rules/no-await-sync-queries.test.ts
+++ b/tests/rules/no-await-sync-queries.test.ts
@@ -19,6 +19,7 @@ type RuleInvalidTestCase = InvalidTestCase<MessageIds, []>;
 const SUPPORTED_TESTING_FRAMEWORKS = [
 	'@testing-library/dom',
 	'@testing-library/angular',
+	'@testing-library/angular/zoneless',
 	'@testing-library/react',
 	'@testing-library/vue',
 	'@marko/testing-library',

--- a/tests/rules/no-container.test.ts
+++ b/tests/rules/no-container.test.ts
@@ -5,6 +5,7 @@ const ruleTester = createRuleTester();
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
 	'@testing-library/angular',
+	'@testing-library/angular/zoneless',
 	'@testing-library/react',
 	'@testing-library/vue',
 	'@marko/testing-library',

--- a/tests/rules/no-debugging-utils.test.ts
+++ b/tests/rules/no-debugging-utils.test.ts
@@ -5,6 +5,7 @@ const ruleTester = createRuleTester();
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
 	'@testing-library/angular',
+	'@testing-library/angular/zoneless',
 	'@testing-library/react',
 	'@testing-library/vue',
 	'@marko/testing-library',

--- a/tests/rules/no-node-access.test.ts
+++ b/tests/rules/no-node-access.test.ts
@@ -15,6 +15,7 @@ type RuleInvalidTestCase = InvalidTestCase<MessageIds, Options>;
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
 	'@testing-library/angular',
+	'@testing-library/angular/zoneless',
 	'@testing-library/react',
 	'@testing-library/vue',
 	'@marko/testing-library',

--- a/tests/rules/no-promise-in-fire-event.test.ts
+++ b/tests/rules/no-promise-in-fire-event.test.ts
@@ -6,6 +6,7 @@ const ruleTester = createRuleTester();
 const SUPPORTED_TESTING_FRAMEWORKS = [
 	'@testing-library/dom',
 	'@testing-library/angular',
+	'@testing-library/angular/zoneless',
 	'@testing-library/react',
 	'@testing-library/vue',
 	'@marko/testing-library',

--- a/tests/rules/no-render-in-lifecycle.test.ts
+++ b/tests/rules/no-render-in-lifecycle.test.ts
@@ -6,6 +6,7 @@ const ruleTester = createRuleTester();
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
 	'@testing-library/angular',
+	'@testing-library/angular/zoneless',
 	'@testing-library/react',
 	'@testing-library/vue',
 	'@marko/testing-library',

--- a/tests/rules/no-test-id-queries.test.ts
+++ b/tests/rules/no-test-id-queries.test.ts
@@ -6,6 +6,7 @@ const ruleTester = createRuleTester();
 const SUPPORTED_TESTING_FRAMEWORKS = [
 	'@testing-library/dom',
 	'@testing-library/angular',
+	'@testing-library/angular/zoneless',
 	'@testing-library/react',
 	'@testing-library/vue',
 	'@marko/testing-library',

--- a/tests/rules/no-wait-for-multiple-assertions.test.ts
+++ b/tests/rules/no-wait-for-multiple-assertions.test.ts
@@ -15,6 +15,7 @@ const ruleTester = createRuleTester();
 const SUPPORTED_TESTING_FRAMEWORKS = [
 	'@testing-library/dom',
 	'@testing-library/angular',
+	'@testing-library/angular/zoneless',
 	'@testing-library/react',
 	'@testing-library/vue',
 	'@marko/testing-library',

--- a/tests/rules/no-wait-for-side-effects.test.ts
+++ b/tests/rules/no-wait-for-side-effects.test.ts
@@ -16,6 +16,7 @@ const ruleTester = createRuleTester();
 const SUPPORTED_TESTING_FRAMEWORKS = [
 	'@testing-library/dom',
 	'@testing-library/angular',
+	'@testing-library/angular/zoneless',
 	'@testing-library/react',
 	'@testing-library/vue',
 	'@marko/testing-library',

--- a/tests/rules/no-wait-for-snapshot.test.ts
+++ b/tests/rules/no-wait-for-snapshot.test.ts
@@ -7,6 +7,7 @@ const ruleTester = createRuleTester();
 const SUPPORTED_TESTING_FRAMEWORKS = [
 	'@testing-library/dom',
 	'@testing-library/angular',
+	'@testing-library/angular/zoneless',
 	'@testing-library/react',
 	'@testing-library/vue',
 	'@marko/testing-library',

--- a/tests/rules/prefer-find-by.test.ts
+++ b/tests/rules/prefer-find-by.test.ts
@@ -16,6 +16,7 @@ const ruleTester = createRuleTester();
 const SUPPORTED_TESTING_FRAMEWORKS = [
 	'@testing-library/dom',
 	'@testing-library/angular',
+	'@testing-library/angular/zoneless',
 	'@testing-library/react',
 	'@testing-library/vue',
 	'@marko/testing-library',

--- a/tests/rules/prefer-query-by-disappearance.test.ts
+++ b/tests/rules/prefer-query-by-disappearance.test.ts
@@ -6,6 +6,7 @@ const ruleTester = createRuleTester();
 const SUPPORTED_TESTING_FRAMEWORKS = [
 	'@testing-library/dom',
 	'@testing-library/angular',
+	'@testing-library/angular/zoneless',
 	'@testing-library/react',
 	'@testing-library/vue',
 	'@marko/testing-library',

--- a/tests/rules/prefer-screen-queries.test.ts
+++ b/tests/rules/prefer-screen-queries.test.ts
@@ -11,6 +11,7 @@ const ruleTester = createRuleTester();
 const SUPPORTED_TESTING_FRAMEWORKS = [
 	'@testing-library/dom',
 	'@testing-library/angular',
+	'@testing-library/angular/zoneless',
 	'@testing-library/react',
 	'@testing-library/vue',
 	'@marko/testing-library',

--- a/tests/rules/render-result-naming-convention.test.ts
+++ b/tests/rules/render-result-naming-convention.test.ts
@@ -5,6 +5,7 @@ const ruleTester = createRuleTester();
 
 const SUPPORTED_TESTING_FRAMEWORKS = [
 	'@testing-library/angular',
+	'@testing-library/angular/zoneless',
 	'@testing-library/react',
 	'@testing-library/vue',
 	'@marko/testing-library',

--- a/tests/utils/is-testing-library-module.test.ts
+++ b/tests/utils/is-testing-library-module.test.ts
@@ -15,6 +15,7 @@ const OLD_LIBRARY_MODULES = [
 const LIBRARY_MODULES = [
 	'@testing-library/dom',
 	'@testing-library/angular',
+	'@testing-library/angular/zoneless',
 	'@testing-library/react',
 	'@testing-library/preact',
 	'@testing-library/vue',


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- Enable all Angular rules for `@testing-library/angular/zoneless`

## Context

Fixes #1366
