### PR TITLE
fix(prefer-user-event-setup): detect namespace import of userEvent

### DIFF
--- a/src/rules/prefer-user-event-setup.ts
+++ b/src/rules/prefer-user-event-setup.ts
@@ -83,6 +83,14 @@ export default createTestingLibraryRule<Options, MessageIds>({
 					) {
 						userEventIdentifier = namedImport.local.name;
 					}
+
+					// Namespace import: import * as userEvent from '@testing-library/user-event'
+					const namespaceImport = node.specifiers.find(
+						(spec) => spec.type === AST_NODE_TYPES.ImportNamespaceSpecifier
+					);
+					if (namespaceImport) {
+						userEventIdentifier = namespaceImport.local.name;
+					}
 				}
 			},
 

--- a/tests/rules/prefer-user-event-setup.test.ts
+++ b/tests/rules/prefer-user-event-setup.test.ts
@@ -114,7 +114,18 @@ ruleTester.run(rule.name, rule, {
 		{
 			code: `
 				import { userEvent } from '@testing-library/user-event';
-				
+
+				test('example', async () => {
+					const user = userEvent.setup();
+					await user.click(element);
+				});
+			`,
+		},
+		// Namespace import
+		{
+			code: `
+				import * as userEvent from '@testing-library/user-event';
+
 				test('example', async () => {
 					const user = userEvent.setup();
 					await user.click(element);
@@ -246,6 +257,24 @@ ruleTester.run(rule.name, rule, {
 		{
 			code: `
 				import { userEvent } from '@testing-library/user-event';
+
+				test('example', async () => {
+					await userEvent.click(element);
+				});
+			`,
+			errors: [
+				{
+					line: 5,
+					column: 12,
+					messageId: 'preferUserEventSetup',
+					data: { method: 'click' },
+				},
+			],
+		},
+		// Namespace import with direct call
+		{
+			code: `
+				import * as userEvent from '@testing-library/user-event';
 
 				test('example', async () => {
 					await userEvent.click(element);


### PR DESCRIPTION
## Checks

- [x] I have read the [contributing guidelines](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/CONTRIBUTING.md).

## Changes

<!-- List the changes you're making with this pull request. -->

- `prefer-user-event-setup`: track `ImportNamespaceSpecifier` (`import * as userEvent from '@testing-library/user-event'`) when resolving the `userEvent` identifier, so the rule no longer silently reports nothing for files using this import style.
- Add valid/invalid test cases covering namespace imports.

## Context

<!--
If you're fixing an issue with this pull request then use the "Fixes" keyword, like this:
Fixes #123
-->

Previously, only default imports (`import userEvent from ...`) and named imports (`import { userEvent } from ...`) were tracked. Namespace imports left `userEventIdentifier` as `null`, causing every check in the rule to bail out early (`if (!userEventIdentifier) return;`), effectively disabling the rule for any file using `import * as userEvent`.